### PR TITLE
은행창구 매니저[Step1] Nala, Tacocat

### DIFF
--- a/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
+++ b/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		A877AA9C26AFF6A500A77397 /* Node.swift in Sources */ = {isa = PBXBuildFile; fileRef = A877AA9B26AFF6A500A77397 /* Node.swift */; };
 		C7694E7A259C3EC00053667F /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7694E79259C3EC00053667F /* main.swift */; };
 		C7D65D1B259C8190005510E0 /* BankManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7D65D1A259C8190005510E0 /* BankManager.swift */; };
 /* End PBXBuildFile section */
@@ -24,6 +25,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		A877AA9B26AFF6A500A77397 /* Node.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Node.swift; sourceTree = "<group>"; };
 		C7694E76259C3EC00053667F /* BankManagerConsoleApp */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = BankManagerConsoleApp; sourceTree = BUILT_PRODUCTS_DIR; };
 		C7694E79259C3EC00053667F /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
 		C7D65D1A259C8190005510E0 /* BankManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = BankManager.swift; path = ../../BankManager.swift; sourceTree = "<group>"; };
@@ -61,6 +63,7 @@
 			children = (
 				C7D65D1A259C8190005510E0 /* BankManager.swift */,
 				C7694E79259C3EC00053667F /* main.swift */,
+				A877AA9B26AFF6A500A77397 /* Node.swift */,
 			);
 			path = BankManagerConsoleApp;
 			sourceTree = "<group>";
@@ -122,6 +125,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A877AA9C26AFF6A500A77397 /* Node.swift in Sources */,
 				C7694E7A259C3EC00053667F /* main.swift in Sources */,
 				C7D65D1B259C8190005510E0 /* BankManager.swift in Sources */,
 			);

--- a/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
+++ b/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
@@ -351,7 +351,7 @@
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				DEVELOPMENT_TEAM = LHNXD357QL;
+				DEVELOPMENT_TEAM = 7MJ69FU8BU;
 				INFOPLIST_FILE = QueueMethodTest/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -370,7 +370,7 @@
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				DEVELOPMENT_TEAM = LHNXD357QL;
+				DEVELOPMENT_TEAM = 7MJ69FU8BU;
 				INFOPLIST_FILE = QueueMethodTest/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",

--- a/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
+++ b/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		A877AA9C26AFF6A500A77397 /* Node.swift in Sources */ = {isa = PBXBuildFile; fileRef = A877AA9B26AFF6A500A77397 /* Node.swift */; };
+		A877AA9E26AFFF3000A77397 /* LinkedList.swift in Sources */ = {isa = PBXBuildFile; fileRef = A877AA9D26AFFF3000A77397 /* LinkedList.swift */; };
 		C7694E7A259C3EC00053667F /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7694E79259C3EC00053667F /* main.swift */; };
 		C7D65D1B259C8190005510E0 /* BankManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7D65D1A259C8190005510E0 /* BankManager.swift */; };
 /* End PBXBuildFile section */
@@ -26,6 +27,7 @@
 
 /* Begin PBXFileReference section */
 		A877AA9B26AFF6A500A77397 /* Node.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Node.swift; sourceTree = "<group>"; };
+		A877AA9D26AFFF3000A77397 /* LinkedList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkedList.swift; sourceTree = "<group>"; };
 		C7694E76259C3EC00053667F /* BankManagerConsoleApp */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = BankManagerConsoleApp; sourceTree = BUILT_PRODUCTS_DIR; };
 		C7694E79259C3EC00053667F /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
 		C7D65D1A259C8190005510E0 /* BankManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = BankManager.swift; path = ../../BankManager.swift; sourceTree = "<group>"; };
@@ -64,6 +66,7 @@
 				C7D65D1A259C8190005510E0 /* BankManager.swift */,
 				C7694E79259C3EC00053667F /* main.swift */,
 				A877AA9B26AFF6A500A77397 /* Node.swift */,
+				A877AA9D26AFFF3000A77397 /* LinkedList.swift */,
 			);
 			path = BankManagerConsoleApp;
 			sourceTree = "<group>";
@@ -127,6 +130,7 @@
 			files = (
 				A877AA9C26AFF6A500A77397 /* Node.swift in Sources */,
 				C7694E7A259C3EC00053667F /* main.swift in Sources */,
+				A877AA9E26AFFF3000A77397 /* LinkedList.swift in Sources */,
 				C7D65D1B259C8190005510E0 /* BankManager.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
+++ b/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		A877AA9C26AFF6A500A77397 /* Node.swift in Sources */ = {isa = PBXBuildFile; fileRef = A877AA9B26AFF6A500A77397 /* Node.swift */; };
 		A877AA9E26AFFF3000A77397 /* LinkedList.swift in Sources */ = {isa = PBXBuildFile; fileRef = A877AA9D26AFFF3000A77397 /* LinkedList.swift */; };
+		A877AA9F26B1842F00A77397 /* Queue.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF133A5826B00ACB009FED1B /* Queue.swift */; };
 		C7694E7A259C3EC00053667F /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7694E79259C3EC00053667F /* main.swift */; };
 		C7D65D1B259C8190005510E0 /* BankManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7D65D1A259C8190005510E0 /* BankManager.swift */; };
 		DF133A5926B00ACB009FED1B /* Queue.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF133A5826B00ACB009FED1B /* Queue.swift */; };
@@ -17,7 +18,6 @@
 		DF133A7726B12EE1009FED1B /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7694E79259C3EC00053667F /* main.swift */; };
 		DF133A7826B12EE1009FED1B /* Node.swift in Sources */ = {isa = PBXBuildFile; fileRef = A877AA9B26AFF6A500A77397 /* Node.swift */; };
 		DF133A7926B12EE1009FED1B /* LinkedList.swift in Sources */ = {isa = PBXBuildFile; fileRef = A877AA9D26AFFF3000A77397 /* LinkedList.swift */; };
-		DF133A7A26B12EE1009FED1B /* Queue.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF133A5826B00ACB009FED1B /* Queue.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -201,11 +201,11 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A877AA9F26B1842F00A77397 /* Queue.swift in Sources */,
 				DF133A7626B12EE1009FED1B /* BankManager.swift in Sources */,
 				DF133A7726B12EE1009FED1B /* main.swift in Sources */,
 				DF133A7826B12EE1009FED1B /* Node.swift in Sources */,
 				DF133A7926B12EE1009FED1B /* LinkedList.swift in Sources */,
-				DF133A7A26B12EE1009FED1B /* Queue.swift in Sources */,
 				DF133A7126B12B29009FED1B /* QueueMethodTest.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
+++ b/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
@@ -12,6 +12,12 @@
 		C7694E7A259C3EC00053667F /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7694E79259C3EC00053667F /* main.swift */; };
 		C7D65D1B259C8190005510E0 /* BankManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7D65D1A259C8190005510E0 /* BankManager.swift */; };
 		DF133A5926B00ACB009FED1B /* Queue.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF133A5826B00ACB009FED1B /* Queue.swift */; };
+		DF133A7126B12B29009FED1B /* QueueMethodTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF133A7026B12B29009FED1B /* QueueMethodTest.swift */; };
+		DF133A7626B12EE1009FED1B /* BankManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7D65D1A259C8190005510E0 /* BankManager.swift */; };
+		DF133A7726B12EE1009FED1B /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7694E79259C3EC00053667F /* main.swift */; };
+		DF133A7826B12EE1009FED1B /* Node.swift in Sources */ = {isa = PBXBuildFile; fileRef = A877AA9B26AFF6A500A77397 /* Node.swift */; };
+		DF133A7926B12EE1009FED1B /* LinkedList.swift in Sources */ = {isa = PBXBuildFile; fileRef = A877AA9D26AFFF3000A77397 /* LinkedList.swift */; };
+		DF133A7A26B12EE1009FED1B /* Queue.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF133A5826B00ACB009FED1B /* Queue.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -33,10 +39,20 @@
 		C7694E79259C3EC00053667F /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
 		C7D65D1A259C8190005510E0 /* BankManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = BankManager.swift; path = ../../BankManager.swift; sourceTree = "<group>"; };
 		DF133A5826B00ACB009FED1B /* Queue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Queue.swift; sourceTree = "<group>"; };
+		DF133A6E26B12B29009FED1B /* QueueMethodTest.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = QueueMethodTest.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		DF133A7026B12B29009FED1B /* QueueMethodTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QueueMethodTest.swift; sourceTree = "<group>"; };
+		DF133A7226B12B29009FED1B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
 		C7694E73259C3EC00053667F /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		DF133A6B26B12B29009FED1B /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -50,6 +66,7 @@
 			isa = PBXGroup;
 			children = (
 				C7694E78259C3EC00053667F /* BankManagerConsoleApp */,
+				DF133A6F26B12B29009FED1B /* QueueMethodTest */,
 				C7694E77259C3EC00053667F /* Products */,
 			);
 			sourceTree = "<group>";
@@ -58,6 +75,7 @@
 			isa = PBXGroup;
 			children = (
 				C7694E76259C3EC00053667F /* BankManagerConsoleApp */,
+				DF133A6E26B12B29009FED1B /* QueueMethodTest.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -72,6 +90,15 @@
 				DF133A5826B00ACB009FED1B /* Queue.swift */,
 			);
 			path = BankManagerConsoleApp;
+			sourceTree = "<group>";
+		};
+		DF133A6F26B12B29009FED1B /* QueueMethodTest */ = {
+			isa = PBXGroup;
+			children = (
+				DF133A7026B12B29009FED1B /* QueueMethodTest.swift */,
+				DF133A7226B12B29009FED1B /* Info.plist */,
+			);
+			path = QueueMethodTest;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -94,17 +121,37 @@
 			productReference = C7694E76259C3EC00053667F /* BankManagerConsoleApp */;
 			productType = "com.apple.product-type.tool";
 		};
+		DF133A6D26B12B29009FED1B /* QueueMethodTest */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = DF133A7526B12B29009FED1B /* Build configuration list for PBXNativeTarget "QueueMethodTest" */;
+			buildPhases = (
+				DF133A6A26B12B29009FED1B /* Sources */,
+				DF133A6B26B12B29009FED1B /* Frameworks */,
+				DF133A6C26B12B29009FED1B /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = QueueMethodTest;
+			productName = QueueMethodTest;
+			productReference = DF133A6E26B12B29009FED1B /* QueueMethodTest.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
 		C7694E6E259C3EC00053667F /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastSwiftUpdateCheck = 1210;
+				LastSwiftUpdateCheck = 1250;
 				LastUpgradeCheck = 1210;
 				TargetAttributes = {
 					C7694E75259C3EC00053667F = {
 						CreatedOnToolsVersion = 12.1;
+					};
+					DF133A6D26B12B29009FED1B = {
+						CreatedOnToolsVersion = 12.5.1;
 					};
 				};
 			};
@@ -122,9 +169,20 @@
 			projectRoot = "";
 			targets = (
 				C7694E75259C3EC00053667F /* BankManagerConsoleApp */,
+				DF133A6D26B12B29009FED1B /* QueueMethodTest */,
 			);
 		};
 /* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		DF133A6C26B12B29009FED1B /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		C7694E72259C3EC00053667F /* Sources */ = {
@@ -136,6 +194,19 @@
 				C7694E7A259C3EC00053667F /* main.swift in Sources */,
 				A877AA9E26AFFF3000A77397 /* LinkedList.swift in Sources */,
 				C7D65D1B259C8190005510E0 /* BankManager.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		DF133A6A26B12B29009FED1B /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				DF133A7626B12EE1009FED1B /* BankManager.swift in Sources */,
+				DF133A7726B12EE1009FED1B /* main.swift in Sources */,
+				DF133A7826B12EE1009FED1B /* Node.swift in Sources */,
+				DF133A7926B12EE1009FED1B /* LinkedList.swift in Sources */,
+				DF133A7A26B12EE1009FED1B /* Queue.swift in Sources */,
+				DF133A7126B12B29009FED1B /* QueueMethodTest.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -275,6 +346,44 @@
 			};
 			name = Release;
 		};
+		DF133A7326B12B29009FED1B /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				DEVELOPMENT_TEAM = LHNXD357QL;
+				INFOPLIST_FILE = QueueMethodTest/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+					"@loader_path/../Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 11.2;
+				PRODUCT_BUNDLE_IDENTIFIER = com.Nala.QueueMethodTest;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		DF133A7426B12B29009FED1B /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				DEVELOPMENT_TEAM = LHNXD357QL;
+				INFOPLIST_FILE = QueueMethodTest/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+					"@loader_path/../Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 11.2;
+				PRODUCT_BUNDLE_IDENTIFIER = com.Nala.QueueMethodTest;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -292,6 +401,15 @@
 			buildConfigurations = (
 				C7694E7E259C3EC00053667F /* Debug */,
 				C7694E7F259C3EC00053667F /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		DF133A7526B12B29009FED1B /* Build configuration list for PBXNativeTarget "QueueMethodTest" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				DF133A7326B12B29009FED1B /* Debug */,
+				DF133A7426B12B29009FED1B /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
+++ b/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
@@ -351,7 +351,7 @@
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				DEVELOPMENT_TEAM = 7MJ69FU8BU;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = QueueMethodTest/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -370,7 +370,7 @@
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				DEVELOPMENT_TEAM = 7MJ69FU8BU;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = QueueMethodTest/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",

--- a/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
+++ b/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		A877AA9E26AFFF3000A77397 /* LinkedList.swift in Sources */ = {isa = PBXBuildFile; fileRef = A877AA9D26AFFF3000A77397 /* LinkedList.swift */; };
 		C7694E7A259C3EC00053667F /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7694E79259C3EC00053667F /* main.swift */; };
 		C7D65D1B259C8190005510E0 /* BankManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7D65D1A259C8190005510E0 /* BankManager.swift */; };
+		DF133A5926B00ACB009FED1B /* Queue.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF133A5826B00ACB009FED1B /* Queue.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -31,6 +32,7 @@
 		C7694E76259C3EC00053667F /* BankManagerConsoleApp */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = BankManagerConsoleApp; sourceTree = BUILT_PRODUCTS_DIR; };
 		C7694E79259C3EC00053667F /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
 		C7D65D1A259C8190005510E0 /* BankManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = BankManager.swift; path = ../../BankManager.swift; sourceTree = "<group>"; };
+		DF133A5826B00ACB009FED1B /* Queue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Queue.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -67,6 +69,7 @@
 				C7694E79259C3EC00053667F /* main.swift */,
 				A877AA9B26AFF6A500A77397 /* Node.swift */,
 				A877AA9D26AFFF3000A77397 /* LinkedList.swift */,
+				DF133A5826B00ACB009FED1B /* Queue.swift */,
 			);
 			path = BankManagerConsoleApp;
 			sourceTree = "<group>";
@@ -128,6 +131,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				DF133A5926B00ACB009FED1B /* Queue.swift in Sources */,
 				A877AA9C26AFF6A500A77397 /* Node.swift in Sources */,
 				C7694E7A259C3EC00053667F /* main.swift in Sources */,
 				A877AA9E26AFFF3000A77397 /* LinkedList.swift in Sources */,

--- a/BankManagerConsoleApp/BankManagerConsoleApp/LinkedList.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/LinkedList.swift
@@ -25,4 +25,9 @@ class LinkedList<Value> {
         tail?.next = Node(value: value)
         tail = tail?.next
     }
+    
+    func remove(_ value: Value) -> Value? {
+        defer { head = head?.next }
+        return head?.value ?? nil
+    }
 }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/LinkedList.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/LinkedList.swift
@@ -32,7 +32,7 @@ extension LinkedList {
     
     mutating func remove() -> Value? {
         defer { head = head?.next }
-        return head?.value ?? nil
+        return head?.value
     }
     
     mutating func removeAll() {

--- a/BankManagerConsoleApp/BankManagerConsoleApp/LinkedList.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/LinkedList.swift
@@ -17,4 +17,11 @@ class LinkedList<Value> {
     func isEmpty() -> Bool {
         return head == nil
     }
+    
+    func push(_ value: Value) {
+        if isEmpty() && tail == nil {
+            head = Node(value: value)
+            tail = head
+        }
+    }
 }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/LinkedList.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/LinkedList.swift
@@ -7,32 +7,36 @@
 
 import Foundation
 
-class LinkedList<Value> {
+struct LinkedList<Value> {
+    //MARK: Properties
     private var head: Node<Value>?
     private var tail: Node<Value>?
-    
+}
+
+//MARK:- Node Manage Method
+extension LinkedList {
     func isEmpty() -> Bool {
         return head == nil
     }
     
-    func append(_ value: Value) {
-        guard !isEmpty() && tail != nil else {
-            head = Node(value: value)
-            tail = head
-            return
+    mutating func append(_ value: Value) {
+        if isEmpty() {
+            tail?.next = Node(value: value)
+            tail = tail?.next
         }
         
-        tail?.next = Node(value: value)
-        tail = tail?.next
+        head = Node(value: value)
+        tail = head
     }
     
-    func remove(_ value: Value) -> Value? {
+    mutating func remove(_ value: Value) -> Value? {
         defer { head = head?.next }
         return head?.value ?? nil
     }
     
-    func removeAll() {
+    mutating func removeAll() {
         head = nil
+        tail = nil
     }
     
     func glance() -> Value? {

--- a/BankManagerConsoleApp/BankManagerConsoleApp/LinkedList.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/LinkedList.swift
@@ -21,15 +21,16 @@ extension LinkedList {
     
     mutating func append(_ value: Value) {
         if isEmpty() {
-            tail?.next = Node(value: value)
-            tail = tail?.next
+            head = Node(value: value)
+            tail = head
+            return
         }
         
-        head = Node(value: value)
-        tail = head
+        tail?.next = Node(value: value)
+        tail = tail?.next
     }
     
-    mutating func remove(_ value: Value) -> Value? {
+    mutating func remove() -> Value? {
         defer { head = head?.next }
         return head?.value ?? nil
     }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/LinkedList.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/LinkedList.swift
@@ -30,4 +30,8 @@ class LinkedList<Value> {
         defer { head = head?.next }
         return head?.value ?? nil
     }
+    
+    func removeAll() {
+        head = nil
+    }
 }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/LinkedList.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/LinkedList.swift
@@ -1,0 +1,20 @@
+//
+//  LinkedList.swift
+//  BankManagerConsoleApp
+//
+//  Created by Do Yi Lee on 2021/07/27.
+//
+
+import Foundation
+
+class LinkedList<Value> {
+    private var head: Node<Value>?
+    private var tail: Node<Value>?
+    
+    // ieEmpty - 굳이 왜 연산프로퍼티일까?? 그러게요...음.. 흐음 public -흐음
+    // 연산프로퍼트 vs 메소드
+    
+    func isEmpty() -> Bool {
+        return head == nil
+    }
+}

--- a/BankManagerConsoleApp/BankManagerConsoleApp/LinkedList.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/LinkedList.swift
@@ -11,17 +11,18 @@ class LinkedList<Value> {
     private var head: Node<Value>?
     private var tail: Node<Value>?
     
-    // ieEmpty - 굳이 왜 연산프로퍼티일까?? 그러게요...음.. 흐음 public -흐음
-    // 연산프로퍼트 vs 메소드
-    
     func isEmpty() -> Bool {
         return head == nil
     }
     
-    func push(_ value: Value) {
-        if isEmpty() && tail == nil {
+    func append(_ value: Value) {
+        guard !isEmpty() && tail != nil else {
             head = Node(value: value)
             tail = head
+            return
         }
+        
+        tail?.next = Node(value: value)
+        tail = tail?.next
     }
 }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/LinkedList.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/LinkedList.swift
@@ -34,4 +34,8 @@ class LinkedList<Value> {
     func removeAll() {
         head = nil
     }
+    
+    func glance() -> Value? {
+        return head?.value
+    }
 }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Node.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Node.swift
@@ -1,0 +1,17 @@
+//
+//  Node.swift
+//  BankManagerConsoleApp
+//
+//  Created by Do Yi Lee on 2021/07/27.
+//
+
+import Foundation
+
+class Node<Value> {
+    var value: Value
+    var next: Node?
+    
+    init(value: Value, next: Node? = nil) {
+        self.value = value
+    }
+}

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Node.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Node.swift
@@ -18,6 +18,6 @@ class Node<Value> {
 
 extension Node {
     func printNodes() -> String {
-        "\(value) -> \(String(describing: next))"
+        return "\(value) -> \(String(describing: next))"
     }
 }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Node.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Node.swift
@@ -14,4 +14,5 @@ class Node<Value> {
     init(value: Value, next: Node? = nil) {
         self.value = value
     }
+    //d
 }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Node.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Node.swift
@@ -14,5 +14,10 @@ class Node<Value> {
     init(value: Value, next: Node? = nil) {
         self.value = value
     }
-    //d
+}
+
+extension Node {
+    func printNodes() -> String {
+        "\(value) -> \(String(describing: next))"
+    }
 }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Node.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Node.swift
@@ -8,6 +8,7 @@
 import Foundation
 
 class Node<Value> {
+    //MARK: Properties
     var value: Value
     var next: Node?
     
@@ -16,6 +17,7 @@ class Node<Value> {
     }
 }
 
+//MARK:-Node Print Method
 extension Node {
     func printNodes() -> String {
         return "\(value) -> \(String(describing: next))"

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Node.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Node.swift
@@ -20,6 +20,10 @@ class Node<Value> {
         self.value = value
         self.next = next
     }
+    
+    deinit {
+        print("\(self.value)가 해제되었습니다.")
+    }
 }
 
 //MARK:-Node Print Method

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Queue.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Queue.swift
@@ -25,4 +25,8 @@ class Queue<Value> {
     func clear() {
         linkedList.removeAll()
     }
+    
+    func peek() -> Value? {
+        return linkedList.glance()
+    }
 }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Queue.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Queue.swift
@@ -10,6 +10,10 @@ import Foundation
 class Queue<Value> {
     let linkedList = LinkedList<Value>()
     
+    func isEmpty() -> Bool {
+        return linkedList.isEmpty()
+    }
+    
     func enqueue(_ value: Value) {
         linkedList.append(value)
     }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Queue.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Queue.swift
@@ -1,0 +1,16 @@
+//
+//  Queue.swift
+//  BankManagerConsoleApp
+//
+//  Created by 이윤주 on 2021/07/27.
+//
+
+import Foundation
+
+class Queue<Value> {
+    let linkedList = LinkedList<Value>()
+    
+    func enqueue(_ value: Value) {
+        linkedList.append(value)
+    }
+}

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Queue.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Queue.swift
@@ -22,8 +22,8 @@ extension Queue {
         linkedList.append(value)
     }
     
-    mutating func dequeue(_ value: Value) -> Value? {
-        return linkedList.remove(value)
+    mutating func dequeue() -> Value? {
+        return linkedList.remove()
     }
     
     mutating func clear() {

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Queue.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Queue.swift
@@ -7,26 +7,30 @@
 
 import Foundation
 
-class Queue<Value> {
-    let linkedList = LinkedList<Value>()
-    
+struct Queue<Value> {
+    //MARK: Properties
+    var linkedList = LinkedList<Value>()
+}
+
+//MARK:-Queue Manage Method
+extension Queue {
     func isEmpty() -> Bool {
         return linkedList.isEmpty()
     }
     
-    func enqueue(_ value: Value) {
+    mutating func enqueue(_ value: Value) {
         linkedList.append(value)
     }
     
-    func dequeue(_ value: Value) -> Value? {
+    mutating func dequeue(_ value: Value) -> Value? {
         return linkedList.remove(value)
     }
     
-    func clear() {
+    mutating func clear() {
         linkedList.removeAll()
     }
     
-    func peek() -> Value? {
+    mutating func peek() -> Value? {
         return linkedList.glance()
     }
 }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Queue.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Queue.swift
@@ -9,7 +9,7 @@ import Foundation
 
 struct Queue<Value> {
     //MARK: Properties
-    var linkedList = LinkedList<Value>()
+    private var linkedList = LinkedList<Value>()
 }
 
 //MARK:-Queue Manage Method

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Queue.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Queue.swift
@@ -17,4 +17,8 @@ class Queue<Value> {
     func enqueue(_ value: Value) {
         linkedList.append(value)
     }
+    
+    func dequeue(_ value: Value) -> Value? {
+        return linkedList.remove(value)
+    }
 }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Queue.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Queue.swift
@@ -21,4 +21,8 @@ class Queue<Value> {
     func dequeue(_ value: Value) -> Value? {
         return linkedList.remove(value)
     }
+    
+    func clear() {
+        linkedList.removeAll()
+    }
 }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/main.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/main.swift
@@ -5,5 +5,3 @@
 // 
 
 import Foundation
-let queue = Queue<Int>()
-let queue2 = Queue<Int>()

--- a/BankManagerConsoleApp/QueueMethodTest/Info.plist
+++ b/BankManagerConsoleApp/QueueMethodTest/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/BankManagerConsoleApp/QueueMethodTest/QueueMethodTest.swift
+++ b/BankManagerConsoleApp/QueueMethodTest/QueueMethodTest.swift
@@ -9,7 +9,7 @@ import XCTest
 @testable import BankManagerConsoleApp
 
 class QueueMethodTest: XCTestCase {
-    func test_testQueuee에_1을추가했을때_Queue의첫번째값이1이다() {
+    func test_testQueue에_1을추가했을때_Queue의첫번째값이1이다() {
         //given
         var testQueue = Queue<Int>()
         
@@ -48,7 +48,7 @@ class QueueMethodTest: XCTestCase {
         XCTAssertEqual(outputValue, expectedResult)
     }
     
-    func test_Queue에_1과2를넣고_dequeu메소드사용시_Queue의가장첫번째값은2가된다() {
+    func test_Queue에1과2를넣고_dequeu메소드사용시_Queue의가장첫번째값은2가된다() {
         //given
         var testQueue = Queue<Int>()
         testQueue.enqueue(1)

--- a/BankManagerConsoleApp/QueueMethodTest/QueueMethodTest.swift
+++ b/BankManagerConsoleApp/QueueMethodTest/QueueMethodTest.swift
@@ -35,6 +35,19 @@ class QueueMethodTest: XCTestCase {
         XCTAssertEqual(outputValue, expectedResult)
     }
     
+    func test_값이있는Queue를_isEmpty메소드로확인했을때_결과값이false가나올것이다() {
+        // given
+        var testQueue = Queue<Int>()
+        testQueue.enqueue(1)
+        
+        //when
+        let outputValue = testQueue.isEmpty()
+        let expectedResult = false
+        
+        //then
+        XCTAssertEqual(outputValue, expectedResult)
+    }
+    
     func test_Queue에_1과2를넣고_dequeu메소드사용시_Queue의가장첫번째값은2가된다() {
         //given
         var testQueue = Queue<Int>()
@@ -49,4 +62,7 @@ class QueueMethodTest: XCTestCase {
         //then
         XCTAssertEqual(outputValue, expectedResult)
     }
+    
+ 
+    
 }

--- a/BankManagerConsoleApp/QueueMethodTest/QueueMethodTest.swift
+++ b/BankManagerConsoleApp/QueueMethodTest/QueueMethodTest.swift
@@ -1,0 +1,24 @@
+//
+//  QueueMethodTest.swift
+//  QueueMethodTest
+//
+//  Created by 이윤주 on 2021/07/28.
+//
+
+import XCTest
+@testable import BankManagerConsoleApp
+
+class QueueMethodTest: XCTestCase {
+    func test_testQueuee에_1을추가했을때_Queue의첫번째값이1일것이다() {
+        //given
+        var testQueue = Queue<Int>()
+        
+        //when
+        testQueue.enqueue(1)
+        let outputValue = testQueue.peek() ?? .zero
+        let expectResult = 1
+        
+        //then
+        XCTAssertEqual(outputValue, expectResult)
+    }
+}

--- a/BankManagerConsoleApp/QueueMethodTest/QueueMethodTest.swift
+++ b/BankManagerConsoleApp/QueueMethodTest/QueueMethodTest.swift
@@ -15,11 +15,12 @@ class QueueMethodTest: XCTestCase {
         
         //when
         testQueue.enqueue(1)
+        testQueue.enqueue(2)
         let outputValue = testQueue.peek() ?? .zero
-        let expectResult = 1
+        let expectedResult = 1
         
         //then
-        XCTAssertEqual(outputValue, expectResult)
+        XCTAssertEqual(outputValue, expectedResult)
     }
     
     func test_비어있는Queue를_isEmpty메소드로확인했을때_결과값이true가나올것이다() {
@@ -28,9 +29,24 @@ class QueueMethodTest: XCTestCase {
         
         //when
         let outputValue = testQueue.isEmpty()
-        let expectResult = true
+        let expectedResult = true
         
         //then
-        XCTAssertEqual(outputValue, expectResult)
+        XCTAssertEqual(outputValue, expectedResult)
+    }
+    
+    func test_Queue에_1과2를넣고_dequeu메소드사용시_Queue의가장첫번째값은2가된다() {
+        //given
+        var testQueue = Queue<Int>()
+        testQueue.enqueue(1)
+        testQueue.enqueue(2)
+        
+        //when
+        testQueue.dequeue()
+        let outputValue = testQueue.peek() ?? .zero
+        let expectedResult = 2
+        
+        //then
+        XCTAssertEqual(outputValue, expectedResult)
     }
 }

--- a/BankManagerConsoleApp/QueueMethodTest/QueueMethodTest.swift
+++ b/BankManagerConsoleApp/QueueMethodTest/QueueMethodTest.swift
@@ -9,7 +9,7 @@ import XCTest
 @testable import BankManagerConsoleApp
 
 class QueueMethodTest: XCTestCase {
-    func test_testQueuee에_1을추가했을때_Queue의첫번째값이1일것이다() {
+    func test_testQueuee에_1을추가했을때_Queue의첫번째값이1이다() {
         //given
         var testQueue = Queue<Int>()
         
@@ -23,7 +23,7 @@ class QueueMethodTest: XCTestCase {
         XCTAssertEqual(outputValue, expectedResult)
     }
     
-    func test_비어있는Queue를_isEmpty메소드로확인했을때_결과값이true가나올것이다() {
+    func test_비어있는Queue를_isEmpty메소드로확인했을때_결과값이true가나온다() {
         //given
         var testQueue = Queue<Int>()
         
@@ -35,7 +35,7 @@ class QueueMethodTest: XCTestCase {
         XCTAssertEqual(outputValue, expectedResult)
     }
     
-    func test_값이있는Queue를_isEmpty메소드로확인했을때_결과값이false가나올것이다() {
+    func test_값이있는Queue를_isEmpty메소드로확인했을때_결과값이false가나온다() {
         // given
         var testQueue = Queue<Int>()
         testQueue.enqueue(1)
@@ -63,6 +63,18 @@ class QueueMethodTest: XCTestCase {
         XCTAssertEqual(outputValue, expectedResult)
     }
     
- 
-    
+    func test_Queue에1과2를넣고_clear메소드사용시_Queue의모든값이사라진다() {
+        //given
+        var testQueue = Queue<Int>()
+        testQueue.enqueue(1)
+        testQueue.enqueue(2)
+        
+        //when
+        testQueue.clear()
+        let outputValue = testQueue.isEmpty()
+        let expectedValue = true
+        
+        //then
+        XCTAssertEqual(outputValue, expectedValue)
+    }
 }

--- a/BankManagerConsoleApp/QueueMethodTest/QueueMethodTest.swift
+++ b/BankManagerConsoleApp/QueueMethodTest/QueueMethodTest.swift
@@ -77,4 +77,18 @@ class QueueMethodTest: XCTestCase {
         //then
         XCTAssertEqual(outputValue, expectedValue)
     }
+    
+    func test_Queue에1과2를넣고_peek메소드사용시_맨앞의값인1이나온다() {
+        //given
+        var testQueue = Queue<Int>()
+        testQueue.enqueue(1)
+        testQueue.enqueue(2)
+        
+        //when
+        let outputValue = testQueue.peek()
+        let expectedValue = 1
+        
+        //then
+        XCTAssertEqual(outputValue, expectedValue)
+    }
 }

--- a/BankManagerConsoleApp/QueueMethodTest/QueueMethodTest.swift
+++ b/BankManagerConsoleApp/QueueMethodTest/QueueMethodTest.swift
@@ -21,4 +21,16 @@ class QueueMethodTest: XCTestCase {
         //then
         XCTAssertEqual(outputValue, expectResult)
     }
+    
+    func test_비어있는Queue를_isEmpty메소드로확인했을때_결과값이true가나올것이다() {
+        //given
+        var testQueue = Queue<Int>()
+        
+        //when
+        let outputValue = testQueue.isEmpty()
+        let expectResult = true
+        
+        //then
+        XCTAssertEqual(outputValue, expectResult)
+    }
 }


### PR DESCRIPTION
비비 안녕하세요~~~!! 질문을 정리하다보니 어느새 이렇게 많아졌네요...😭 잘 부탁드립니다!!!!
@YebinKim 

# 코드에 대해 고민한 점 
1. Queue를 구현할 연결리스트를 단일연결리스트와 이중연결리스트 중 무엇으로 만들지 고민했습니다.
    1. 프로젝트 요구사항을 구현하는 데는 이중연결리스트의 추가적인 기능이 필요하지 않다고 생각해 단일연결리스트로 구현하기로 하였습니다. 
        - 이중연결리스트의 특성상, 노드를 Head와 Tail 각각에서 양방향으로 접근할 수 있는데 현재 기능 요구사항에서는 굳이 필요하지 않다고 생각했습니다. 이중연결리스트를 구현하는 경우 메모리를 많이 차지해 메모리 효율이 낮아지므로 단일연결리스트를 사용해 구현하는 것이 더욱 좋다고 판단했습니다.

2. 코드의 가독성을 위해 `head`, `tail` 노드로 명명하였습니다. 
    1. 처음엔 head만 있어도 된다고 생각했지만 날라의 의견을 들어보니 head, tail로 나눈 것이 직관적이라는 것에 동의하였습니다. 
        1. head :  첫 Node 인스턴스 
        2. tail : 마지막 Node 인스턴스 

3. `Queue`와 `LinkedList` 클래스를 나눈 이유
    1. 처음엔 `LinkedList` 로 구현했습니다.
    2. 프로젝트 명세서에 Queue와LinkedList 타입을 구현하라고 하였기 때문에 위와 같이 하였는데 프로젝트 명세서에 없었다면 Queue 타입안에 LinkedLIst 타입을 한꺼번에 구현해도 되지않을까하는 생각이 듭니다. 

## 프로젝트를 진행하면서 나온 질문들 
4. `Node`, `LinkedList`, `Queue` 구현 시 클래스 와 구조체 중 어느것으로 해야하는지 궁금해서 아래와 같이 생각했는데 타당한 이유인지 그리고 다른 이유들이 있는지 궁금합니다. 
    1. `Node`의 타입 Class vs Struct
        1. 클래스와 스트럭 중 어느것으로 할 것인가
            1. 클래스로 구현한 이유 : 클래스를 이용하면 하나의 노드(head)를 참조하게 되고 이 head에 연결된 노드들에 대해 참조할 수 있게 된다 
            2. 구조체로 구현하게 되면 생기는 단점 : 노드를 만들때마다(head.next, [head.next.next](http://head.next.next) ...) 스택에 모든 노드가 계속 복사되기 때문에 메모리 최적화 측면에서 효율적이지 않다고 판단
    2. `LinkedList`의 타입
        1. `클래스`로 구현 시 장점
            1. 클래스 안에 스트럭 타입의 속성이 생기면 해당 클래스의 인스턴스가 생길 때마다 내부의 속성에 대한 참조 카운트가 생길때마다 올라가서 클래스로 구현
        2. `스트럭`으로 구현하면 좋은 점과 이유
            1. 스택에 위치하기 때문에 빠른 접근이 가능하다 
            2. 스위프트에서 default 로 설정한 타입은 `Struct`

    b. `Node`를 `Class` 로 구현했다가 `Struct`로 바꾼 이유

    1. 참조 타입이기 때문에 노드를 추가하거나 제거할 때마다 기존 노드의 값을 변경해 주면되지만 구조체의 경우 매번 값을 복사해야하기 때문에 메모리 낭비가 생긴다고 판단했습니다. 
    2. 하지만 현재 Queue인스턴스를 한 개만 만들기 때문에 Struct안의 LinkedList 인스턴스에 대한 참조카운트 문제는 발생하지 않을 것이라고 생각했습니다. 

5. `queue`의 `clear` 메소드를 `haed`에 `nil`을 할당하는 형식으로 진행했는데 모든 `Node`인스턴스가 사라지는 이유를 이렇게 생각해 보았는데 비비의 생각이 궁금합니다

    ```swift
    let queue = Queue
    queue.enqueue(1)
    queue.clear
    ```

    1. 이유 
        1. Queue인스턴스의 위치를 가리키는 상수 `queue` 는 스택에 위치해 있고 이는 인스턴스의 값이 저장된 heap의 주소를 저장하고 있다. 
        2. 이 때 head를 가리키고 있는 head를 nil로 만드는 경우  haed의 next로 참조 되고있던 `Node(1,nil)` 또한 사라진다
        3. 이런 과정이 연쇄적으로 일어나면서 모든 `Node`가 사라진다  

6.  LinkedList 구조체 안의 removeAll 메소드에서 처음엔 head 만 nil 로 해 주었는데 아래와 같이 tail에 대한 참조 카운트가 남아있는 것을 확인했습니다. 코드에서 head 와 tail를 따로 참조하고 있기 때문에 모든 Node 인스턴스를 해제하는  removeAll 메소드를 구현하기 위해선 head 뿐 아니라 tail또한 nil로 해주어야 한다고 생각 했는데 맞는 판단인지 궁금합니다. 

    ```swift
    let linkedList = LinkedList<Int>()
    linkedList.append(1)
    linkedList.append(2)
    linkedList.append(3)

    print(CFGetRetainCount(linkedList.tail)) // 2

    linkedList.removeAll()

    print(CFGetRetainCount(linkedList.tail)) //1
    ```

7. MARK주석을 다는 것과 관련해 궁금한 점이 있습니다.
    1. `Node`클래스에서 프로퍼티에 `Properties`라는 주석을 달아주면서 `init()`에도 주석을 달아줘야하나 고민했는데요. 타입이라면 프로퍼티에 대한 `init()` 메소드는 당연히 항상 가지고 있는 것이기 때문에 굳이 달아주지 않아도 되겠다고 생각해 MARK주석을 써주지 않았습니다. 보통 이니셜라이저에도 주석을 달아주는지 궁금합니다.
    2. 주석의 위치 및 조건은 개발자의 주관이라고 생가하면 되는지 궁금합니다. 

8. 테스트코드를 구현할 때, 매직 넘버를 사용하는 것에 대한 고민을 했습니다. 1을 enqueue해주는 상황에서 저희는 `enqueue(1)`을 해주는 방식으로 코드를 작성했는데요.
이렇게 하지 않고 1을 `expectedInputValue`라는 상수로 따로 선언해주고 given에서 알려주는 방식이 더 좋은 방식인 것인지 궁금합니다.

    ```swift
    //1. 1을 숫자 그대로 사용
    //given
        var testQueue = Queue<Int>()

    //when
        testQueue.enqueue(1)
        let outputValue = testQueue.peek() ?? .zero
        let expectedResult = 2

    //2. 1을 상수로 선언해 사용
    //given
        var testQueue = Queue<Int>()
        let expectInputValue = 1
            
    //when
        testQueue.enqueue(expectInputValue)
        let outputValue = testQueue.peek() ?? .zero
        let expectedResult = expectedInputValue
    ```

9. 유닛테스트에서 테스트하는 메소드를 써도 되는지 궁금합니다
    - `Queue`가 제대로 작동하는지 `Queue`의 메소드를 검사하는 테스트를 구현해봤습니다. 그런데 각 메소드를 검사하는 로직에서, 테스트 대상인 다른 `Queue`의 메소드를 반복적으로 사용하게 되었습니다. 테스트는 각각이 의존적이면 안된다고 알고 있는데, 이런 식으로 테스트를 구성해도 되는 것인지 궁금합니다.
    만약 안 된다면, `Queue`의 메소드가 아닌 `LinkedList`의 메소드를 사용해 로직을 구현하는 방식은 괜찮은걸까요? `LinkedLis`t의 메소드들 역시 테스트가 되지 않은 것들인데 어떤 식으로 하는 게 좋은지, 유닛테스트의 범위가 어디까지여야하는지가 잘 이해가 가지 않습니다ㅠㅠ
    - 예를 들어, 현재 `enqueue` 테스트 함수와 `peek` 테스트 함수가 given과 when의 배치만 다르고 확인 로직이 똑같은 상황입니다. 이를 해결하기 위해 아래 코드와 같이 `LinkedList`클래스에서 `first`라는 프로퍼티를 만들어 밖에서 `head`를 읽을 수 있게 만들고, `head`의 `value`를 활용해 `enqueue` 메소드를 테스트해보는 방식을 생각해봤는데요.
    테스트를 위해 코드를 수정하는 것은 하면 안 되는 것으로 알고있어서 어떤 식으로 수정하는 것이 좋을지 비비의 의견이 궁금합니다!

        ```swift
        // LinkedList 클래스
        class LinkedList<Value> {
            var first: Node<Value>? {
                return head
            }
        }

        // enqueue테스트 함수
        func test_testQueue에_1을추가했을때_Queue의첫번째값이1이다() {
            //given
            var testQueue = Queue<Int>()
                
            //when
            testQueue.enqueue(1)
            testQueue.enqueue(2)
            let outputValue = testQueue.linkedlList.first?.value
            let expectedResult = 1
                
            //then
            XCTAssertEqual(outputValue, expectedResult)
        }
        ```

## 코드 Refactoring의 관점에서 생각해본 것들

1. 코드의 가독성(조건을 부정으로 준 것)과 guard와 if의 차이를 반영해 리팩토링 해 보았는데요, 비비의 생각은 어떠신가요?

    ```swift
    // 1. 이전 방식     
    guard !isEmpty() else
        head = Node(value: value)
        tail = head
        return
    }
            
    tail?.next = Node(value: value)
    tail = tail?.next

    // 2. 수정한 방식
    if isEmpty() {
        head = Node(value: value)
                tail = head
                return
    }

    tail?.next = Node(value: value)
            tail = tail?.next
    ```

2. 메소드 이름에 관하여 
    1. LinkedList타입으로 구현 시 사용하는 메소드 이름을 임의로 정해도 되는것인지 궁금합니다
        1. 상식적으로 선택되는 메소드 이름인 `enqueue`, `dequeue`등인건지 궁금합니다.
        2. 예를들어 스택에서는  자료를 추가 및 제거하는 메소드의 이름으로 push, pop을 사용했는데 Queue에서는 Enqueue, Dequeue의 이름으로 설명하는 경우도 있고 완전히 다른 이름으로 사용하는경우, 스택에서 썼던 push, pop 이라는 이름을 그대로 사용하는 경우 등을 찾았습니다. 
3. `Node` 클래스에서 노드를 콘솔에 프린트해보기 위해 2가지 방식을 생각해보았습니다. 굳이 `CustomStringConvertible`을 쓸 이유가 있을까 해서 메소드로 구현을 해봤는데요. 이 상황에서 메소드로 구현하는 것과 `CustomStringConvertible`을 채택해 쓰는 것에 어떤 차이가 있는지 궁금합니다!
    1. `printNodes()` 메소드

        ```swift
        extension Node {
            func printNodes() -> String {
                return "\(value) -> \(String(describing: next))"
            }
        }
        ```

    2. `CustomStringConvertible`

        ```swift
        extension Node: CustomStringConvertible {
          var description: String {
            return "\(value) -> " + String(describing: next)
          }
        }
        ```

4. `isEmpty` 연산프로퍼티와 메소드 구현 차이
    1. LinkedList의 isEmpty 메소드를 연산프로퍼티로 구현할 지 메소드로 구현할 지 고민하였습니다. 연산프로퍼티는 계산의 결과를 저장할 때 사용하고 메소드의 경우 한 번 사용하고 저장하진 않아도 되는 경우라고 생각했습니다. 그래서 현재와 같이 메소드로 구현했는데 비비의 생각은 어떠신지 궁금합니다. 

5. LinkedList, Queue, Node의 메소드를 `Extension`으로 구분하는 것에 대하여 
    1. 클래스에는 상수만 선언하고 메소드의 경우 extension으로구현하면 어떤 이점이 있는가에 대해서 생각해보았습니다.
        1.  Static Dispatch로 메소드가 구현되어 빠른 실행이 가능하다 

6. `defer`의 사용
    1. `remove` 메소드에서 head의 반환하면서 제거하기 위해 defer를 사용
    2. 다른 방법이 있을지 궁금합니다