### PR TITLE
 🏦 은행 매니저 [STEP 1] 💸 Yun, Ryan

### DIFF
--- a/BankManager.swift
+++ b/BankManager.swift
@@ -1,6 +1,6 @@
 //
 //  BankManager.swift
-//  Created by yagom.
+//  Created by Yun, Ryan.
 //  Copyright © yagom academy. All rights reserved.
 //
 

--- a/BankManager.swift
+++ b/BankManager.swift
@@ -5,3 +5,43 @@
 //
 
 import Foundation
+
+struct BankManager {
+    private var bank: Bank
+    
+    init(numberOfTeller: Int = 1) {
+        self.bank = Bank(numberOfTeller)
+    }
+    
+    private enum Menu {
+        static let openBank = 1
+        static let closeBank = 2
+    }
+    
+    private func selectMenu() throws -> Int {
+        print("1: 은행 개점\n2: 종료\n입력: ", terminator: "")
+        guard let userInput: String = readLine(),
+              let userInputNumber: Int = Int(userInput) else {
+            throw BankManagerError.invaildMenu(#function)
+        }
+        return userInputNumber
+    }
+    
+    mutating func start() {
+        while true {
+            do {
+                switch try selectMenu() {
+                case Menu.openBank:
+                    bank.open()
+                case Menu.closeBank:
+                    return
+                default:
+                    print("유효하지 않은 입력입니다.")
+                }
+            } catch {
+                print(error)
+            }
+        }
+    }
+}
+

--- a/BankManager.swift
+++ b/BankManager.swift
@@ -29,12 +29,12 @@ struct BankManager {
         return userInputNumber
     }
     
-    mutating private func moveToSelectedMenu() throws {
-        switch try selectMenu() {
+    mutating private func move(to selectedMenu: Int) {
+        switch selectedMenu {
         case Menu.openBank:
             bank.open()
         case Menu.exit:
-            return
+            exit(0)
         default:
             print("유효하지 않은 입력입니다. 1과 2 중에서 선택해주세요.")
         }
@@ -43,7 +43,8 @@ struct BankManager {
     mutating func start() {
         while true {
             do {
-                try moveToSelectedMenu()
+                let selectedMenu: Int = try selectMenu()
+                move(to: selectedMenu)
             } catch {
                 print(error)
             }

--- a/BankManager.swift
+++ b/BankManager.swift
@@ -14,15 +14,15 @@ struct BankManager {
     }
     
     private enum Menu {
-        static let openBank = 1
-        static let closeBank = 2
+        static let openBank: Int = 1
+        static let closeBank: Int = 2
     }
     
     private func selectMenu() throws -> Int {
         print("1: 은행 개점\n2: 종료\n입력: ", terminator: "")
         guard let userInput: String = readLine(),
               let userInputNumber: Int = Int(userInput) else {
-            throw BankManagerError.invaildMenu(#function)
+            throw BankManagerError.invalidMenu(#function)
         }
         return userInputNumber
     }

--- a/BankManager.swift
+++ b/BankManager.swift
@@ -7,18 +7,21 @@
 import Foundation
 
 struct BankManager {
+    // MARK: - Properties
     private var bank: Bank
     
     init(numberOfTeller: Int = 1) {
         self.bank = Bank(numberOfTeller: numberOfTeller)
     }
     
+    // MARK: - NameSpaces
     private enum Menu {
         static let text: String = "1: 은행 개점\n2: 종료\n입력: "
         static let openBank: Int = 1
         static let exit: Int = 2
     }
     
+    // MARK: - Private Methods
     private func selectMenu() throws -> Int {
         print(Menu.text, terminator: "")
         let userInput: String? = readLine()

--- a/BankManager.swift
+++ b/BankManager.swift
@@ -14,12 +14,13 @@ struct BankManager {
     }
     
     private enum Menu {
+        static let text: String = "1: 은행 개점\n2: 종료\n입력: "
         static let openBank: Int = 1
         static let closeBank: Int = 2
     }
     
     private func selectMenu() throws -> Int {
-        print("1: 은행 개점\n2: 종료\n입력: ", terminator: "")
+        print(Menu.text, terminator: "")
         guard let userInput: String = readLine(),
               let userInputNumber: Int = Int(userInput) else {
             throw BankManagerError.invalidMenu(#function)

--- a/BankManager.swift
+++ b/BankManager.swift
@@ -10,7 +10,7 @@ struct BankManager {
     private var bank: Bank
     
     init(numberOfTeller: Int = 1) {
-        self.bank = Bank(numberOfTeller)
+        self.bank = Bank(numberOfTeller: numberOfTeller)
     }
     
     private enum Menu {

--- a/BankManager.swift
+++ b/BankManager.swift
@@ -10,44 +10,43 @@ struct BankManager {
     // MARK: - Properties
     private var bank: Bank
     
-    init(numberOfTeller: Int = 1) {
+    init(numberOfTeller: Int) {
         self.bank = Bank(numberOfTeller: numberOfTeller)
     }
     
     // MARK: - NameSpaces
     private enum Menu {
         static let text: String = "1: 은행 개점\n2: 종료\n입력: "
-        static let openBank: Int = 1
-        static let exit: Int = 2
+        static let openBank: String = "1"
+        static let exit: String = "2"
     }
     
     // MARK: - Private Methods
-    private func selectMenu() throws -> Int {
+    private func printMenu() {
         print(Menu.text, terminator: "")
-        let userInput: String? = readLine()
-        guard let userInputText: String = userInput,
-              let userInputNumber: Int = Int(userInputText) else {
-            throw BankManagerError.invalidMenu("\"\(userInput ?? "nil")\"")
-        }
-        return userInputNumber
     }
     
-    mutating private func move(to selectedMenu: Int) {
-        switch selectedMenu {
-        case Menu.openBank:
-            bank.open()
-        case Menu.exit:
-            exit(0)
-        default:
-            print("유효하지 않은 입력입니다. 1과 2 중에서 선택해주세요.")
+    private func selectMenu() throws -> String {
+        guard let userInputText: String = readLine() else {
+            throw BankManagerError.invalidMenu
         }
+        return userInputText
     }
     
     mutating func start() {
         while true {
             do {
-                let selectedMenu: Int = try selectMenu()
-                move(to: selectedMenu)
+                printMenu()
+                let selectedMenu: String = try selectMenu()
+                
+                switch selectedMenu {
+                case Menu.openBank:
+                    bank.open()
+                case Menu.exit:
+                    return
+                default:
+                    print("유효하지 않은 입력입니다. 1과 2 중에서 선택해주세요.")
+                }
             } catch {
                 print(error)
             }

--- a/BankManager.swift
+++ b/BankManager.swift
@@ -16,29 +16,34 @@ struct BankManager {
     private enum Menu {
         static let text: String = "1: 은행 개점\n2: 종료\n입력: "
         static let openBank: Int = 1
-        static let closeBank: Int = 2
+        static let exit: Int = 2
     }
     
     private func selectMenu() throws -> Int {
         print(Menu.text, terminator: "")
-        guard let userInput: String = readLine(),
-              let userInputNumber: Int = Int(userInput) else {
-            throw BankManagerError.invalidMenu(#function)
+        let userInput: String? = readLine()
+        guard let userInputText: String = userInput,
+              let userInputNumber: Int = Int(userInputText) else {
+            throw BankManagerError.invalidMenu("\"\(userInput ?? "nil")\"")
         }
         return userInputNumber
+    }
+    
+    mutating private func moveToSelectedMenu() throws {
+        switch try selectMenu() {
+        case Menu.openBank:
+            bank.open()
+        case Menu.exit:
+            return
+        default:
+            print("유효하지 않은 입력입니다. 1과 2 중에서 선택해주세요.")
+        }
     }
     
     mutating func start() {
         while true {
             do {
-                switch try selectMenu() {
-                case Menu.openBank:
-                    bank.open()
-                case Menu.closeBank:
-                    return
-                default:
-                    print("유효하지 않은 입력입니다.")
-                }
+                try moveToSelectedMenu()
             } catch {
                 print(error)
             }

--- a/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
+++ b/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
@@ -9,11 +9,11 @@
 /* Begin PBXBuildFile section */
 		52B2BCFE263ABD14003932BB /* BankManagerError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52B2BCFD263ABD14003932BB /* BankManagerError.swift */; };
 		52B2BD01263ABF0E003932BB /* BankManagerError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52B2BCFD263ABD14003932BB /* BankManagerError.swift */; };
-		52B68BA426382A2F0007B69F /* Customer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52B68BA326382A2F0007B69F /* Customer.swift */; };
+		52B68BA426382A2F0007B69F /* Client.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52B68BA326382A2F0007B69F /* Client.swift */; };
 		52B68BD6263832270007B69F /* BankManagerTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52B68BD5263832270007B69F /* BankManagerTest.swift */; };
 		52B68BDE263836F60007B69F /* Bank.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA1BDBE326381A1F00A9F227 /* Bank.swift */; };
 		52B68BE2263836F80007B69F /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7694E79259C3EC00053667F /* main.swift */; };
-		52B68BEF263836FF0007B69F /* Customer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52B68BA326382A2F0007B69F /* Customer.swift */; };
+		52B68BEF263836FF0007B69F /* Client.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52B68BA326382A2F0007B69F /* Client.swift */; };
 		52B68BF3263837010007B69F /* BankManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7D65D1A259C8190005510E0 /* BankManager.swift */; };
 		AA1BDBE426381A1F00A9F227 /* Bank.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA1BDBE326381A1F00A9F227 /* Bank.swift */; };
 		C7694E7A259C3EC00053667F /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7694E79259C3EC00053667F /* main.swift */; };
@@ -34,7 +34,7 @@
 
 /* Begin PBXFileReference section */
 		52B2BCFD263ABD14003932BB /* BankManagerError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BankManagerError.swift; sourceTree = "<group>"; };
-		52B68BA326382A2F0007B69F /* Customer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Customer.swift; sourceTree = "<group>"; };
+		52B68BA326382A2F0007B69F /* Client.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Client.swift; sourceTree = "<group>"; };
 		52B68BD3263832260007B69F /* BankManagerTest.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = BankManagerTest.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		52B68BD5263832270007B69F /* BankManagerTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BankManagerTest.swift; sourceTree = "<group>"; };
 		52B68BD7263832270007B69F /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -94,7 +94,7 @@
 			children = (
 				C7D65D1A259C8190005510E0 /* BankManager.swift */,
 				52B2BCFD263ABD14003932BB /* BankManagerError.swift */,
-				52B68BA326382A2F0007B69F /* Customer.swift */,
+				52B68BA326382A2F0007B69F /* Client.swift */,
 				C7694E79259C3EC00053667F /* main.swift */,
 				AA1BDBE326381A1F00A9F227 /* Bank.swift */,
 			);
@@ -189,7 +189,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				52B68BEF263836FF0007B69F /* Customer.swift in Sources */,
+				52B68BEF263836FF0007B69F /* Client.swift in Sources */,
 				52B68BF3263837010007B69F /* BankManager.swift in Sources */,
 				52B68BD6263832270007B69F /* BankManagerTest.swift in Sources */,
 				52B68BDE263836F60007B69F /* Bank.swift in Sources */,
@@ -205,7 +205,7 @@
 				AA1BDBE426381A1F00A9F227 /* Bank.swift in Sources */,
 				C7694E7A259C3EC00053667F /* main.swift in Sources */,
 				52B2BCFE263ABD14003932BB /* BankManagerError.swift in Sources */,
-				52B68BA426382A2F0007B69F /* Customer.swift in Sources */,
+				52B68BA426382A2F0007B69F /* Client.swift in Sources */,
 				C7D65D1B259C8190005510E0 /* BankManager.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
+++ b/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
@@ -7,6 +7,15 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		52B2BCFE263ABD14003932BB /* BankManagerError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52B2BCFD263ABD14003932BB /* BankManagerError.swift */; };
+		52B2BD01263ABF0E003932BB /* BankManagerError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52B2BCFD263ABD14003932BB /* BankManagerError.swift */; };
+		52B68BA426382A2F0007B69F /* Customer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52B68BA326382A2F0007B69F /* Customer.swift */; };
+		52B68BD6263832270007B69F /* BankManagerTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52B68BD5263832270007B69F /* BankManagerTest.swift */; };
+		52B68BDE263836F60007B69F /* Bank.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA1BDBE326381A1F00A9F227 /* Bank.swift */; };
+		52B68BE2263836F80007B69F /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7694E79259C3EC00053667F /* main.swift */; };
+		52B68BEF263836FF0007B69F /* Customer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52B68BA326382A2F0007B69F /* Customer.swift */; };
+		52B68BF3263837010007B69F /* BankManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7D65D1A259C8190005510E0 /* BankManager.swift */; };
+		AA1BDBE426381A1F00A9F227 /* Bank.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA1BDBE326381A1F00A9F227 /* Bank.swift */; };
 		C7694E7A259C3EC00053667F /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7694E79259C3EC00053667F /* main.swift */; };
 		C7D65D1B259C8190005510E0 /* BankManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7D65D1A259C8190005510E0 /* BankManager.swift */; };
 /* End PBXBuildFile section */
@@ -24,12 +33,25 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		52B2BCFD263ABD14003932BB /* BankManagerError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BankManagerError.swift; sourceTree = "<group>"; };
+		52B68BA326382A2F0007B69F /* Customer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Customer.swift; sourceTree = "<group>"; };
+		52B68BD3263832260007B69F /* BankManagerTest.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = BankManagerTest.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		52B68BD5263832270007B69F /* BankManagerTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BankManagerTest.swift; sourceTree = "<group>"; };
+		52B68BD7263832270007B69F /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		AA1BDBE326381A1F00A9F227 /* Bank.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Bank.swift; sourceTree = "<group>"; };
 		C7694E76259C3EC00053667F /* BankManagerConsoleApp */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = BankManagerConsoleApp; sourceTree = BUILT_PRODUCTS_DIR; };
 		C7694E79259C3EC00053667F /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
 		C7D65D1A259C8190005510E0 /* BankManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = BankManager.swift; path = ../../BankManager.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		52B68BD0263832260007B69F /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		C7694E73259C3EC00053667F /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -40,10 +62,20 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		52B68BD4263832270007B69F /* BankManagerTest */ = {
+			isa = PBXGroup;
+			children = (
+				52B68BD5263832270007B69F /* BankManagerTest.swift */,
+				52B68BD7263832270007B69F /* Info.plist */,
+			);
+			path = BankManagerTest;
+			sourceTree = "<group>";
+		};
 		C7694E6D259C3EC00053667F = {
 			isa = PBXGroup;
 			children = (
 				C7694E78259C3EC00053667F /* BankManagerConsoleApp */,
+				52B68BD4263832270007B69F /* BankManagerTest */,
 				C7694E77259C3EC00053667F /* Products */,
 			);
 			sourceTree = "<group>";
@@ -52,6 +84,7 @@
 			isa = PBXGroup;
 			children = (
 				C7694E76259C3EC00053667F /* BankManagerConsoleApp */,
+				52B68BD3263832260007B69F /* BankManagerTest.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -60,7 +93,10 @@
 			isa = PBXGroup;
 			children = (
 				C7D65D1A259C8190005510E0 /* BankManager.swift */,
+				52B2BCFD263ABD14003932BB /* BankManagerError.swift */,
+				52B68BA326382A2F0007B69F /* Customer.swift */,
 				C7694E79259C3EC00053667F /* main.swift */,
+				AA1BDBE326381A1F00A9F227 /* Bank.swift */,
 			);
 			path = BankManagerConsoleApp;
 			sourceTree = "<group>";
@@ -68,6 +104,23 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
+		52B68BD2263832260007B69F /* BankManagerTest */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 52B68BDA263832270007B69F /* Build configuration list for PBXNativeTarget "BankManagerTest" */;
+			buildPhases = (
+				52B68BCF263832260007B69F /* Sources */,
+				52B68BD0263832260007B69F /* Frameworks */,
+				52B68BD1263832260007B69F /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = BankManagerTest;
+			productName = BankManagerTest;
+			productReference = 52B68BD3263832260007B69F /* BankManagerTest.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 		C7694E75259C3EC00053667F /* BankManagerConsoleApp */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = C7694E7D259C3EC00053667F /* Build configuration list for PBXNativeTarget "BankManagerConsoleApp" */;
@@ -91,9 +144,12 @@
 		C7694E6E259C3EC00053667F /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastSwiftUpdateCheck = 1210;
+				LastSwiftUpdateCheck = 1240;
 				LastUpgradeCheck = 1210;
 				TargetAttributes = {
+					52B68BD2263832260007B69F = {
+						CreatedOnToolsVersion = 12.4;
+					};
 					C7694E75259C3EC00053667F = {
 						CreatedOnToolsVersion = 12.1;
 					};
@@ -113,16 +169,43 @@
 			projectRoot = "";
 			targets = (
 				C7694E75259C3EC00053667F /* BankManagerConsoleApp */,
+				52B68BD2263832260007B69F /* BankManagerTest */,
 			);
 		};
 /* End PBXProject section */
 
+/* Begin PBXResourcesBuildPhase section */
+		52B68BD1263832260007B69F /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
 /* Begin PBXSourcesBuildPhase section */
+		52B68BCF263832260007B69F /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				52B68BEF263836FF0007B69F /* Customer.swift in Sources */,
+				52B68BF3263837010007B69F /* BankManager.swift in Sources */,
+				52B68BD6263832270007B69F /* BankManagerTest.swift in Sources */,
+				52B68BDE263836F60007B69F /* Bank.swift in Sources */,
+				52B2BD01263ABF0E003932BB /* BankManagerError.swift in Sources */,
+				52B68BE2263836F80007B69F /* main.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		C7694E72259C3EC00053667F /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				AA1BDBE426381A1F00A9F227 /* Bank.swift in Sources */,
 				C7694E7A259C3EC00053667F /* main.swift in Sources */,
+				52B2BCFE263ABD14003932BB /* BankManagerError.swift in Sources */,
+				52B68BA426382A2F0007B69F /* Customer.swift in Sources */,
 				C7D65D1B259C8190005510E0 /* BankManager.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -130,6 +213,42 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin XCBuildConfiguration section */
+		52B68BD8263832270007B69F /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				INFOPLIST_FILE = BankManagerTest/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+					"@loader_path/../Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 11.1;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.Coni-yun37.BankManagerTest";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		52B68BD9263832270007B69F /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				INFOPLIST_FILE = BankManagerTest/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+					"@loader_path/../Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 11.1;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.Coni-yun37.BankManagerTest";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
 		C7694E7B259C3EC00053667F /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -266,6 +385,15 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		52B68BDA263832270007B69F /* Build configuration list for PBXNativeTarget "BankManagerTest" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				52B68BD8263832270007B69F /* Debug */,
+				52B68BD9263832270007B69F /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		C7694E71259C3EC00053667F /* Build configuration list for PBXProject "BankManagerConsoleApp" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/xcshareddata/xcschemes/BankManagerConsoleApp.xcscheme
+++ b/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/xcshareddata/xcschemes/BankManagerConsoleApp.xcscheme
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1240"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "C7694E75259C3EC00053667F"
+               BuildableName = "BankManagerConsoleApp"
+               BlueprintName = "BankManagerConsoleApp"
+               ReferencedContainer = "container:BankManagerConsoleApp.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      onlyGenerateCoverageForSpecifiedTargets = "YES">
+      <CodeCoverageTargets>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "C7694E75259C3EC00053667F"
+            BuildableName = "BankManagerConsoleApp"
+            BlueprintName = "BankManagerConsoleApp"
+            ReferencedContainer = "container:BankManagerConsoleApp.xcodeproj">
+         </BuildableReference>
+      </CodeCoverageTargets>
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "C7694E75259C3EC00053667F"
+            BuildableName = "BankManagerConsoleApp"
+            BlueprintName = "BankManagerConsoleApp"
+            ReferencedContainer = "container:BankManagerConsoleApp.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "C7694E75259C3EC00053667F"
+            BuildableName = "BankManagerConsoleApp"
+            BlueprintName = "BankManagerConsoleApp"
+            ReferencedContainer = "container:BankManagerConsoleApp.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/xcshareddata/xcschemes/BankManagerTest.xcscheme
+++ b/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/xcshareddata/xcschemes/BankManagerTest.xcscheme
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1240"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      codeCoverageEnabled = "YES"
+      onlyGenerateCoverageForSpecifiedTargets = "YES">
+      <CodeCoverageTargets>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "C7694E75259C3EC00053667F"
+            BuildableName = "BankManagerConsoleApp"
+            BlueprintName = "BankManagerConsoleApp"
+            ReferencedContainer = "container:BankManagerConsoleApp.xcodeproj">
+         </BuildableReference>
+      </CodeCoverageTargets>
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "52B68BD2263832260007B69F"
+               BuildableName = "BankManagerTest.xctest"
+               BlueprintName = "BankManagerTest"
+               ReferencedContainer = "container:BankManagerConsoleApp.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
@@ -32,7 +32,7 @@ struct Bank {
     mutating func open() {
         assignTeller()
         processedTime = totalProcessedTime {
-            visitNewClient()
+            processTasks(of: clients())
         }
         close()
     }
@@ -48,8 +48,7 @@ struct Bank {
         waitingQueue.maxConcurrentOperationCount = numberOfTeller
     }
     
-    @discardableResult
-    mutating func visitNewClient() -> [Client] {
+    mutating func clients() -> [Client] {
         var clients: [Client] = []
         totalClient = Int.random(in: NumberOfClient.minimum...NumberOfClient.maximum)
         
@@ -57,8 +56,11 @@ struct Bank {
             clients.append(Client(waitingNumber))
         }
         
-        waitingQueue.addOperations(clients, waitUntilFinished: true)
         return clients
+    }
+    
+    mutating func processTasks(of clients: [Client]) {
+        waitingQueue.addOperations(clients, waitUntilFinished: true)
     }
 }
 

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
@@ -11,7 +11,7 @@ struct Bank {
     // MARK: - Properties
     private(set) var waitingQueue: OperationQueue = OperationQueue()
     
-    init(numberOfTeller: Int) {
+    init(numberOfTeller: Int = 1) {
         self.waitingQueue.maxConcurrentOperationCount = numberOfTeller
     }
     
@@ -33,6 +33,10 @@ struct Bank {
     
     mutating func makeClients(number: Int) -> [Client] {
         var clients: [Client] = []
+        
+        guard number >= 1 else {
+            return clients
+        }
         
         for waitingNumber in 1...number {
             clients.append(Client(waitingNumber))

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
@@ -9,7 +9,7 @@ import Foundation
 
 struct Bank {
     // MARK: - Properties
-    private(set) var waitingQueue: OperationQueue = OperationQueue()
+    private var waitingQueue: OperationQueue = OperationQueue()
     
     init(numberOfTeller: Int = 1) {
         self.waitingQueue.maxConcurrentOperationCount = numberOfTeller
@@ -34,9 +34,7 @@ struct Bank {
     mutating func makeClients(number: Int) -> [Client] {
         var clients: [Client] = []
         
-        guard number >= 1 else {
-            return clients
-        }
+        guard number >= 1 else { return clients }
         
         for waitingNumber in 1...number {
             clients.append(Client(waitingNumber))
@@ -52,7 +50,7 @@ struct Bank {
         return floor(processTime * 100) / 100
     }
     
-    mutating private func processTasks(of clients: [Client]) {
+    mutating func processTasks(of clients: [Client]) {
         waitingQueue.addOperations(clients, waitUntilFinished: true)
     }
     

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
@@ -31,13 +31,6 @@ struct Bank {
         close(totalProcessTime, numberOfClient: clients.count)
     }
     
-    func measureTime(_ closure: () -> Void) -> Double {
-        let startTime = CFAbsoluteTimeGetCurrent()
-        closure()
-        let processTime = CFAbsoluteTimeGetCurrent() - startTime
-        return processTime
-    }
-    
     mutating func clients(number: Int) -> [Client] {
         var clients: [Client] = []
         
@@ -46,6 +39,13 @@ struct Bank {
         }
         
         return clients
+    }
+    
+    func measureTime(_ closure: () -> Void) -> Double {
+        let startTime = CFAbsoluteTimeGetCurrent()
+        closure()
+        let processTime = CFAbsoluteTimeGetCurrent() - startTime
+        return processTime
     }
     
     mutating private func processTasks(of clients: [Client]) {

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
@@ -8,9 +8,9 @@
 import Foundation
 
 struct Bank {
-    var totalClient: Int = 0
-    var waitingQueue: OperationQueue = OperationQueue()
-    var numberOfTeller: Int
+    private(set) var totalClient: Int = 0
+    private(set) var waitingQueue: OperationQueue = OperationQueue()
+    private(set) var numberOfTeller: Int
     var processedTime: Double = 0
     
     private enum NumberOfClient {
@@ -59,7 +59,7 @@ struct Bank {
         return clients
     }
     
-    mutating func processTasks(of clients: [Client]) {
+    mutating private func processTasks(of clients: [Client]) {
         waitingQueue.addOperations(clients, waitUntilFinished: true)
     }
 }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
@@ -11,7 +11,7 @@ struct Bank {
     var totalCustomer: Int = 0
     var waitingQueue: OperationQueue = OperationQueue()
     var numberOfTeller: Int
-    var time: Double = 0
+    var processedTime: Double = 0
     
     private enum NumberOfCustomer {
         static let minimum: Int = 10
@@ -31,14 +31,14 @@ struct Bank {
     
     mutating func open() {
         assignTeller()
-        time = totalProcessedTime {
+        processedTime = totalProcessedTime {
             visitNewCustomer()
         }
         close()
     }
     
     private func close() {
-        let totalProcessedTime = floor(time * 100) / 100
+        let totalProcessedTime = floor(processedTime * 100) / 100
         print("업무가 마감되었습니다. 오늘 업무를 처리한 고객은 총 \(totalCustomer) 명이며, 총 업무 시간은 \(totalProcessedTime)초입니다.")
     }
     

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
@@ -9,13 +9,10 @@ import Foundation
 
 struct Bank {
     // MARK: - Properties
-    private(set) var totalClient: Int = 0
     private(set) var waitingQueue: OperationQueue = OperationQueue()
-    private(set) var numberOfTeller: Int
-    var processedTime: Double = 0
     
     init(numberOfTeller: Int) {
-        self.numberOfTeller = numberOfTeller
+        self.waitingQueue.maxConcurrentOperationCount = numberOfTeller
     }
     
     // MARK: - NameSpaces
@@ -26,29 +23,27 @@ struct Bank {
     
     // MARK: - Private Methods
     mutating func open() {
-        assignTeller()
-        processedTime = totalProcessedTime {
-            processTasks(of: clients())
-        }
-        close()
+        let clients: [Client] = clients(number: generateRandomClientNumber())
+        let totalProcessTime: Double = measureTime { processTasks(of: clients) }
+        
+        close(totalProcessTime, numberOfClient: clients.count)
     }
     
-    func assignTeller() {
-        waitingQueue.maxConcurrentOperationCount = numberOfTeller
+    func generateRandomClientNumber() -> Int {
+        return Int.random(in: NumberOfClient.minimum...NumberOfClient.maximum)
     }
     
-    func totalProcessedTime(_ closure: () -> Void) -> Double {
+    func measureTime(_ closure: () -> Void) -> Double {
         let startTime = CFAbsoluteTimeGetCurrent()
         closure()
-        let processedTime = CFAbsoluteTimeGetCurrent() - startTime
-        return processedTime
+        let processTime = CFAbsoluteTimeGetCurrent() - startTime
+        return processTime
     }
     
-    mutating func clients() -> [Client] {
+    mutating func clients(number: Int) -> [Client] {
         var clients: [Client] = []
-        totalClient = Int.random(in: NumberOfClient.minimum...NumberOfClient.maximum)
         
-        for waitingNumber in 1...totalClient {
+        for waitingNumber in 1...number {
             clients.append(Client(waitingNumber))
         }
         
@@ -60,10 +55,11 @@ struct Bank {
     }
     
     @discardableResult
-    func close() -> Double {
-        let totalProcessedTime = floor(processedTime * 100) / 100
-        print("업무가 마감되었습니다. 오늘 업무를 처리한 고객은 총 \(totalClient) 명이며, 총 업무 시간은 \(totalProcessedTime)초입니다.")
-        return totalProcessedTime
+    func close(_ totalProcessTime: Double, numberOfClient: Int) -> Double {
+        let flooredTotalProcessTime: Double = floor(totalProcessTime * 100) / 100
+        
+        print("업무가 마감되었습니다. 오늘 업무를 처리한 고객은 총 \(numberOfClient) 명이며, 총 업무 시간은 \(flooredTotalProcessTime)초입니다.")
+        return flooredTotalProcessTime
     }
 }
 

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
@@ -28,7 +28,7 @@ struct Bank {
         )
         let totalProcessTime: Double = measureTime { processTasks(of: clients) }
         
-        close(totalProcessTime, numberOfClient: clients.count)
+        close(numberOfClient: clients.count, totalProcessTime)
     }
     
     mutating func makeClients(number: Int) -> [Client] {
@@ -54,7 +54,7 @@ struct Bank {
         waitingQueue.addOperations(clients, waitUntilFinished: true)
     }
     
-    func close(_ totalProcessTime: Double, numberOfClient: Int) {
+    func close(numberOfClient: Int, _ totalProcessTime: Double) {
         print("업무가 마감되었습니다. 오늘 업무를 처리한 고객은 총 \(numberOfClient) 명이며, 총 업무 시간은 \(totalProcessTime)초입니다.")
     }
 }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
@@ -1,0 +1,62 @@
+//
+//  Bank.swift
+//  BankManagerConsoleApp
+//
+//  Created by Ryan-Son on 2021/04/27.
+//
+
+import Foundation
+
+struct Bank {
+    var totalCustomer: Int = 0
+    var waitingQueue: OperationQueue = OperationQueue()
+    var numberOfTeller: Int
+    var time: Double = 0
+    
+    private enum NumberOfCustomer {
+        static let minimum: Int = 10
+        static let maximum: Int = 30
+    }
+    
+    init(_ numberOfTeller: Int) {
+        self.numberOfTeller = numberOfTeller
+    }
+    
+    private func totalProcessedTime(_ closure: () -> Void) -> Double {
+        let startTime = CFAbsoluteTimeGetCurrent()
+        closure()
+        let processedTime = CFAbsoluteTimeGetCurrent() - startTime
+        return processedTime
+    }
+    
+    mutating func open() {
+        assignTeller()
+        time = totalProcessedTime {
+            visitNewCustomer()
+        }
+        close()
+    }
+    
+    private func close() {
+        let totalProcessedTime = floor(time * 100) / 100
+        print("업무가 마감되었습니다. 오늘 업무를 처리한 고객은 총 \(totalCustomer) 명이며, 총 업무 시간은 \(totalProcessedTime)초입니다.")
+    }
+    
+    func assignTeller() {
+        waitingQueue.maxConcurrentOperationCount = numberOfTeller
+    }
+    
+    @discardableResult
+    mutating func visitNewCustomer() -> [Customer] {
+        var customers: [Customer] = []
+        totalCustomer = Int.random(in: NumberOfCustomer.minimum...NumberOfCustomer.maximum)
+        
+        for waitingNumber in 1...totalCustomer {
+            customers.append(Customer(waitingNumber))
+        }
+        
+        waitingQueue.addOperations(customers, waitUntilFinished: true)
+        return customers
+    }
+}
+

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
@@ -47,7 +47,11 @@ struct Bank {
         let startTime = CFAbsoluteTimeGetCurrent()
         subjectMethodsToBeMeasured()
         let processTime = CFAbsoluteTimeGetCurrent() - startTime
-        return floor(processTime * 100) / 100
+        return processTime
+    }
+    
+    func preferredNumberFormat(_ number: Double) -> Double {
+        return floor(number * 100) / 100
     }
     
     mutating func processTasks(of clients: [Client]) {
@@ -55,7 +59,7 @@ struct Bank {
     }
     
     func close(numberOfClient: Int, _ totalProcessTime: Double) {
-        print("업무가 마감되었습니다. 오늘 업무를 처리한 고객은 총 \(numberOfClient) 명이며, 총 업무 시간은 \(totalProcessTime)초입니다.")
+        print("업무가 마감되었습니다. 오늘 업무를 처리한 고객은 총 \(numberOfClient) 명이며, 총 업무 시간은 \(preferredNumberFormat(totalProcessTime))초입니다.")
     }
 }
 

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
@@ -8,12 +8,12 @@
 import Foundation
 
 struct Bank {
-    var totalCustomer: Int = 0
+    var totalClient: Int = 0
     var waitingQueue: OperationQueue = OperationQueue()
     var numberOfTeller: Int
     var processedTime: Double = 0
     
-    private enum NumberOfCustomer {
+    private enum NumberOfClient {
         static let minimum: Int = 10
         static let maximum: Int = 30
     }
@@ -32,7 +32,7 @@ struct Bank {
     mutating func open() {
         assignTeller()
         processedTime = totalProcessedTime {
-            visitNewCustomer()
+            visitNewClient()
         }
         close()
     }
@@ -40,7 +40,7 @@ struct Bank {
     @discardableResult
     func close() -> Double {
         let totalProcessedTime = floor(processedTime * 100) / 100
-        print("업무가 마감되었습니다. 오늘 업무를 처리한 고객은 총 \(totalCustomer) 명이며, 총 업무 시간은 \(totalProcessedTime)초입니다.")
+        print("업무가 마감되었습니다. 오늘 업무를 처리한 고객은 총 \(totalClient) 명이며, 총 업무 시간은 \(totalProcessedTime)초입니다.")
         return totalProcessedTime
     }
     
@@ -49,16 +49,16 @@ struct Bank {
     }
     
     @discardableResult
-    mutating func visitNewCustomer() -> [Customer] {
-        var customers: [Customer] = []
-        totalCustomer = Int.random(in: NumberOfCustomer.minimum...NumberOfCustomer.maximum)
+    mutating func visitNewClient() -> [Client] {
+        var clients: [Client] = []
+        totalClient = Int.random(in: NumberOfClient.minimum...NumberOfClient.maximum)
         
-        for waitingNumber in 1...totalCustomer {
-            customers.append(Customer(waitingNumber))
+        for waitingNumber in 1...totalClient {
+            clients.append(Client(waitingNumber))
         }
         
-        waitingQueue.addOperations(customers, waitUntilFinished: true)
-        return customers
+        waitingQueue.addOperations(clients, waitUntilFinished: true)
+        return clients
     }
 }
 

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
@@ -11,7 +11,7 @@ struct Bank {
     // MARK: - Properties
     private var waitingQueue: OperationQueue = OperationQueue()
     
-    init(numberOfTeller: Int = 1) {
+    init(numberOfTeller: Int) {
         self.waitingQueue.maxConcurrentOperationCount = numberOfTeller
     }
     
@@ -26,18 +26,24 @@ struct Bank {
         let clients: [Client] = makeClients(
             number: Int.random(in: NumberOfClient.minimum...NumberOfClient.maximum)
         )
-        let totalProcessTime: Double = measureTime { processTasks(of: clients) }
+        let totalProcessTime: Double = measureTime { () -> Void in
+            return processTasks(of: clients)
+        }
+        let closeText = close(numberOfClient: clients.count, totalProcessTime)
         
-        close(numberOfClient: clients.count, totalProcessTime)
+        print(closeText)
     }
     
     mutating func makeClients(number: Int) -> [Client] {
         var clients: [Client] = []
         
-        guard number >= 1 else { return clients }
+        guard number >= 1 else {
+            return clients
+        }
         
         for waitingNumber in 1...number {
-            clients.append(Client(waitingNumber))
+            let client: Client = Client(waitingNumber)
+            clients.append(client)
         }
         
         return clients
@@ -58,8 +64,8 @@ struct Bank {
         waitingQueue.addOperations(clients, waitUntilFinished: true)
     }
     
-    func close(numberOfClient: Int, _ totalProcessTime: Double) {
-        print("업무가 마감되었습니다. 오늘 업무를 처리한 고객은 총 \(numberOfClient) 명이며, 총 업무 시간은 \(preferredNumberFormat(totalProcessTime))초입니다.")
+    func close(numberOfClient: Int, _ totalProcessTime: Double) -> String {
+        return "업무가 마감되었습니다. 오늘 업무를 처리한 고객은 총 \(numberOfClient) 명이며, 총 업무 시간은 \(preferredNumberFormat(totalProcessTime))초입니다."
     }
 }
 

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
@@ -2,7 +2,7 @@
 //  Bank.swift
 //  BankManagerConsoleApp
 //
-//  Created by Ryan-Son on 2021/04/27.
+//  Created by Yun, Ryan on 2021/04/27.
 //
 
 import Foundation

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
@@ -23,14 +23,12 @@ struct Bank {
     
     // MARK: - Private Methods
     mutating func open() {
-        let clients: [Client] = clients(number: generateRandomClientNumber())
+        let clients: [Client] = clients(
+            number: Int.random(in: NumberOfClient.minimum...NumberOfClient.maximum)
+        )
         let totalProcessTime: Double = measureTime { processTasks(of: clients) }
         
         close(totalProcessTime, numberOfClient: clients.count)
-    }
-    
-    func generateRandomClientNumber() -> Int {
-        return Int.random(in: NumberOfClient.minimum...NumberOfClient.maximum)
     }
     
     func measureTime(_ closure: () -> Void) -> Double {

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
@@ -23,7 +23,7 @@ struct Bank {
     
     // MARK: - Private Methods
     mutating func open() {
-        let clients: [Client] = clients(
+        let clients: [Client] = makeClients(
             number: Int.random(in: NumberOfClient.minimum...NumberOfClient.maximum)
         )
         let totalProcessTime: Double = measureTime { processTasks(of: clients) }
@@ -31,7 +31,7 @@ struct Bank {
         close(totalProcessTime, numberOfClient: clients.count)
     }
     
-    mutating func clients(number: Int) -> [Client] {
+    mutating func makeClients(number: Int) -> [Client] {
         var clients: [Client] = []
         
         for waitingNumber in 1...number {
@@ -41,9 +41,9 @@ struct Bank {
         return clients
     }
     
-    func measureTime(_ closure: () -> Void) -> Double {
+    func measureTime(_ subjectMethodsToBeMeasured: () -> Void) -> Double {
         let startTime = CFAbsoluteTimeGetCurrent()
-        closure()
+        subjectMethodsToBeMeasured()
         let processTime = CFAbsoluteTimeGetCurrent() - startTime
         return processTime
     }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
@@ -49,19 +49,15 @@ struct Bank {
         let startTime = CFAbsoluteTimeGetCurrent()
         subjectMethodsToBeMeasured()
         let processTime = CFAbsoluteTimeGetCurrent() - startTime
-        return processTime
+        return floor(processTime * 100) / 100
     }
     
     mutating private func processTasks(of clients: [Client]) {
         waitingQueue.addOperations(clients, waitUntilFinished: true)
     }
     
-    @discardableResult
-    func close(_ totalProcessTime: Double, numberOfClient: Int) -> Double {
-        let flooredTotalProcessTime: Double = floor(totalProcessTime * 100) / 100
-        
-        print("업무가 마감되었습니다. 오늘 업무를 처리한 고객은 총 \(numberOfClient) 명이며, 총 업무 시간은 \(flooredTotalProcessTime)초입니다.")
-        return flooredTotalProcessTime
+    func close(_ totalProcessTime: Double, numberOfClient: Int) {
+        print("업무가 마감되었습니다. 오늘 업무를 처리한 고객은 총 \(numberOfClient) 명이며, 총 업무 시간은 \(totalProcessTime)초입니다.")
     }
 }
 

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
@@ -8,27 +8,23 @@
 import Foundation
 
 struct Bank {
+    // MARK: - Properties
     private(set) var totalClient: Int = 0
     private(set) var waitingQueue: OperationQueue = OperationQueue()
     private(set) var numberOfTeller: Int
     var processedTime: Double = 0
     
+    init(numberOfTeller: Int) {
+        self.numberOfTeller = numberOfTeller
+    }
+    
+    // MARK: - NameSpaces
     private enum NumberOfClient {
         static let minimum: Int = 10
         static let maximum: Int = 30
     }
     
-    init(numberOfTeller: Int) {
-        self.numberOfTeller = numberOfTeller
-    }
-    
-    func totalProcessedTime(_ closure: () -> Void) -> Double {
-        let startTime = CFAbsoluteTimeGetCurrent()
-        closure()
-        let processedTime = CFAbsoluteTimeGetCurrent() - startTime
-        return processedTime
-    }
-    
+    // MARK: - Private Methods
     mutating func open() {
         assignTeller()
         processedTime = totalProcessedTime {
@@ -37,15 +33,15 @@ struct Bank {
         close()
     }
     
-    @discardableResult
-    func close() -> Double {
-        let totalProcessedTime = floor(processedTime * 100) / 100
-        print("업무가 마감되었습니다. 오늘 업무를 처리한 고객은 총 \(totalClient) 명이며, 총 업무 시간은 \(totalProcessedTime)초입니다.")
-        return totalProcessedTime
-    }
-    
     func assignTeller() {
         waitingQueue.maxConcurrentOperationCount = numberOfTeller
+    }
+    
+    func totalProcessedTime(_ closure: () -> Void) -> Double {
+        let startTime = CFAbsoluteTimeGetCurrent()
+        closure()
+        let processedTime = CFAbsoluteTimeGetCurrent() - startTime
+        return processedTime
     }
     
     mutating func clients() -> [Client] {
@@ -61,6 +57,13 @@ struct Bank {
     
     mutating private func processTasks(of clients: [Client]) {
         waitingQueue.addOperations(clients, waitUntilFinished: true)
+    }
+    
+    @discardableResult
+    func close() -> Double {
+        let totalProcessedTime = floor(processedTime * 100) / 100
+        print("업무가 마감되었습니다. 오늘 업무를 처리한 고객은 총 \(totalClient) 명이며, 총 업무 시간은 \(totalProcessedTime)초입니다.")
+        return totalProcessedTime
     }
 }
 

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
@@ -18,11 +18,11 @@ struct Bank {
         static let maximum: Int = 30
     }
     
-    init(_ numberOfTeller: Int) {
+    init(numberOfTeller: Int) {
         self.numberOfTeller = numberOfTeller
     }
     
-    private func totalProcessedTime(_ closure: () -> Void) -> Double {
+    func totalProcessedTime(_ closure: () -> Void) -> Double {
         let startTime = CFAbsoluteTimeGetCurrent()
         closure()
         let processedTime = CFAbsoluteTimeGetCurrent() - startTime
@@ -37,9 +37,11 @@ struct Bank {
         close()
     }
     
-    private func close() {
+    @discardableResult
+    func close() -> Double {
         let totalProcessedTime = floor(processedTime * 100) / 100
         print("업무가 마감되었습니다. 오늘 업무를 처리한 고객은 총 \(totalCustomer) 명이며, 총 업무 시간은 \(totalProcessedTime)초입니다.")
+        return totalProcessedTime
     }
     
     func assignTeller() {

--- a/BankManagerConsoleApp/BankManagerConsoleApp/BankManagerError.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/BankManagerError.swift
@@ -2,7 +2,7 @@
 //  BankManagerError.swift
 //  BankManagerConsoleApp
 //
-//  Created by Yunhwa on 2021/04/29.
+//  Created by Yun, Ryan on 2021/04/29.
 //
 
 import Foundation

--- a/BankManagerConsoleApp/BankManagerConsoleApp/BankManagerError.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/BankManagerError.swift
@@ -8,12 +8,12 @@
 import Foundation
 
 enum BankManagerError: Error, CustomStringConvertible {
-    case invaildMenu(String)
+    case invalidMenu(String)
     
     var description: String {
         switch self {
-        case .invaildMenu(let functionName):
-            return "invaildInput \(functionName)"
+        case .invalidMenu(let functionName):
+            return "invalidInput. Method Name: \(functionName)"
         }
     }
 }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/BankManagerError.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/BankManagerError.swift
@@ -1,0 +1,19 @@
+//
+//  BankManagerError.swift
+//  BankManagerConsoleApp
+//
+//  Created by Yunhwa on 2021/04/29.
+//
+
+import Foundation
+
+enum BankManagerError: Error, CustomStringConvertible {
+    case invaildMenu(String)
+    
+    var description: String {
+        switch self {
+        case .invaildMenu(let functionName):
+            return "invaildInput \(functionName)"
+        }
+    }
+}

--- a/BankManagerConsoleApp/BankManagerConsoleApp/BankManagerError.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/BankManagerError.swift
@@ -5,8 +5,6 @@
 //  Created by Yun, Ryan on 2021/04/29.
 //
 
-import Foundation
-
 enum BankManagerError: Error, CustomStringConvertible {
     case invalidMenu(String)
     

--- a/BankManagerConsoleApp/BankManagerConsoleApp/BankManagerError.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/BankManagerError.swift
@@ -6,12 +6,12 @@
 //
 
 enum BankManagerError: Error, CustomStringConvertible {
-    case invalidMenu(String)
+    case invalidMenu
     
     var description: String {
         switch self {
-        case .invalidMenu(let userInput):
-            return "Invalid Input. User Input: \(userInput)"
+        case .invalidMenu:
+            return "Invalid Input"
         }
     }
 }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/BankManagerError.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/BankManagerError.swift
@@ -12,8 +12,8 @@ enum BankManagerError: Error, CustomStringConvertible {
     
     var description: String {
         switch self {
-        case .invalidMenu(let functionName):
-            return "invalidInput. Method Name: \(functionName)"
+        case .invalidMenu(let userInput):
+            return "Invalid Input. User Input: \(userInput)"
         }
     }
 }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Client.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Client.swift
@@ -7,16 +7,19 @@
 import Foundation
 
 final class Client: Operation {
+    // MARK: - Properties
     let waitingNumber: Int
     
-    private enum TimeForProcessingTask {
-        static let deposit: Double = 0.7
-    }
-
     init(_ waitingNumber: Int) {
         self.waitingNumber = waitingNumber
     }
     
+    // MARK: - NameSpaces
+    private enum TimeForProcessingTask {
+        static let deposit: Double = 0.7
+    }
+    
+    // MARK: - Override Method from the Operation Class
     override func main() {
         print("\(waitingNumber) 번 고객 업무 시작.")
         Thread.sleep(forTimeInterval: TimeForProcessingTask.deposit)

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Client.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Client.swift
@@ -4,6 +4,7 @@
 //
 //  Created by Yun, Ryan on 2021/04/27.
 //
+
 import Foundation
 
 final class Client: Operation {

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Client.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Client.swift
@@ -2,7 +2,7 @@
 //  Client.swift
 //  BankManagerConsoleApp
 //
-//  Created by Yunhwa on 2021/04/27.
+//  Created by Yun, Ryan on 2021/04/27.
 //
 import Foundation
 

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Client.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Client.swift
@@ -13,6 +13,7 @@ final class Client: Operation {
     
     init(_ waitingNumber: Int) {
         self.waitingNumber = waitingNumber
+        
     }
     
     // MARK: - NameSpaces
@@ -20,11 +21,23 @@ final class Client: Operation {
         static let deposit: Double = 0.7
     }
     
+    // MARK: - Private Method
+    func startTask() -> String {
+        return "\(waitingNumber) 번 고객 업무 시작."
+    }
+    
+    func endTask() -> String {
+        return "\(waitingNumber) 번 고객 업무 종료!"
+    }
+    
     // MARK: - Override Method from the Operation Class
     override func main() {
-        print("\(waitingNumber) 번 고객 업무 시작.")
+        let startTaskText: String = startTask()
+        let endTaskText: String = endTask()
+        
+        print(startTaskText)
         Thread.sleep(forTimeInterval: TimeForProcessingTask.deposit)
-        print("\(waitingNumber) 번 고객 업무 종료!")
+        print(endTaskText)
     }
 }
 

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Client.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Client.swift
@@ -1,12 +1,12 @@
 //
-//  Customer.swift
+//  Client.swift
 //  BankManagerConsoleApp
 //
 //  Created by Yunhwa on 2021/04/27.
 //
 import Foundation
 
-final class Customer: Operation {
+final class Client: Operation {
     let waitingNumber: Int
     
     private enum TimeForProcessingTask {

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Customer.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Customer.swift
@@ -11,7 +11,6 @@ final class Customer: Operation {
     
     private enum TimeForProcessingTask {
         static let deposit: Double = 0.7
-        static let withdrawal: Double = 1.1
     }
 
     init(_ waitingNumber: Int) {
@@ -19,9 +18,9 @@ final class Customer: Operation {
     }
     
     override func main() {
-        print("\(waitingNumber) 번 고객 업무 시작")
+        print("\(waitingNumber) 번 고객 업무 시작.")
         Thread.sleep(forTimeInterval: TimeForProcessingTask.deposit)
-        print("\(waitingNumber) 번 고객 업무 종료")
+        print("\(waitingNumber) 번 고객 업무 종료!")
     }
 }
 

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Customer.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Customer.swift
@@ -1,0 +1,27 @@
+//
+//  Customer.swift
+//  BankManagerConsoleApp
+//
+//  Created by Yunhwa on 2021/04/27.
+//
+import Foundation
+
+final class Customer: Operation {
+    let waitingNumber: Int
+    
+    private enum TimeForProcessingTask {
+        static let deposit: Double = 0.7
+        static let withdrawal: Double = 1.1
+    }
+
+    init(_ waitingNumber: Int) {
+        self.waitingNumber = waitingNumber
+    }
+    
+    override func main() {
+        print("\(waitingNumber) 번 고객 업무 시작")
+        Thread.sleep(forTimeInterval: TimeForProcessingTask.deposit)
+        print("\(waitingNumber) 번 고객 업무 종료")
+    }
+}
+

--- a/BankManagerConsoleApp/BankManagerConsoleApp/main.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/main.swift
@@ -4,4 +4,5 @@
 //  Copyright © yagom academy. All rights reserved.
 // 
 
-import Foundation
+private var bankManager = BankManager()
+bankManager.start()

--- a/BankManagerConsoleApp/BankManagerConsoleApp/main.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/main.swift
@@ -1,6 +1,6 @@
 //
 //  BankManagerConsoleApp - main.swift
-//  Created by yagom. 
+//  Created by Yun, Ryan. 
 //  Copyright © yagom academy. All rights reserved.
 // 
 

--- a/BankManagerConsoleApp/BankManagerConsoleApp/main.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/main.swift
@@ -4,5 +4,5 @@
 //  Copyright © yagom academy. All rights reserved.
 // 
 
-private var bankManager = BankManager()
+private var bankManager = BankManager(numberOfTeller: 1)
 bankManager.start()

--- a/BankManagerConsoleApp/BankManagerTest/BankManagerTest.swift
+++ b/BankManagerConsoleApp/BankManagerTest/BankManagerTest.swift
@@ -12,18 +12,20 @@ final class BankManagerTests: XCTestCase {
     private var sutBank: Bank?
     
     override func setUpWithError() throws {
-        try super.setUpWithError()
-        
         sutBank = Bank(numberOfTeller: 1)
+        
+        try super.setUpWithError()
     }
     
     override func tearDownWithError() throws {
+        sutBank = nil
+        
         try super.tearDownWithError()
     }
 
-    func test_bank_visitNewCustomer() {
-        let customers: [Customer]? = sutBank?.visitNewCustomer()
-        XCTAssertEqual(customers?.count, sutBank?.totalCustomer)
+    func test_bank_visitNewClient() {
+        let clients: [Client]? = sutBank?.visitNewClient()
+        XCTAssertEqual(clients?.count, sutBank?.totalClient)
     }
 
     func test_bank_assignTeller() {

--- a/BankManagerConsoleApp/BankManagerTest/BankManagerTest.swift
+++ b/BankManagerConsoleApp/BankManagerTest/BankManagerTest.swift
@@ -37,13 +37,13 @@ final class BankManagerTests: XCTestCase {
     func testClose_whenProcessedTimeHasMoreThanTwoDecimalPlaces_checksResultHasTwoDecimalPlaces() {
         var sutBank: Bank = Bank(numberOfTeller: 1)
         
-        sutBank.processedTime = 123.56789
+        sutBank.        total:processedTime = 123.56789
         XCTAssertEqual(sutBank.close(), 123.56)
     }
     
     func testTotalProcessedTime_whenGivenProcessingTime_checksGivenValueAndCalculatedResultAreSame() {
         let sutBank: Bank = Bank(numberOfTeller: 1)
-        let sleepTime: Double = sutBank.totalProcessedTime {
+        let sleepTime: Double = sutBank.processedTime {
             Thread.sleep(forTimeInterval: 0.01)
         }
         

--- a/BankManagerConsoleApp/BankManagerTest/BankManagerTest.swift
+++ b/BankManagerConsoleApp/BankManagerTest/BankManagerTest.swift
@@ -23,8 +23,8 @@ final class BankManagerTests: XCTestCase {
         try super.tearDownWithError()
     }
 
-    func test_bank_visitNewClient() {
-        let clients: [Client]? = sutBank?.visitNewClient()
+    func test_bank_clients() {
+        let clients: [Client]? = sutBank?.clients()
         XCTAssertEqual(clients?.count, sutBank?.totalClient)
     }
 

--- a/BankManagerConsoleApp/BankManagerTest/BankManagerTest.swift
+++ b/BankManagerConsoleApp/BankManagerTest/BankManagerTest.swift
@@ -2,7 +2,7 @@
 //  BankManagerTests.swift
 //  BankManagerTests
 //
-//  Created by Yunhwa on 2021/04/27.
+//  Created by Yun, Ryan on 2021/04/27.
 //
 
 import XCTest

--- a/BankManagerConsoleApp/BankManagerTest/BankManagerTest.swift
+++ b/BankManagerConsoleApp/BankManagerTest/BankManagerTest.swift
@@ -9,45 +9,44 @@ import XCTest
 @testable import BankManagerConsoleApp
 
 final class BankManagerTests: XCTestCase {
-    private var sutBank: Bank?
     
     override func setUpWithError() throws {
-        sutBank = Bank(numberOfTeller: 1)
-        
         try super.setUpWithError()
     }
     
     override func tearDownWithError() throws {
-        sutBank = nil
-        
         try super.tearDownWithError()
     }
 
-    func test_bank_clients() {
-        let clients: [Client]? = sutBank?.clients()
-        XCTAssertEqual(clients?.count, sutBank?.totalClient)
+    func testClients_whenInitiated_checksArrayandNumberAreSame() {
+        var sutBank: Bank = Bank(numberOfTeller: 1)
+        let clients: [Client] = sutBank.clients()
+        
+        XCTAssertEqual(clients.count, sutBank.totalClient)
     }
 
-    func test_bank_assignTeller() {
-        sutBank?.assignTeller()
-        XCTAssertEqual(sutBank?.waitingQueue.maxConcurrentOperationCount, sutBank?.numberOfTeller)
+    func testAssignTeller_whenThreeTellers_checksAssignedState() {
+        let sutBank: Bank = Bank(numberOfTeller: 3)
+        
+        sutBank.assignTeller()
+        
+        XCTAssertEqual(sutBank.waitingQueue.maxConcurrentOperationCount, 3)
+        XCTAssertEqual(sutBank.numberOfTeller, 3)
     }
     
-    func test_bank_close() {
-        sutBank?.processedTime = 123.56789
-        XCTAssertEqual(sutBank?.close(), 123.56)
+    func testClose_whenProcessedTimeHasMoreThanTwoDecimalPlaces_checksResultHasTwoDecimalPlaces() {
+        var sutBank: Bank = Bank(numberOfTeller: 1)
+        
+        sutBank.processedTime = 123.56789
+        XCTAssertEqual(sutBank.close(), 123.56)
     }
     
-    func test_bank_totalProcessedTime() {
-        let sleepTime: Double? = sutBank?.totalProcessedTime {
+    func testTotalProcessedTime_whenGivenProcessingTime_checksGivenValueAndCalculatedResultAreSame() {
+        let sutBank: Bank = Bank(numberOfTeller: 1)
+        let sleepTime: Double = sutBank.totalProcessedTime {
             Thread.sleep(forTimeInterval: 0.01)
         }
-        guard let sleepTime: Double = sleepTime else {
-            XCTFail("Failed to initialize sleepTime.")
-            return
-        }
-        let flooredSleepTime: Double = floor(sleepTime * 100) / 100
         
-        XCTAssertEqual(flooredSleepTime, 0.01)
+        XCTAssertEqual(floor(sleepTime * 100) / 100, 0.01)
     }
 }

--- a/BankManagerConsoleApp/BankManagerTest/BankManagerTest.swift
+++ b/BankManagerConsoleApp/BankManagerTest/BankManagerTest.swift
@@ -18,7 +18,7 @@ final class BankManagerTests: XCTestCase {
         try super.tearDownWithError()
     }
 
-    func testClients_whenInitiated_checksArrayandNumberAreSame() {
+    func testClients_whenInitiated_checksArrayAndNumberAreSame() {
         var sutBank: Bank = Bank(numberOfTeller: 1)
         let clients: [Client] = sutBank.clients()
         

--- a/BankManagerConsoleApp/BankManagerTest/BankManagerTest.swift
+++ b/BankManagerConsoleApp/BankManagerTest/BankManagerTest.swift
@@ -46,10 +46,12 @@ final class BankManagerTests: XCTestCase {
         XCTAssertEqual(sleepTime, 0.01)
     }
     
-//    func testClose_whenProcessedTimeHasMoreThanTwoDecimalPlaces_checksResultHasTwoDecimalPlaces() {
-//        var sutBank: Bank = Bank(numberOfTeller: 1)
-//
-//        sutBank.        total:processedTime = 123.56789
-//        XCTAssertEqual(sutBank.close(), 123.56)
-//    }
+    func testProcessTasks_whenProcessOneDepositTask_takesPointSevenSeconds() {
+        var sutBank: Bank = Bank()
+        let processTime: Double = sutBank.measureTime {
+            sutBank.processTasks(of: [Client(1)])
+        }
+        
+        XCTAssertEqual(processTime, 0.7)
+    }
 }

--- a/BankManagerConsoleApp/BankManagerTest/BankManagerTest.swift
+++ b/BankManagerConsoleApp/BankManagerTest/BankManagerTest.swift
@@ -18,35 +18,38 @@ final class BankManagerTests: XCTestCase {
         try super.tearDownWithError()
     }
 
-    func testClients_whenInitiated_checksArrayAndNumberAreSame() {
-        var sutBank: Bank = Bank(numberOfTeller: 1)
-        let clients: [Client] = sutBank.clients()
+    func testMakeClients_whenClientNumberLessThanOne_returnEmptyArray() {
+        var sutBank: Bank = Bank()
         
-        XCTAssertEqual(clients.count, sutBank.totalClient)
-    }
-
-    func testAssignTeller_whenThreeTellers_checksAssignedState() {
-        let sutBank: Bank = Bank(numberOfTeller: 3)
-        
-        sutBank.assignTeller()
-        
-        XCTAssertEqual(sutBank.waitingQueue.maxConcurrentOperationCount, 3)
-        XCTAssertEqual(sutBank.numberOfTeller, 3)
-    }
-    
-    func testClose_whenProcessedTimeHasMoreThanTwoDecimalPlaces_checksResultHasTwoDecimalPlaces() {
-        var sutBank: Bank = Bank(numberOfTeller: 1)
-        
-        sutBank.        total:processedTime = 123.56789
-        XCTAssertEqual(sutBank.close(), 123.56)
-    }
-    
-    func testTotalProcessedTime_whenGivenProcessingTime_checksGivenValueAndCalculatedResultAreSame() {
-        let sutBank: Bank = Bank(numberOfTeller: 1)
-        let sleepTime: Double = sutBank.processedTime {
-            Thread.sleep(forTimeInterval: 0.01)
+        for lessThanOne in -1...0 {
+            XCTAssertEqual(sutBank.makeClients(number: lessThanOne), [])
         }
-        
-        XCTAssertEqual(floor(sleepTime * 100) / 100, 0.01)
     }
+    
+    func testMakeClients_whenClientNumberIsMoreThanOne_returnClientsWithWaitingNumber() {
+        var sutBank: Bank = Bank()
+        let sutClients: [Client] = sutBank.makeClients(number: 3)
+        
+        XCTAssertEqual(sutClients.count, 3)
+        
+        for index in 0...2 {
+            XCTAssertEqual(sutClients[index].waitingNumber, index + 1)
+        }
+    }
+    
+//    func testClose_whenProcessedTimeHasMoreThanTwoDecimalPlaces_checksResultHasTwoDecimalPlaces() {
+//        var sutBank: Bank = Bank(numberOfTeller: 1)
+//
+//        sutBank.        total:processedTime = 123.56789
+//        XCTAssertEqual(sutBank.close(), 123.56)
+//    }
+    
+//    func testTotalProcessedTime_whenGivenProcessingTime_checksGivenValueAndCalculatedResultAreSame() {
+//        let sutBank: Bank = Bank(numberOfTeller: 1)
+//        let sleepTime: Double = sutBank.processedTime {
+//            Thread.sleep(forTimeInterval: 0.01)
+//        }
+//        
+//        XCTAssertEqual(floor(sleepTime * 100) / 100, 0.01)
+//    }
 }

--- a/BankManagerConsoleApp/BankManagerTest/BankManagerTest.swift
+++ b/BankManagerConsoleApp/BankManagerTest/BankManagerTest.swift
@@ -9,7 +9,7 @@ import XCTest
 @testable import BankManagerConsoleApp
 
 final class BankManagerTests: XCTestCase {
-    var sutBank: Bank = Bank()
+    var sutBank: Bank = Bank(numberOfTeller: 1)
     
     override func setUpWithError() throws {
         try super.setUpWithError()
@@ -36,22 +36,24 @@ final class BankManagerTests: XCTestCase {
     }
     
     func testMeasureTime_whenNoTaskGiven_returnsZero() {
-        let sleepTime: Double = sutBank.measureTime { }
+        let processTime: Double = sutBank.measureTime { }
         
-        XCTAssertEqual(sleepTime, 0)
+        XCTAssertEqual(floor(processTime), 0)
     }
     
     func testMeasureTime_whenProcessTimeIsGiven_returnsGivenTime() {
-        let sleepTime: Double = sutBank.measureTime {
-            Thread.sleep(forTimeInterval: 0.01)
+        let processTime: Double = sutBank.measureTime { () -> Void in
+            return Thread.sleep(forTimeInterval: 0.01)
         }
         
-        XCTAssertEqual(floor(sleepTime * 100) / 100, 0.01)
+        XCTAssertEqual(floor(processTime * 100) / 100, 0.01)
     }
     
     func testProcessTasks_whenProcessOneDepositTask_takesPointSevenSeconds() {
-        let processTime: Double = sutBank.measureTime {
-            sutBank.processTasks(of: [Client(1)])
+       
+        let processTime: Double = sutBank.measureTime { () -> Void in
+            let clients: [Client] = [Client(1)]
+            return sutBank.processTasks(of: clients)
         }
         
         XCTAssertEqual(floor(processTime * 100) / 100 , 0.7)
@@ -59,5 +61,22 @@ final class BankManagerTests: XCTestCase {
     
     func testPreferredNumberFormat_whenNumberMoreThanTwoDecimalPlacesIsGiven_returnsNumberWithTwoDecimalPlaces() {
         XCTAssertEqual(sutBank.preferredNumberFormat(123.456789), 123.45)
+    }
+
+    func testStarttask_whenClientHasWaitingNumberOne_returnStartTaskTextWithWaitingNumberOne() {
+        let client: Client = Client(1)
+        XCTAssertEqual(client.startTask(), "1 번 고객 업무 시작.")
+    }
+
+    func testEndTask_whenClientHasWaitingNumberOne_returnEndTaskTextWithWaitingNumberOne() {
+        let client: Client = Client(1)
+        XCTAssertEqual(client.endTask(), "1 번 고객 업무 종료!")
+    }
+    
+    func testClose_whenNumberOfClientAndTotalProcessTimeAreGiven_returnCloseTextWithGivenNumbers() {
+        XCTAssertEqual(
+            sutBank.close(numberOfClient: 3, 2.1),
+            "업무가 마감되었습니다. 오늘 업무를 처리한 고객은 총 3 명이며, 총 업무 시간은 2.1초입니다."
+        )
     }
 }

--- a/BankManagerConsoleApp/BankManagerTest/BankManagerTest.swift
+++ b/BankManagerConsoleApp/BankManagerTest/BankManagerTest.swift
@@ -1,0 +1,31 @@
+//
+//  BankManagerTests.swift
+//  BankManagerTests
+//
+//  Created by Yunhwa on 2021/04/27.
+//
+
+import XCTest
+@testable import BankManagerConsoleApp
+
+final class BankManagerTests: XCTestCase {
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+    }
+    
+    override func tearDownWithError() throws {
+        try super.tearDownWithError()
+    }
+
+    func test_visitNewCustomer() {
+        var bank = Bank(1)
+        let customers: [Customer] = bank.visitNewCustomer()
+        XCTAssertEqual(customers.count, bank.totalCustomer)
+    }
+
+    func test_assignTeller() {
+        let bank = Bank(1)
+        bank.assignTeller()
+        XCTAssertEqual(bank.waitingQueue.maxConcurrentOperationCount, bank.numberOfTeller)
+    }
+}

--- a/BankManagerConsoleApp/BankManagerTest/BankManagerTest.swift
+++ b/BankManagerConsoleApp/BankManagerTest/BankManagerTest.swift
@@ -37,6 +37,13 @@ final class BankManagerTests: XCTestCase {
         }
     }
     
+    func testMeasureTime_whenNoTaskGiven_returnsZero() {
+        let sutBank: Bank = Bank()
+        let sleepTime: Double = sutBank.measureTime { }
+        
+        XCTAssertEqual(sleepTime, 0)
+    }
+    
     func testMeasureTime_whenProcessTimeIsGiven_returnsGivenTime() {
         let sutBank: Bank = Bank()
         let sleepTime: Double = sutBank.measureTime {

--- a/BankManagerConsoleApp/BankManagerTest/BankManagerTest.swift
+++ b/BankManagerConsoleApp/BankManagerTest/BankManagerTest.swift
@@ -9,6 +9,7 @@ import XCTest
 @testable import BankManagerConsoleApp
 
 final class BankManagerTests: XCTestCase {
+    var sutBank: Bank = Bank()
     
     override func setUpWithError() throws {
         try super.setUpWithError()
@@ -19,15 +20,12 @@ final class BankManagerTests: XCTestCase {
     }
 
     func testMakeClients_whenClientNumberLessThanOne_returnsEmptyArray() {
-        var sutBank: Bank = Bank()
-        
         for lessThanOne in -1...0 {
             XCTAssertEqual(sutBank.makeClients(number: lessThanOne), [])
         }
     }
     
     func testMakeClients_whenClientNumberIsMoreThanOne_returnsClientsWithWaitingNumber() {
-        var sutBank: Bank = Bank()
         let sutClients: [Client] = sutBank.makeClients(number: 3)
         
         XCTAssertEqual(sutClients.count, 3)
@@ -38,27 +36,28 @@ final class BankManagerTests: XCTestCase {
     }
     
     func testMeasureTime_whenNoTaskGiven_returnsZero() {
-        let sutBank: Bank = Bank()
         let sleepTime: Double = sutBank.measureTime { }
         
         XCTAssertEqual(sleepTime, 0)
     }
     
     func testMeasureTime_whenProcessTimeIsGiven_returnsGivenTime() {
-        let sutBank: Bank = Bank()
         let sleepTime: Double = sutBank.measureTime {
             Thread.sleep(forTimeInterval: 0.01)
         }
         
-        XCTAssertEqual(sleepTime, 0.01)
+        XCTAssertEqual(floor(sleepTime * 100) / 100, 0.01)
     }
     
     func testProcessTasks_whenProcessOneDepositTask_takesPointSevenSeconds() {
-        var sutBank: Bank = Bank()
         let processTime: Double = sutBank.measureTime {
             sutBank.processTasks(of: [Client(1)])
         }
         
-        XCTAssertEqual(processTime, 0.7)
+        XCTAssertEqual(floor(processTime * 100) / 100 , 0.7)
+    }
+    
+    func testPreferredNumberFormat_whenNumberMoreThanTwoDecimalPlacesIsGiven_returnsNumberWithTwoDecimalPlaces() {
+        XCTAssertEqual(sutBank.preferredNumberFormat(123.456789), 123.45)
     }
 }

--- a/BankManagerConsoleApp/BankManagerTest/BankManagerTest.swift
+++ b/BankManagerConsoleApp/BankManagerTest/BankManagerTest.swift
@@ -9,23 +9,42 @@ import XCTest
 @testable import BankManagerConsoleApp
 
 final class BankManagerTests: XCTestCase {
+    private var sutBank: Bank?
+    
     override func setUpWithError() throws {
         try super.setUpWithError()
+        
+        sutBank = Bank(numberOfTeller: 1)
     }
     
     override func tearDownWithError() throws {
         try super.tearDownWithError()
     }
 
-    func test_visitNewCustomer() {
-        var bank = Bank(1)
-        let customers: [Customer] = bank.visitNewCustomer()
-        XCTAssertEqual(customers.count, bank.totalCustomer)
+    func test_bank_visitNewCustomer() {
+        let customers: [Customer]? = sutBank?.visitNewCustomer()
+        XCTAssertEqual(customers?.count, sutBank?.totalCustomer)
     }
 
-    func test_assignTeller() {
-        let bank = Bank(1)
-        bank.assignTeller()
-        XCTAssertEqual(bank.waitingQueue.maxConcurrentOperationCount, bank.numberOfTeller)
+    func test_bank_assignTeller() {
+        sutBank?.assignTeller()
+        XCTAssertEqual(sutBank?.waitingQueue.maxConcurrentOperationCount, sutBank?.numberOfTeller)
+    }
+    
+    func test_bank_close() {
+        sutBank?.processedTime = 123.56789
+        XCTAssertEqual(sutBank?.close(), 123.56)
+    }
+    
+    func test_bank_totalProcessedTime() {
+        let sleepTime: Double? = sutBank?.totalProcessedTime {
+            Thread.sleep(forTimeInterval: 0.01)
+        }
+        guard let sleepTime = sleepTime else {
+            XCTFail("Failed to initialize sleepTime.")
+            return
+        }
+        
+        XCTAssertEqual(floor(sleepTime * 100) / 100, 0.01)
     }
 }

--- a/BankManagerConsoleApp/BankManagerTest/BankManagerTest.swift
+++ b/BankManagerConsoleApp/BankManagerTest/BankManagerTest.swift
@@ -18,7 +18,7 @@ final class BankManagerTests: XCTestCase {
         try super.tearDownWithError()
     }
 
-    func testMakeClients_whenClientNumberLessThanOne_returnEmptyArray() {
+    func testMakeClients_whenClientNumberLessThanOne_returnsEmptyArray() {
         var sutBank: Bank = Bank()
         
         for lessThanOne in -1...0 {
@@ -26,7 +26,7 @@ final class BankManagerTests: XCTestCase {
         }
     }
     
-    func testMakeClients_whenClientNumberIsMoreThanOne_returnClientsWithWaitingNumber() {
+    func testMakeClients_whenClientNumberIsMoreThanOne_returnsClientsWithWaitingNumber() {
         var sutBank: Bank = Bank()
         let sutClients: [Client] = sutBank.makeClients(number: 3)
         
@@ -37,19 +37,19 @@ final class BankManagerTests: XCTestCase {
         }
     }
     
+    func testMeasureTime_whenProcessTimeIsGiven_returnsGivenTime() {
+        let sutBank: Bank = Bank()
+        let sleepTime: Double = sutBank.measureTime {
+            Thread.sleep(forTimeInterval: 0.01)
+        }
+        
+        XCTAssertEqual(sleepTime, 0.01)
+    }
+    
 //    func testClose_whenProcessedTimeHasMoreThanTwoDecimalPlaces_checksResultHasTwoDecimalPlaces() {
 //        var sutBank: Bank = Bank(numberOfTeller: 1)
 //
 //        sutBank.        total:processedTime = 123.56789
 //        XCTAssertEqual(sutBank.close(), 123.56)
-//    }
-    
-//    func testTotalProcessedTime_whenGivenProcessingTime_checksGivenValueAndCalculatedResultAreSame() {
-//        let sutBank: Bank = Bank(numberOfTeller: 1)
-//        let sleepTime: Double = sutBank.processedTime {
-//            Thread.sleep(forTimeInterval: 0.01)
-//        }
-//        
-//        XCTAssertEqual(floor(sleepTime * 100) / 100, 0.01)
 //    }
 }

--- a/BankManagerConsoleApp/BankManagerTest/BankManagerTest.swift
+++ b/BankManagerConsoleApp/BankManagerTest/BankManagerTest.swift
@@ -40,11 +40,12 @@ final class BankManagerTests: XCTestCase {
         let sleepTime: Double? = sutBank?.totalProcessedTime {
             Thread.sleep(forTimeInterval: 0.01)
         }
-        guard let sleepTime = sleepTime else {
+        guard let sleepTime: Double = sleepTime else {
             XCTFail("Failed to initialize sleepTime.")
             return
         }
+        let flooredSleepTime: Double = floor(sleepTime * 100) / 100
         
-        XCTAssertEqual(floor(sleepTime * 100) / 100, 0.01)
+        XCTAssertEqual(flooredSleepTime, 0.01)
     }
 }

--- a/BankManagerConsoleApp/BankManagerTest/Info.plist
+++ b/BankManagerConsoleApp/BankManagerTest/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/README.md
+++ b/README.md
@@ -1,6 +1,23 @@
-## iOS 커리어 스타터 캠프
+# 은행 매니저 프로젝트
 
-### 은행 매니저 프로젝트 저장소
+## 타임라인
 
-- 이 저장소를 자신의 저장소로 fork하여 프로젝트를 진행합니다
+- 4/26(월):
+    - 프로젝트 핵심 개념 학습
+        - ARC
+            - [https://docs.swift.org/swift-book/LanguageGuide/AutomaticReferenceCounting.html](https://docs.swift.org/swift-book/LanguageGuide/AutomaticReferenceCounting.html)
+            - [http://minsone.github.io/mac/ios/swift-automatic-reference-counting-summary](http://minsone.github.io/mac/ios/swift-automatic-reference-counting-summary)
+        - iOS App Life Cycle
+            - [https://developer.apple.com/documentation/uikit/app_and_environment/responding_to_the_launch_of_your_app/about_the_app_launch_sequence](https://developer.apple.com/documentation/uikit/app_and_environment/responding_to_the_launch_of_your_app/about_the_app_launch_sequence)
+            - [https://hcn1519.github.io/articles/2017-09/ios_app_lifeCycle](https://hcn1519.github.io/articles/2017-09/ios_app_lifeCycle)
+            - [https://developer.apple.com/documentation/uikit/uiapplicationdelegate](https://developer.apple.com/documentation/uikit/uiapplicationdelegate)
+        - Process/Thread Scheduling
+            - [https://etst.tistory.com/114](https://etst.tistory.com/114)
+        - Sync/Async
+            - [https://etst.tistory.com/114](https://etst.tistory.com/114)
+        - Stack
+            - 
+- 4/27(화):
+    - 학습한 내용 공유
+    - Class Diagram 작성
 


### PR DESCRIPTION
@AppleCEO 

안녕하세요, 도미닉! 한 주동안 열심히 관련 내용을 학습하고 코드를 작성하여 Step 1 PR을 보냅니다!
이번 주에는 `Process`와 `Thread`, `Operation`과 `OperationQueue`의 개념을 익히고 적용하는데 주안점을 두었습니다. 도미닉의 의견을 듬뿍 담아 따끔한 피드백을 많이 받을 수 있으면 좋겠습니다! 😄

# Class Diagram
![image](https://user-images.githubusercontent.com/69730931/116753024-62ac7e80-aa41-11eb-8b3a-4ccf54b7d501.png)

# 각 타입의 역할
## `BankManager`
- 프로그램 사용자가 프로그램을 시작하고 종료할 수 있는 기능을 제공합니다.
  - `selectMenu() throws -> Int`: 사용자의 입력을 받아 입력한 숫자를 반환합니다. 정수가 아닌 입력을 할 경우 에러를 throw합니다.
  - `move(to:)`: 선택된 메뉴로 이동합니다.
  - `start()`: 프로그램을 시작합니다. 메뉴 선택 시 발생한 에러에 대한 에러 처리를 수행합니다.
- 인스턴스 생성 시 이니셜라이저를 통해 `Bank` 타입에서 근무할 은행원의 수를 설정할 수 있습니다.

## `Bank`
- 은행 개점과 마감, 업무 처리 시 총 소요 시간을 계산하는 기능을 제공합니다.
- 인스턴스 생성 시 입력 받은 `numberOfTeller` 전달 인자를 통해 한 번에 처리할 `Operation` 수를 설정합니다(`OperationQueue.maxConcurrentOperationCount`).
- `makeClients(number:)`: 입력 받은 수만큼 `Client` 인스턴스를 만들어 배열에 넣은 후 결과를 반환합니다.
- `measureTime(_:) -> Double`: 전달 인자로 입력받은 클로저 내부에 입력된 메서드의 처리에 걸리는 시간을 측정하여 소수점 아래 두 자리 수로 반환합니다.
- `processTasks(of:)`: OperationQueue에 [Operation]을 할당합니다.
- `preferredNumberFormat(_:)`: 입력 받은 수의 소수점을 두 번째 자리 이후로 버리고 반환합니다. (123.456789 -> 123.45)

## `Client`
- `Operation` 클래스를 상속받은 타입입니다.
- `waitingNumber` 프로퍼티를 가지고 있습니다.
- `Operation`이 실행되면 재정의된 `main()` 메서드를 통해 업무 처리 상태를 출력합니다.

# 요구 기능과 구현 방식
## 타입구현
- 은행에는 n명의 은행원이 근무합니다
  - `Bank` 타입 `waitingQueue: OperationQueue`의 `maxConcurrentOperationCount` 프로퍼티를 통해 은행원 수를 설정하였습니다.
- 은행에는 n명의 고객이 업무처리를 위해 대기합니다
  - `open()` 메서드에서 `Int.random(in:)` 함수를 통해 임의의 정수를 생성합니다. 최소/최대 인원수는 `Bank` 타입에 위치한 `NumberOfClient` 열거형에 정의된 상수를 사용하여 설정합니다.
- 대기 중인 고객의 업무가 모두 끝나면 은행업무를 마감합니다
  - `Bank`의 `open()` 메서드는 모든 업무가 처리되면 은행을 마감하는 `close()` 메서드를 실행합니다.
- 업무를 마감할 때 "업무가 마감되었습니다. 오늘 업무를 처리한 고객은 총 XX명이며, 총 업무시간은 XX초입니다."라고 출력합니다
  - `Bank` 타입의 `close()` 메서드가 해당 기능을 담당합니다.
  - 총 소요시간은 `close()` 메서드 실행 이전에 `measureTime(_:)` 메서드를 통해 계산됩니다.
  - `measureTime(_:)` 메서드는 `CFAbsoluteTimeGetCurrent()` 메서드를 사용하여 업무 처리에 소요된 실제 시간을 산출합니다.
- 은행원은 각 창구를 하나씩 담당하며, 창구에는 번호가 있습니다
  - 창구에 번호를 부여하는 방법을 해결하지 못하였으며, 아래 `해결이 되지 않은 점`에 내용을 상세히 설명하였습니다.
- 은행원은 고객의 업무를 처리합니다
  - `processTasks(of:)` 메서드에서 `OperationQueue`에 `Operation`을 할당하는 작업을 수행하여 업무를 처리하도록 하였습니다.
- 각 고객의 업무를 처리하는 데 걸리는 시간은 0.7초입니다
  - `Operation`을 상속받은 `Client`에 `TimeForProcessingTask` 열거형에 업무에 소요되는 시간을 작성하였습니다.
- 은행원이 한 번에 처리할 수 있는 고객은 한 명입니다
  - `OperationQueue`의 `maxConcurrentOperationCount` 프로퍼티를 통해 쓰레드 수를 설정함으로써 한 번에 처리할 고객 수를 설정할 수 있었으며, 하나의 쓰레드는 하나의 `Operation`을 처리함을 확인하였습니다.
- 대기중인 고객의 업무처리를 시작할 때 아래와 같이 출력합니다
    - "3번 고객 업무 시작"
    - `Operation`을 상속받은 `Client`의 인스턴스가 재정의된 `main()` 메서드를 통해 출력합니다.
- 고객의 업무를 처리하면 아래와 같이 출력합니다
    - "5번 고객 업무 완료"
    -  `Operation`을 상속받은 `Client`의 인스턴스가 재정의된 `main()` 메서드를 통해 출력합니다.
- 고객이 은행에 방문하면 대기순번을 부여받습니다
  - `makeClients()` 메서드가 입력 받은 수(총 고객수)를 이용하여 반복문으로 `Client` 인스턴스를 생성하며 이니셜라이저를 통해 대기번호를 부여합니다.
- 고객은 업무를 처리할 담당 은행원이 배정될 때 까지 대기합니다
  - 별도로 실행하지 않으면 `Operation`이 `OperationQueue`에 할당되기 전에 실행되지 않음을 확인하였습니다.

## 콘솔앱 구현

- Step 1의 은행에는 한 명의 은행원이 근무합니다.
  - 초기 `BankManager` 인스턴스 생성 시 근무할 은행원 수를 1로 설정하였습니다.
- 앱을 실행하면 두 개의 메뉴를 출력합니다.
  1 : 은행 개점
  2 : 종료
  - `BankManager` 타입의 `selectMenu()` 메서드가 메뉴 출력을 담당합니다.
- 사용자가 1을 입력하면 은행을 개점하고 10명~30명의 고객이 방문합니다. 10에서 30 사이의 임의의 수 만큼의 고객의 업무를 처리하면 은행문이 닫히고 다시 메뉴를 출력합니다.
  - 타입 구현에서 설명한 내용입니다.
- 사용자가 2를 입력하면 프로그램을 종료합니다.
  - `BankManager` 타입의 `start()` 메서드가 이를 담당합니다.

# 실행 화면
![image](https://user-images.githubusercontent.com/69730931/116645455-e4a09700-a9b0-11eb-8476-4ca04c0c8e50.png)
![image](https://user-images.githubusercontent.com/69730931/116645491-f6823a00-a9b0-11eb-9088-6e54a2c9fdf5.png)

# 해결이 되지 않은 점 / 조언을 얻고 싶은 부분
- **은행원은 각 창구를 하나씩 담당하며, 창구에는 번호가 있습니다**라는 요구사항을 만족시키지 못했습니다.
  - `OperationQueue`의 `maxConcurrentOperation` 프로퍼티를 설정함으로써 창구 수를 설정할 수 있게끔 하였습니다.
  - 저희가 아직 잘 모르는 것일 수 있지만, 이 방법을 적용할 경우 순간순간 작동하는 쓰레드의 이름을 설정할 수 없었습니다.
  - 요구사항을 만족시키는 방법으로 `OperationQueue`를 창구 수만큼 생성하고 `OperationQueue.name` 프로퍼티를 이용하여 창구 번호를 붙인 후 `OperationQueue.operationCount` 프로퍼티를 활용하여 비어있는 `OperationQueue`에 `Operation`을 할당하는 방식으로 처리할 수 있을 듯 합니다. 하지만 이 경우 제공되는 `maxConcurrentOperation` 프로퍼티를 활용하지 않고, 각 `OperationQueue`에 작업을 할당하는 로직을 직접 만들어 사용해야하기에 적합하지 않다고 판단하였습니다. 이렇게 요구사항과 구현 방법에서 충돌이 발생하는데, 도미닉은 이 이슈에 대해 어떻게 생각하시나요? 어떤 방식으로 대응하면 좋을지 궁금합니다.

- 은행에 방문한 손님이 처리할 업무 대상인 `Operation`이므로 아래와 같이 `main()` 메서드를 가지게 되었습니다. 손님이 업무 처리와 관련된 메서드를 가지고 있는 것이 논리적으로 어긋나는 부분이 있는 것 같은데, `Client`를 `Operation`으로 두고 진행하는 방향이 적절한지 문의 드리고 싶습니다 (손님의 네이밍을 BankingTask와 같이 변경하면 더 적절해보이기도 합니다.).  

```swift
override func main() {
    print("\(waitingNumber) 번 고객 업무 시작.")
    Thread.sleep(forTimeInterval: TimeForProcessingTask.deposit)
    print("\(waitingNumber) 번 고객 업무 종료!")
}
```

- 대부분의 메서드가 `print` 등으로 적절한 반환값이 없는 형태라 모든 메서드에 대한 유닛 테스트를 수행할 수 없었습니다. 추가로 테스트해보면 좋을 메서드가 있을까요?
- 테스트 한 메서드 중 테스트 방식이 적절하지 않은 것이 있을 경우 알려주시면 감사하겠습니다!
  - 테스트한 메서드
    - `makeClients(number:)`
    - `measureTime(_:)`
    - `processTasks(of:)`
    - `preferredNumberFormat(_:)`

- 테스트를 위해 유닛 테스트 파일에서 사용되는 메서드나 참조가 필요한 프로퍼티에는 `private` 접근수준을 설정하지 못하였습니다. 테스트를 위한 접근 수준을 별도로 설정하거나 `private`이라도 테스트에서는 접근할 수 있게 설정하는 방법이 있을까요?

그럼 오늘도 즐거운 하루 보내세요! 🚀