### PR TITLE
STEP 1 찌루루

### DIFF
--- a/BankManager.swift
+++ b/BankManager.swift
@@ -58,7 +58,7 @@ final class BankManager {
     }
     
     private func assignCustomer(_ customerIndex: Int, to clerk: DispatchQueue, group: DispatchGroup) {
-        clerk.async(group: group) {
+        clerk.async {
             let (currentTotalTime, processTime): (Double, Double) = self.getTimeInfo(clerk: clerk)
             let updatedTotalTime: Double = currentTotalTime + processTime
             
@@ -84,7 +84,7 @@ final class BankManager {
     }
     
     private func sleep(_ time: Double) {
-        let time: useconds_t = useconds_t(time * 1000000)
+        let time: useconds_t = useconds_t(time * 1_000_000)
         usleep(time)
     }
     

--- a/BankManager.swift
+++ b/BankManager.swift
@@ -47,7 +47,7 @@ enum Task: CaseIterable {
     var processTime: Double {
         switch self {
         case .loan:
-            return 1.1
+            return 0.7
         case .deposit:
             return 0.7
         }
@@ -148,6 +148,6 @@ final class BankManager {
     }
     
     private func printCloseMessage() {
-        print("업무가 마감되었습니다. 오늘 업무를 처리한 고객은 총 \(customerCount)명이며, 총 업무시간은 \(totalTime)초입니다.")
+        print(String(format: "업무가 마감되었습니다. 오늘 업무를 처리한 고객은 총 %d명이며, 총 업무시간은 %.2f초입니다.", customerCount, totalTime))
     }
 }

--- a/BankManager.swift
+++ b/BankManager.swift
@@ -6,74 +6,91 @@
 
 import Foundation
 
+// clerk, customer 각각 객체로 만들어도 될 듯 ( 왜냐면 processTime 이 각각 다를 경우 )
+
 final class BankManager {
-    let clerkNumber: Int = 3
-    //let customerNumber: Int = Int.random(in: 10...30)
-    let customerNumber: Int = Int.random(in: 5...10)
+    // private
+    // type 선언 통일! 할지말지
+    // number 보단 count
+    private let clerkNumber: Int = 1
+    private let customerNumber: Int = Int.random(in: 10...30)
+    // 0.25 면 100 등등 고려하기
+    // 그냥 올림으로 다시 바꾸기 double 해서
+    private var _processTime: Int = 7 //{ processTime * 10 }
+    public var processTime: Double = 0.7
     
-    var clerks: [DispatchQueue] = []
-    var customers: [Int] = []
-    
-    let totalTimeKey = DispatchSpecificKey<Double>()
-    let processTimeKey = DispatchSpecificKey<Double>()
-    var totalTimes: [Double] = [] //{
-//        didSet {
-//            print(totalTimes.count)
-//            print(totalTimes)
-//            if totalTimes.count == clerkNumber {
-//                print("업무가 마감되었습니다. 오늘 업무를 처리한 고객은 총 \(customerNumber)명이며, 총 업무시간은 \(totalTimes.max()!)초입니다.")
-//            }
-//        }
-    //}
-    
-    var bankTaskGroup: DispatchGroup = DispatchGroup()
-    
-    init() {
-        for i in 0..<clerkNumber {
-            let clerk = DispatchQueue(label: "\(i)")
+    private let totalTimeKey = DispatchSpecificKey<Int>()
+    private let processTimeKey = DispatchSpecificKey<Int>()
+    private lazy var clerks: [DispatchQueue] = {
+        var clerks: [DispatchQueue] = []
+        for index in 0..<clerkNumber {
+            let clerk = DispatchQueue(label: "\(index)")
+            // 배열로 따로 만들어도 됨
             clerk.setSpecific(key: totalTimeKey, value: 0)
-            clerk.setSpecific(key: processTimeKey, value: 0.7)
+            clerk.setSpecific(key: processTimeKey, value: _processTime)
             clerks.append(clerk)
         }
-        customers = Array(1...customerNumber)
-    }
+        
+        return clerks
+    }()
+    private lazy var customers: [Int] = {
+        Array(1...customerNumber)
+    }()
+    //
+//    private lazy var clerkTotalTimes: [Int] = {
+//        Array(1...customerNumber)
+//    }()
+    var totalTimes: [Int] = []
     
     func open() {
-        print("customerNumber: \(customerNumber)")
         if customerNumber <= 0 { return }
     
+        let semaphore = DispatchSemaphore(value: 0)
+        let bankTaskGroup: DispatchGroup = DispatchGroup()
+        
         for index in 0..<clerkNumber {
             bankTaskGroup.enter()
-            print("enter")
-            assignCustomer(customers.removeFirst(), to: clerks[index])
+            assignCustomer(customers.removeFirst(), to: clerks[index], group: bankTaskGroup)
+            bankTaskGroup.notify(queue: clerks[index]) {
+                semaphore.signal()
+            }
         }
         
-        bankTaskGroup.notify(queue: .main) {
-            print("모든 작업 완료!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!")
+        for _ in 0..<clerkNumber {
+            semaphore.wait()
         }
+        
+        // TODO: Double -> ComputedProperty 로 바꾸기
+        print("업무가 마감되었습니다. 오늘 업무를 처리한 고객은 총 \(customerNumber)명이며, 총 업무시간은 \(Double(totalTimes.max()!)/10)초입니다.")
     }
     
-    private func assignCustomer(_ customerIndex: Int, to clerk: DispatchQueue) {
-        clerk.async(group: bankTaskGroup) {
-            print("\(customerIndex)번 고객 업무 시작")
-            usleep(700000) // 0.7s
-            
+    private func assignCustomer(_ customerIndex: Int, to clerk: DispatchQueue, group: DispatchGroup) {
+        clerk.async(group: group) {
+            // private 함수로 따로 빼도 될듯
             guard let currentTotalTime = clerk.getSpecific(key: self.totalTimeKey),
-                  let processTime = clerk.getSpecific(key: self.processTimeKey) else {
-                return
-            }
+                  let processTime = clerk.getSpecific(key: self.processTimeKey) else { return }
+            
+            print("\(customerIndex)번 고객 업무 시작")
+            self.sleep(processTime)
             clerk.setSpecific(key: self.totalTimeKey, value: currentTotalTime + processTime)
             print("\(customerIndex)번 고객 업무 완료")
             
             if self.customers.isEmpty {
                 guard let finalTotalTime = clerk.getSpecific(key: self.totalTimeKey) else { return }
-                print("\(clerk.label) 번 은행원의 업무가 끝났습니다. ( 총 걸린시간 : \(finalTotalTime) )")
                 self.totalTimes.append(finalTotalTime)
-                self.bankTaskGroup.leave()
-                print("leave")
+                group.leave()
             } else {
-                self.assignCustomer(self.customers.removeFirst(), to: clerk)
+                self.assignCustomer(self.customers.removeFirst(), to: clerk, group: group)
             }
         }
+    }
+//
+//    private func getTimeInfo() -> (Int, Int) {
+//
+//    }
+    
+    private func sleep(_ time: Int) {
+        let time = useconds_t(time * 100000)
+        usleep(time)
     }
 }

--- a/BankManager.swift
+++ b/BankManager.swift
@@ -61,6 +61,20 @@ struct Customer {
     var task: Task
 }
 
+final class Clerk {
+    var number: Int
+    var queue: DispatchQueue
+    
+    init(_ index: Int) {
+        number = index
+        queue = DispatchQueue(label: "\(index)")
+    }
+    
+    private func work() {
+        
+    }
+}
+
 final class BankManager {
     private let clerkCount: Int = 3
     private let customerCount: Int = Int.random(in: 10...30)

--- a/BankManager.swift
+++ b/BankManager.swift
@@ -6,7 +6,6 @@
 
 import Foundation
 
-// 우선순위 큐
 enum Level: CaseIterable {
     case vvip, vip, general
     

--- a/BankManager.swift
+++ b/BankManager.swift
@@ -6,8 +6,63 @@
 
 import Foundation
 
+// 우선순위 큐
+enum Level: CaseIterable {
+    case vvip, vip, general
+    
+    var priority: Int {
+        switch self {
+        case .vvip:
+            return 0
+        case .vip:
+            return 1
+        case .general:
+            return 2
+        }
+    }
+    
+    var description: String {
+        switch self {
+        case .vvip:
+            return "VVIP"
+        case .vip:
+            return "VIP"
+        case .general:
+            return "일반"
+        }
+    }
+}
+
+enum Task: CaseIterable {
+    case loan, deposit
+    
+    var description: String {
+        switch self {
+        case .loan:
+            return "대출"
+        case .deposit:
+            return "예금"
+        }
+    }
+    
+    var processTiem: Double {
+        switch self {
+        case .loan:
+            return 1.1
+        case .deposit:
+            return 0.7
+        }
+    }
+}
+
+struct Customer {
+    var number: Int
+    var level: Level
+    var task: Task
+}
+
 final class BankManager {
-    private let clerkCount: Int = 1
+    private let clerkCount: Int = 3
     private let customerCount: Int = Int.random(in: 10...30)
     private let processTime: Double = 0.7
     
@@ -25,8 +80,17 @@ final class BankManager {
         
         return clerks
     }()
-    private lazy var customers: [Int] = {
-        Array(1...customerCount)
+    private lazy var customers: [Customer] = {
+        var customers: [Customer] = []
+        for index in 1...customerCount {
+            if let level = Level.allCases.randomElement(),
+               let task = Task.allCases.randomElement() {
+                
+                customers.append(Customer(number: index, level: level, task: task))
+            }
+        }
+        
+        return customers
     }()
     
     private var totalTimes: [Double] = []
@@ -57,15 +121,15 @@ final class BankManager {
         printCloseMessage()
     }
     
-    private func assignCustomer(_ customerIndex: Int, to clerk: DispatchQueue, group: DispatchGroup) {
+    private func assignCustomer(_ customer: Customer, to clerk: DispatchQueue, group: DispatchGroup) {
         clerk.async {
             let (currentTotalTime, processTime): (Double, Double) = self.getTimeInfo(clerk: clerk)
             let updatedTotalTime: Double = currentTotalTime + processTime
             
-            print("\(customerIndex)번 고객 업무 시작")
+            print("\(customer.number)번 고객 업무 시작")
             self.sleep(processTime)
             clerk.setSpecific(key: self.totalTimeKey, value: updatedTotalTime)
-            print("\(customerIndex)번 고객 업무 완료")
+            print("\(customer.number)번 고객 업무 완료")
             
             if self.customers.isEmpty {
                 self.totalTimes.append(updatedTotalTime)

--- a/BankManager.swift
+++ b/BankManager.swift
@@ -5,3 +5,75 @@
 //
 
 import Foundation
+
+final class BankManager {
+    let clerkNumber: Int = 3
+    //let customerNumber: Int = Int.random(in: 10...30)
+    let customerNumber: Int = Int.random(in: 5...10)
+    
+    var clerks: [DispatchQueue] = []
+    var customers: [Int] = []
+    
+    let totalTimeKey = DispatchSpecificKey<Double>()
+    let processTimeKey = DispatchSpecificKey<Double>()
+    var totalTimes: [Double] = [] //{
+//        didSet {
+//            print(totalTimes.count)
+//            print(totalTimes)
+//            if totalTimes.count == clerkNumber {
+//                print("업무가 마감되었습니다. 오늘 업무를 처리한 고객은 총 \(customerNumber)명이며, 총 업무시간은 \(totalTimes.max()!)초입니다.")
+//            }
+//        }
+    //}
+    
+    var bankTaskGroup: DispatchGroup = DispatchGroup()
+    
+    init() {
+        for i in 0..<clerkNumber {
+            let clerk = DispatchQueue(label: "\(i)")
+            clerk.setSpecific(key: totalTimeKey, value: 0)
+            clerk.setSpecific(key: processTimeKey, value: 0.7)
+            clerks.append(clerk)
+        }
+        customers = Array(1...customerNumber)
+    }
+    
+    func open() {
+        print("customerNumber: \(customerNumber)")
+        if customerNumber <= 0 { return }
+    
+        for index in 0..<clerkNumber {
+            bankTaskGroup.enter()
+            print("enter")
+            assignCustomer(customers.removeFirst(), to: clerks[index])
+        }
+        
+        bankTaskGroup.notify(queue: .main) {
+            print("모든 작업 완료!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!")
+        }
+    }
+    
+    private func assignCustomer(_ customerIndex: Int, to clerk: DispatchQueue) {
+        clerk.async(group: bankTaskGroup) {
+            print("\(customerIndex)번 고객 업무 시작")
+            usleep(700000) // 0.7s
+            
+            guard let currentTotalTime = clerk.getSpecific(key: self.totalTimeKey),
+                  let processTime = clerk.getSpecific(key: self.processTimeKey) else {
+                return
+            }
+            clerk.setSpecific(key: self.totalTimeKey, value: currentTotalTime + processTime)
+            print("\(customerIndex)번 고객 업무 완료")
+            
+            if self.customers.isEmpty {
+                guard let finalTotalTime = clerk.getSpecific(key: self.totalTimeKey) else { return }
+                print("\(clerk.label) 번 은행원의 업무가 끝났습니다. ( 총 걸린시간 : \(finalTotalTime) )")
+                self.totalTimes.append(finalTotalTime)
+                self.bankTaskGroup.leave()
+                print("leave")
+            } else {
+                self.assignCustomer(self.customers.removeFirst(), to: clerk)
+            }
+        }
+    }
+}

--- a/BankManager.swift
+++ b/BankManager.swift
@@ -83,7 +83,7 @@ struct Clerk {
 }
 
 final class BankManager {
-    private let clerkCount: Int = 3
+    private let clerkCount: Int = 1
     private let customerCount: Int = Int.random(in: 10...30)
     private var totalTime: Double {
         get {

--- a/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
+++ b/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
@@ -92,7 +92,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 1210;
-				LastUpgradeCheck = 1210;
+				LastUpgradeCheck = 1230;
 				TargetAttributes = {
 					C7694E75259C3EC00053667F = {
 						CreatedOnToolsVersion = 12.1;
@@ -248,6 +248,7 @@
 		C7694E7E259C3EC00053667F /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CODE_SIGN_IDENTITY = "-";
 				CODE_SIGN_STYLE = Automatic;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
@@ -257,6 +258,7 @@
 		C7694E7F259C3EC00053667F /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CODE_SIGN_IDENTITY = "-";
 				CODE_SIGN_STYLE = Automatic;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;

--- a/BankManagerConsoleApp/BankManagerConsoleApp/main.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/main.swift
@@ -25,7 +25,7 @@ enum ConsoleError: Error {
 func bankManagerConsoleApp() {
     var isEnd = false
     while(!isEnd) {
-        printConsoleMessage()
+        printConsoleStartMessage()
 
         guard let input = readLine(),
               let command = Command(rawValue: input) else {
@@ -42,7 +42,7 @@ func bankManagerConsoleApp() {
     }
 }
 
-private func printConsoleMessage() {
+private func printConsoleStartMessage() {
     let startMessage = """
     1 : 은행개점
     2 : 종료

--- a/BankManagerConsoleApp/BankManagerConsoleApp/main.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/main.swift
@@ -22,21 +22,23 @@ enum ConsoleError: Error {
     }
 }
 
-var isEnd = false
-while(!isEnd) {
-    printConsoleMessage()
+func bankManagerConsoleApp() {
+    var isEnd = false
+    while(!isEnd) {
+        printConsoleMessage()
 
-    guard let input = readLine(),
-          let command = Command(rawValue: input) else {
-        print(ConsoleError.wrongInput.errorMessage)
-        continue
-    }
-    
-    switch command {
-    case .open:
-        BankManager().open()
-    case .close:
-        isEnd = true
+        guard let input = readLine(),
+              let command = Command(rawValue: input) else {
+            print(ConsoleError.wrongInput.errorMessage)
+            continue
+        }
+        
+        switch command {
+        case .open:
+            BankManager().open()
+        case .close:
+            isEnd = true
+        }
     }
 }
 
@@ -49,3 +51,5 @@ private func printConsoleMessage() {
     print(startMessage)
     print("입력 : ", terminator: "")
 }
+
+bankManagerConsoleApp()

--- a/BankManagerConsoleApp/BankManagerConsoleApp/main.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/main.swift
@@ -5,3 +5,27 @@
 // 
 
 import Foundation
+
+let startMessage = """
+1 : 은행개점
+2 : 종료
+"""
+var isEnd = false
+
+while(!isEnd) {
+    print(startMessage)
+    print("입력 : ", terminator: "")
+
+    guard let input = readLine() else { fatalError("유효하지 않은 입력입니다.") }
+
+    // TODO: enum 1, 2
+    switch input {
+    case "1":
+        BankManager().open()
+    case "2":
+        isEnd = true
+    default:
+        print("1 또는 2가 유효함.")
+    }
+}
+

--- a/BankManagerConsoleApp/BankManagerConsoleApp/main.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/main.swift
@@ -6,26 +6,46 @@
 
 import Foundation
 
-let startMessage = """
-1 : 은행개점
-2 : 종료
-"""
-var isEnd = false
+enum Command: String {
+    case open = "1"
+    case close = "2"
+}
 
-while(!isEnd) {
-    print(startMessage)
-    print("입력 : ", terminator: "")
-
-    guard let input = readLine() else { fatalError("유효하지 않은 입력입니다.") }
-
-    // TODO: enum 1, 2
-    switch input {
-    case "1":
-        BankManager().open()
-    case "2":
-        isEnd = true
-    default:
-        print("1 또는 2가 유효함.")
+enum ConsoleError: Error {
+    case wrongInput
+    
+    var errorMessage: String {
+        switch self {
+        case .wrongInput:
+            return "⚠️ 잘못된 입력입니다. 1 또는 2를 입력해주세요.\n\n"
+        }
     }
 }
 
+var isEnd = false
+while(!isEnd) {
+    printConsoleMessage()
+
+    guard let input = readLine(),
+          let command = Command(rawValue: input) else {
+        print(ConsoleError.wrongInput.errorMessage)
+        continue
+    }
+    
+    switch command {
+    case .open:
+        BankManager().open()
+    case .close:
+        isEnd = true
+    }
+}
+
+private func printConsoleMessage() {
+    let startMessage = """
+    1 : 은행개점
+    2 : 종료
+    """
+    
+    print(startMessage)
+    print("입력 : ", terminator: "")
+}


### PR DESCRIPTION
**BankManager** 
- 은행원 Clerk, 고객 Customer 
- 은행원 명 수 만큼 Dispatch Queue를 생성하여 일을 할당해주도록 구현하였습니다. (clerks)
( 은행원의 index 를 label 로 붙여서 custom dispatch queue를 생성하도록 하였습니다. default 설정이 serial 큐라서 따로 속성을 명시하거나 바꾸지는 않았습니다. )
- 각 은행원은 작업시간(processTime), 총 작업시간(totalTime)을 가지고 있도록 하였습니다.
( dispatch queue 에 DispatchSpecificKey를 이용하여 value 를 세팅해두는 방식으로 )
- 고객은 아직까지 번호만 필요한거 같아 따로 class 나 struct 로 빼지 않고 번호들을 들고 있는 Int 배열(customers)을 사용하였습니다.
- 은행이 업무를 시작하는 open() 내에서 assignCustomer()를 호출하여 각 은행원(queue)에 첫 고객을 비동기로 할당해주고, 이 후로는 재귀를 통해 각 은행원이 알아서 고객 대기열에서 자신에게 고객을 할당하도록 하였습니다 ( 이 때, 각 큐의 업무 시작과 끝을 알기 위해 bankTaskGroup이라는 이름으로 DispatchGroup을 생성하여 시작시에 group.enter(), 모두 끝마쳤을 때(=더이상 할당할 고객이 없을 때) group.leave()를 호출해 주었습니다. )
- 비동기로 각 큐에 고객을 할당하고 나면 해당 open() 함수가 바로 끝나버리는데, 은행원들이 일을 모두 마칠때까지 기다릴 수 있도록 DispatchSemaphore를 이용하여 은행원 수만큼 semaphore.wait()를 호출하여 기다리도록 하였고, 각 은행원들에게서 group.leave() 가 불리면 group.notify() 를 통해 semaphore.signal() 을 호출할 수 있도록 하였습니다. wait() 가 불린 횟수(은행원 수)만큼 signal()이 불리면 open() 함수가 끝납니다.
- 각 은행원은 업무가 모두 끝날때(bankTaskGroup.leave()) 총 업무시간(totalTime)을 bankManager의 totalTimes에 append 합니다.
- 모든 은행원의 업무가 종료되고 endMessage가 출력될 때, totalTimes의 max 값을 totalTimeCount를 통해 계산하여 가져옵니다

쏠과 같은팀이지만 PR은 따로보내기로 하였습니다🙋‍♂️