### PR TITLE
은행 창구 매니저 [STEP 1] yeha, 호댕

### DIFF
--- a/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
+++ b/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
@@ -10,6 +10,8 @@
 		8459F65827707148001C2851 /* LinkedList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8459F65727707148001C2851 /* LinkedList.swift */; };
 		C7694E7A259C3EC00053667F /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7694E79259C3EC00053667F /* main.swift */; };
 		C7D65D1B259C8190005510E0 /* BankManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7D65D1A259C8190005510E0 /* BankManager.swift */; };
+		DE234FCF27716CC2000F253F /* LinkedListTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE234FCE27716CC2000F253F /* LinkedListTest.swift */; };
+		DE234FD327716CE8000F253F /* LinkedList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8459F65727707148001C2851 /* LinkedList.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -29,10 +31,19 @@
 		C7694E76259C3EC00053667F /* BankManagerConsoleApp */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = BankManagerConsoleApp; sourceTree = BUILT_PRODUCTS_DIR; };
 		C7694E79259C3EC00053667F /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
 		C7D65D1A259C8190005510E0 /* BankManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = BankManager.swift; path = ../../BankManager.swift; sourceTree = "<group>"; };
+		DE234FCC27716CC2000F253F /* LinkedListTest.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = LinkedListTest.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		DE234FCE27716CC2000F253F /* LinkedListTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkedListTest.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
 		C7694E73259C3EC00053667F /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		DE234FC927716CC2000F253F /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -46,6 +57,7 @@
 			isa = PBXGroup;
 			children = (
 				C7694E78259C3EC00053667F /* BankManagerConsoleApp */,
+				DE234FCD27716CC2000F253F /* LinkedListTest */,
 				C7694E77259C3EC00053667F /* Products */,
 			);
 			sourceTree = "<group>";
@@ -54,6 +66,7 @@
 			isa = PBXGroup;
 			children = (
 				C7694E76259C3EC00053667F /* BankManagerConsoleApp */,
+				DE234FCC27716CC2000F253F /* LinkedListTest.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -66,6 +79,14 @@
 				8459F65727707148001C2851 /* LinkedList.swift */,
 			);
 			path = BankManagerConsoleApp;
+			sourceTree = "<group>";
+		};
+		DE234FCD27716CC2000F253F /* LinkedListTest */ = {
+			isa = PBXGroup;
+			children = (
+				DE234FCE27716CC2000F253F /* LinkedListTest.swift */,
+			);
+			path = LinkedListTest;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -88,17 +109,37 @@
 			productReference = C7694E76259C3EC00053667F /* BankManagerConsoleApp */;
 			productType = "com.apple.product-type.tool";
 		};
+		DE234FCB27716CC2000F253F /* LinkedListTest */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = DE234FD227716CC2000F253F /* Build configuration list for PBXNativeTarget "LinkedListTest" */;
+			buildPhases = (
+				DE234FC827716CC2000F253F /* Sources */,
+				DE234FC927716CC2000F253F /* Frameworks */,
+				DE234FCA27716CC2000F253F /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = LinkedListTest;
+			productName = LinkedListTest;
+			productReference = DE234FCC27716CC2000F253F /* LinkedListTest.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
 		C7694E6E259C3EC00053667F /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastSwiftUpdateCheck = 1210;
+				LastSwiftUpdateCheck = 1300;
 				LastUpgradeCheck = 1240;
 				TargetAttributes = {
 					C7694E75259C3EC00053667F = {
 						CreatedOnToolsVersion = 12.1;
+					};
+					DE234FCB27716CC2000F253F = {
+						CreatedOnToolsVersion = 13.0;
 					};
 				};
 			};
@@ -116,9 +157,20 @@
 			projectRoot = "";
 			targets = (
 				C7694E75259C3EC00053667F /* BankManagerConsoleApp */,
+				DE234FCB27716CC2000F253F /* LinkedListTest */,
 			);
 		};
 /* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		DE234FCA27716CC2000F253F /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		C7694E72259C3EC00053667F /* Sources */ = {
@@ -128,6 +180,15 @@
 				8459F65827707148001C2851 /* LinkedList.swift in Sources */,
 				C7694E7A259C3EC00053667F /* main.swift in Sources */,
 				C7D65D1B259C8190005510E0 /* BankManager.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		DE234FC827716CC2000F253F /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				DE234FD327716CE8000F253F /* LinkedList.swift in Sources */,
+				DE234FCF27716CC2000F253F /* LinkedListTest.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -269,6 +330,50 @@
 			};
 			name = Release;
 		};
+		DE234FD027716CC2000F253F /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+					"@loader_path/../Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 11.3;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = net.yagom.LinkedListTest;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		DE234FD127716CC2000F253F /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+					"@loader_path/../Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 11.3;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = net.yagom.LinkedListTest;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -286,6 +391,15 @@
 			buildConfigurations = (
 				C7694E7E259C3EC00053667F /* Debug */,
 				C7694E7F259C3EC00053667F /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		DE234FD227716CC2000F253F /* Build configuration list for PBXNativeTarget "LinkedListTest" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				DE234FD027716CC2000F253F /* Debug */,
+				DE234FD127716CC2000F253F /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
+++ b/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
@@ -74,8 +74,8 @@
 		C7694E78259C3EC00053667F /* BankManagerConsoleApp */ = {
 			isa = PBXGroup;
 			children = (
-				C7D65D1A259C8190005510E0 /* BankManager.swift */,
 				C7694E79259C3EC00053667F /* main.swift */,
+				C7D65D1A259C8190005510E0 /* BankManager.swift */,
 				8459F65727707148001C2851 /* LinkedList.swift */,
 			);
 			path = BankManagerConsoleApp;

--- a/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
+++ b/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
@@ -343,7 +343,7 @@
 					"@executable_path/../Frameworks",
 					"@loader_path/../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 11.3;
+				MACOSX_DEPLOYMENT_TARGET = 10.15;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = net.yagom.LinkedListTest;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -365,7 +365,7 @@
 					"@executable_path/../Frameworks",
 					"@loader_path/../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 11.3;
+				MACOSX_DEPLOYMENT_TARGET = 10.15;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = net.yagom.LinkedListTest;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
+++ b/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		C7D65D1B259C8190005510E0 /* BankManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7D65D1A259C8190005510E0 /* BankManager.swift */; };
 		DE234FCF27716CC2000F253F /* LinkedListTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE234FCE27716CC2000F253F /* LinkedListTest.swift */; };
 		DE234FD327716CE8000F253F /* LinkedList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8459F65727707148001C2851 /* LinkedList.swift */; };
+		DE234FD52771BC01000F253F /* Queue.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE234FD42771BC01000F253F /* Queue.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -33,6 +34,7 @@
 		C7D65D1A259C8190005510E0 /* BankManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = BankManager.swift; path = ../../BankManager.swift; sourceTree = "<group>"; };
 		DE234FCC27716CC2000F253F /* LinkedListTest.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = LinkedListTest.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		DE234FCE27716CC2000F253F /* LinkedListTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkedListTest.swift; sourceTree = "<group>"; };
+		DE234FD42771BC01000F253F /* Queue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Queue.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -77,6 +79,7 @@
 				C7694E79259C3EC00053667F /* main.swift */,
 				C7D65D1A259C8190005510E0 /* BankManager.swift */,
 				8459F65727707148001C2851 /* LinkedList.swift */,
+				DE234FD42771BC01000F253F /* Queue.swift */,
 			);
 			path = BankManagerConsoleApp;
 			sourceTree = "<group>";
@@ -180,6 +183,7 @@
 				8459F65827707148001C2851 /* LinkedList.swift in Sources */,
 				C7694E7A259C3EC00053667F /* main.swift in Sources */,
 				C7D65D1B259C8190005510E0 /* BankManager.swift in Sources */,
+				DE234FD52771BC01000F253F /* Queue.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
+++ b/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		8459F65827707148001C2851 /* LinkedList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8459F65727707148001C2851 /* LinkedList.swift */; };
 		C7694E7A259C3EC00053667F /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7694E79259C3EC00053667F /* main.swift */; };
 		C7D65D1B259C8190005510E0 /* BankManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7D65D1A259C8190005510E0 /* BankManager.swift */; };
 /* End PBXBuildFile section */
@@ -24,6 +25,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		8459F65727707148001C2851 /* LinkedList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkedList.swift; sourceTree = "<group>"; };
 		C7694E76259C3EC00053667F /* BankManagerConsoleApp */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = BankManagerConsoleApp; sourceTree = BUILT_PRODUCTS_DIR; };
 		C7694E79259C3EC00053667F /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
 		C7D65D1A259C8190005510E0 /* BankManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = BankManager.swift; path = ../../BankManager.swift; sourceTree = "<group>"; };
@@ -61,6 +63,7 @@
 			children = (
 				C7D65D1A259C8190005510E0 /* BankManager.swift */,
 				C7694E79259C3EC00053667F /* main.swift */,
+				8459F65727707148001C2851 /* LinkedList.swift */,
 			);
 			path = BankManagerConsoleApp;
 			sourceTree = "<group>";
@@ -92,7 +95,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 1210;
-				LastUpgradeCheck = 1210;
+				LastUpgradeCheck = 1240;
 				TargetAttributes = {
 					C7694E75259C3EC00053667F = {
 						CreatedOnToolsVersion = 12.1;
@@ -122,6 +125,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				8459F65827707148001C2851 /* LinkedList.swift in Sources */,
 				C7694E7A259C3EC00053667F /* main.swift in Sources */,
 				C7D65D1B259C8190005510E0 /* BankManager.swift in Sources */,
 			);
@@ -248,6 +252,7 @@
 		C7694E7E259C3EC00053667F /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CODE_SIGN_IDENTITY = "-";
 				CODE_SIGN_STYLE = Automatic;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
@@ -257,6 +262,7 @@
 		C7694E7F259C3EC00053667F /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CODE_SIGN_IDENTITY = "-";
 				CODE_SIGN_STYLE = Automatic;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;

--- a/BankManagerConsoleApp/BankManagerConsoleApp/LinkedList.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/LinkedList.swift
@@ -29,12 +29,12 @@ struct LinkedList<Type> {
         return head?.data
     }
     
-    mutating func clear() {
+    mutating func removeAll() {
         head = nil
         tail = nil
     }
     
-    mutating func enqueue(_ data: Type) {
+    mutating func append(_ data: Type) {
         let newNode = Node(data: data)
         
         if let lastNode = tail {
@@ -45,7 +45,7 @@ struct LinkedList<Type> {
         tail = newNode
     }
     
-    mutating func dequeue() {
+    mutating func removeFirst() {
         head = head?.next
     }
 }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/LinkedList.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/LinkedList.swift
@@ -14,6 +14,10 @@ struct LinkedList<Type> {
     var isEmpty: Bool {
         head == nil
     }
+    
+    func peek() -> Type? {
+        return head?.data
+    }
 }
 
 class Node<Type> {

--- a/BankManagerConsoleApp/BankManagerConsoleApp/LinkedList.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/LinkedList.swift
@@ -7,18 +7,19 @@
 
 import Foundation
 
-class Node<Type> {
-    var data: Type
-    var next: Node<Type>?
-    
-    init(data: Type) {
-        self.data = data
-    }
-}
-
 struct LinkedList<Type> {
-    var head: Node<Type>?
-    var tail: Node<Type>?
+
+    private class Node<Type> {
+        var data: Type
+        var next: Node<Type>?
+        
+        init(data: Type) {
+            self.data = data
+        }
+    }
+    
+    private var head: Node<Type>?
+    private var tail: Node<Type>?
     
     var isEmpty: Bool {
         head == nil

--- a/BankManagerConsoleApp/BankManagerConsoleApp/LinkedList.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/LinkedList.swift
@@ -1,0 +1,21 @@
+//
+//  LinkedList.swift
+//  BankManagerConsoleApp
+//
+//  Created by yeha on 2021/12/20.
+//
+
+import Foundation
+
+struct LinkedList {
+}
+
+class Node<Type> {
+    var data: Type
+    var next: Node<Type>?
+    
+    init(data: Type, next: Node<Type>? = nil) {
+        self.data = data
+        self.next = next
+    }
+}

--- a/BankManagerConsoleApp/BankManagerConsoleApp/LinkedList.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/LinkedList.swift
@@ -7,7 +7,13 @@
 
 import Foundation
 
-struct LinkedList {
+struct LinkedList<Type> {
+    var head: Node<Type>?
+    var tail: Node<Type>?
+    
+    var isEmpty: Bool {
+        head == nil
+    }
 }
 
 class Node<Type> {

--- a/BankManagerConsoleApp/BankManagerConsoleApp/LinkedList.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/LinkedList.swift
@@ -7,6 +7,15 @@
 
 import Foundation
 
+class Node<Type> {
+    var data: Type
+    var next: Node<Type>?
+    
+    init(data: Type) {
+        self.data = data
+    }
+}
+
 struct LinkedList<Type> {
     var head: Node<Type>?
     var tail: Node<Type>?
@@ -32,21 +41,10 @@ struct LinkedList<Type> {
         } else {
             head = newNode
         }
-        
         tail = newNode
     }
     
     mutating func dequeue() {
         head = head?.next
-    }
-}
-
-class Node<Type> {
-    var data: Type
-    var next: Node<Type>?
-    
-    init(data: Type, next: Node<Type>? = nil) {
-        self.data = data
-        self.next = next
     }
 }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/LinkedList.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/LinkedList.swift
@@ -20,10 +20,8 @@ struct LinkedList<Type> {
     }
     
     mutating func clear() {
-        while head != nil {
-            head = nil
-            head = head?.next
-        }
+        head = nil
+        tail = nil
     }
     
     mutating func enqueue(_ data: Type) {

--- a/BankManagerConsoleApp/BankManagerConsoleApp/LinkedList.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/LinkedList.swift
@@ -37,11 +37,13 @@ struct LinkedList<Type> {
     mutating func append(_ data: Type) {
         let newNode = Node(data: data)
         
-        if let lastNode = tail {
-            lastNode.next = newNode
-        } else {
+        guard let lastNode = tail else {
             head = newNode
+            tail = newNode
+            return
         }
+        
+        lastNode.next = newNode
         tail = newNode
     }
     

--- a/BankManagerConsoleApp/BankManagerConsoleApp/LinkedList.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/LinkedList.swift
@@ -25,6 +25,18 @@ struct LinkedList<Type> {
             head = head?.next
         }
     }
+    
+    mutating func enqueue(_ data: Type) {
+        let newNode = Node(data: data)
+        
+        if let lastNode = tail {
+            lastNode.next = newNode
+        } else {
+            head = newNode
+        }
+        
+        tail = newNode
+    }
 }
 
 class Node<Type> {

--- a/BankManagerConsoleApp/BankManagerConsoleApp/LinkedList.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/LinkedList.swift
@@ -22,7 +22,7 @@ struct LinkedList<Type> {
     private var tail: Node<Type>?
     
     var isEmpty: Bool {
-        head == nil
+        return head == nil
     }
     
     func peek() -> Type? {

--- a/BankManagerConsoleApp/BankManagerConsoleApp/LinkedList.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/LinkedList.swift
@@ -18,6 +18,13 @@ struct LinkedList<Type> {
     func peek() -> Type? {
         return head?.data
     }
+    
+    mutating func clear() {
+        while head != nil {
+            head = nil
+            head = head?.next
+        }
+    }
 }
 
 class Node<Type> {

--- a/BankManagerConsoleApp/BankManagerConsoleApp/LinkedList.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/LinkedList.swift
@@ -37,6 +37,10 @@ struct LinkedList<Type> {
         
         tail = newNode
     }
+    
+    mutating func dequeue() {
+        head = head?.next
+    }
 }
 
 class Node<Type> {

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Queue.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Queue.swift
@@ -19,14 +19,14 @@ struct Queue<Type> {
     }
     
     func clear() {
-        queue.clear()
+        queue.removeAll()
     }
     
     func enqueue(_ data: Type) {
-        queue.enqueue(data)
+        queue.append(data)
     }
     
     func dequeue() {
-        queue.dequeue()
+        queue.removeFirst()
     }
 }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Queue.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Queue.swift
@@ -1,0 +1,32 @@
+//
+//  Queue.swift
+//  BankManagerConsoleApp
+//
+//  Created by 양호준 on 2021/12/21.
+//
+
+import Foundation
+
+struct Queue<Type> {
+    var queue: LinkedList<Type>
+    
+    var isEmpty: Bool {
+        queue.isEmpty
+    }
+    
+    func peek() -> Type {
+        queue.peek()
+    }
+    
+    func clear() {
+        queue.clear()
+    }
+    
+    func enqueue(_ data: Type) {
+        queue.enqueue(data)
+    }
+    
+    func dequeue() {
+        queue.dequeue()
+    }
+}

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Queue.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Queue.swift
@@ -14,19 +14,19 @@ struct Queue<Type> {
         queue.isEmpty
     }
     
-    func peek() -> Type {
+    func peek() -> Type? {
         queue.peek()
     }
     
-    func clear() {
+    mutating func clear() {
         queue.removeAll()
     }
     
-    func enqueue(_ data: Type) {
+    mutating func enqueue(_ data: Type) {
         queue.append(data)
     }
     
-    func dequeue() {
+    mutating func dequeue() {
         queue.removeFirst()
     }
 }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Queue.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Queue.swift
@@ -11,11 +11,11 @@ struct Queue<Type> {
     var queue: LinkedList<Type>
     
     var isEmpty: Bool {
-        queue.isEmpty
+        return queue.isEmpty
     }
     
     func peek() -> Type? {
-        queue.peek()
+        return queue.peek()
     }
     
     mutating func clear() {

--- a/BankManagerConsoleApp/LinkedListTest/LinkedListTest.swift
+++ b/BankManagerConsoleApp/LinkedListTest/LinkedListTest.swift
@@ -43,8 +43,7 @@ class LinkedListTest: XCTestCase {
         linkedList.enqueue(3)
         linkedList.clear()
         
-        XCTAssertNil(linkedList.head)
-        XCTAssertNil(linkedList.tail)
+        XCTAssertTrue(linkedList.isEmpty)
     }
     
     func test_enqueue_shouldAddNode() throws {
@@ -52,9 +51,8 @@ class LinkedListTest: XCTestCase {
         linkedList.enqueue(1)
         linkedList.enqueue(2)
         linkedList.enqueue(3)
-        
-        XCTAssertEqual(linkedList.head?.data, 1)
-        XCTAssertEqual(linkedList.tail?.data, 3)
+
+        XCTAssertEqual(linkedList.peek(), 1)
     }
     
     func test_dequeue_shouldRemoveFirstNode() throws {
@@ -64,14 +62,13 @@ class LinkedListTest: XCTestCase {
         linkedList.enqueue(3)
         linkedList.dequeue()
         
-        XCTAssertEqual(linkedList.head?.data, 2)
+        XCTAssertEqual(linkedList.peek(), 2)
     }
     
     func test_dequeue_withEmptyLinkedList_shouldReturnNil() throws {
         var linkedList = try XCTUnwrap(sut)
         linkedList.dequeue()
         
-        XCTAssertNil(linkedList.head)
-        XCTAssertNil(linkedList.tail)
+        XCTAssertTrue(linkedList.isEmpty)
     }
 }

--- a/BankManagerConsoleApp/LinkedListTest/LinkedListTest.swift
+++ b/BankManagerConsoleApp/LinkedListTest/LinkedListTest.swift
@@ -56,4 +56,22 @@ class LinkedListTest: XCTestCase {
         XCTAssertEqual(result.head?.data, 1)
         XCTAssertEqual(result.tail?.data, 3)
     }
+    
+    func test_dequeue_shouldRemoveFirstNode() throws {
+        var result = try XCTUnwrap(sut)
+        result.enqueue(1)
+        result.enqueue(2)
+        result.enqueue(3)
+        result.dequeue()
+        
+        XCTAssertEqual(result.head?.data, 2)
+    }
+    
+    func test_dequeue_withEmptyLinkedList_shouldReturnNil() throws {
+        var result = try XCTUnwrap(sut)
+        result.dequeue()
+        
+        XCTAssertNil(result.head)
+        XCTAssertNil(result.tail)
+    }
 }

--- a/BankManagerConsoleApp/LinkedListTest/LinkedListTest.swift
+++ b/BankManagerConsoleApp/LinkedListTest/LinkedListTest.swift
@@ -24,50 +24,50 @@ class LinkedListTest: XCTestCase {
 
     func test_isEmpty_shouldReturnExactBooleanType() throws {
         var linkedList = try XCTUnwrap(sut)
-        linkedList.enqueue(1)
+        linkedList.append(1)
 
         XCTAssertFalse(linkedList.isEmpty)
     }
 
     func test_peek_shouldReturnHeadData() throws {
         var linkedList = try XCTUnwrap(sut)
-        linkedList.enqueue(1)
+        linkedList.append(1)
 
         XCTAssertEqual(linkedList.peek(), 1)
     }
 
     func test_clear_shouldRemoveAll() throws {
         var linkedList = try XCTUnwrap(sut)
-        linkedList.enqueue(1)
-        linkedList.enqueue(2)
-        linkedList.enqueue(3)
-        linkedList.clear()
+        linkedList.append(1)
+        linkedList.append(2)
+        linkedList.append(3)
+        linkedList.removeAll()
         
         XCTAssertTrue(linkedList.isEmpty)
     }
     
     func test_enqueue_shouldAddNode() throws {
         var linkedList = try XCTUnwrap(sut)
-        linkedList.enqueue(1)
-        linkedList.enqueue(2)
-        linkedList.enqueue(3)
+        linkedList.append(1)
+        linkedList.append(2)
+        linkedList.append(3)
 
         XCTAssertEqual(linkedList.peek(), 1)
     }
     
     func test_dequeue_shouldRemoveFirstNode() throws {
         var linkedList = try XCTUnwrap(sut)
-        linkedList.enqueue(1)
-        linkedList.enqueue(2)
-        linkedList.enqueue(3)
-        linkedList.dequeue()
+        linkedList.append(1)
+        linkedList.append(2)
+        linkedList.append(3)
+        linkedList.removeFirst()
         
         XCTAssertEqual(linkedList.peek(), 2)
     }
     
     func test_dequeue_withEmptyLinkedList_shouldReturnNil() throws {
         var linkedList = try XCTUnwrap(sut)
-        linkedList.dequeue()
+        linkedList.removeFirst()
         
         XCTAssertTrue(linkedList.isEmpty)
     }

--- a/BankManagerConsoleApp/LinkedListTest/LinkedListTest.swift
+++ b/BankManagerConsoleApp/LinkedListTest/LinkedListTest.swift
@@ -24,15 +24,26 @@ class LinkedListTest: XCTestCase {
 
     func test_isEmpty_shouldReturnExactBooleanType() throws {
         sut?.head = Node(data: 1)
-        let sut = try XCTUnwrap(sut)
-        
-        XCTAssertFalse(sut.isEmpty)
+        let result = try XCTUnwrap(sut)
+
+        XCTAssertFalse(result.isEmpty)
     }
-    
+
     func test_peek_shouldReturnHeadData() throws {
         sut?.head = Node(data: 1)
-        let sut = try XCTUnwrap(sut)
+        let result = try XCTUnwrap(sut)
+
+        XCTAssertEqual(result.peek(), 1)
+    }
+
+    func test_clear_shouldRemoveAll() throws {
+        sut?.head = Node(data: 1)
+        sut?.head?.next = Node(data: 2)
+        sut?.head?.next?.next = Node(data: 3)
+        var result = try XCTUnwrap(sut)
         
-        XCTAssertEqual(sut.peek(), 1)
+        result.clear()
+        
+        XCTAssertNil(result.head)
     }
 }

--- a/BankManagerConsoleApp/LinkedListTest/LinkedListTest.swift
+++ b/BankManagerConsoleApp/LinkedListTest/LinkedListTest.swift
@@ -23,55 +23,54 @@ class LinkedListTest: XCTestCase {
     }
 
     func test_isEmpty_shouldReturnExactBooleanType() throws {
-        sut?.head = Node(data: 1)
-        let result = try XCTUnwrap(sut)
+        var linkedList = try XCTUnwrap(sut)
+        linkedList.enqueue(1)
 
-        XCTAssertFalse(result.isEmpty)
+        XCTAssertFalse(linkedList.isEmpty)
     }
 
     func test_peek_shouldReturnHeadData() throws {
-        sut?.head = Node(data: 1)
-        let result = try XCTUnwrap(sut)
+        var linkedList = try XCTUnwrap(sut)
+        linkedList.enqueue(1)
 
-        XCTAssertEqual(result.peek(), 1)
+        XCTAssertEqual(linkedList.peek(), 1)
     }
 
     func test_clear_shouldRemoveAll() throws {
-        sut?.head = Node(data: 1)
-        sut?.head?.next = Node(data: 2)
-        sut?.head?.next?.next = Node(data: 3)
-        var result = try XCTUnwrap(sut)
+        var linkedList = try XCTUnwrap(sut)
+        linkedList.enqueue(1)
+        linkedList.enqueue(2)
+        linkedList.enqueue(3)
+        linkedList.clear()
         
-        result.clear()
-        
-        XCTAssertNil(result.head)
+        XCTAssertNil(linkedList.head)
     }
     
     func test_enqueue_shouldAddNode() throws {
-        sut?.enqueue(1)
-        sut?.enqueue(2)
-        sut?.enqueue(3)
-        let result = try XCTUnwrap(sut)
+        var linkedList = try XCTUnwrap(sut)
+        linkedList.enqueue(1)
+        linkedList.enqueue(2)
+        linkedList.enqueue(3)
         
-        XCTAssertEqual(result.head?.data, 1)
-        XCTAssertEqual(result.tail?.data, 3)
+        XCTAssertEqual(linkedList.head?.data, 1)
+        XCTAssertEqual(linkedList.tail?.data, 3)
     }
     
     func test_dequeue_shouldRemoveFirstNode() throws {
-        var result = try XCTUnwrap(sut)
-        result.enqueue(1)
-        result.enqueue(2)
-        result.enqueue(3)
-        result.dequeue()
+        var linkedList = try XCTUnwrap(sut)
+        linkedList.enqueue(1)
+        linkedList.enqueue(2)
+        linkedList.enqueue(3)
+        linkedList.dequeue()
         
-        XCTAssertEqual(result.head?.data, 2)
+        XCTAssertEqual(linkedList.head?.data, 2)
     }
     
     func test_dequeue_withEmptyLinkedList_shouldReturnNil() throws {
-        var result = try XCTUnwrap(sut)
-        result.dequeue()
+        var linkedList = try XCTUnwrap(sut)
+        linkedList.dequeue()
         
-        XCTAssertNil(result.head)
-        XCTAssertNil(result.tail)
+        XCTAssertNil(linkedList.head)
+        XCTAssertNil(linkedList.tail)
     }
 }

--- a/BankManagerConsoleApp/LinkedListTest/LinkedListTest.swift
+++ b/BankManagerConsoleApp/LinkedListTest/LinkedListTest.swift
@@ -28,4 +28,11 @@ class LinkedListTest: XCTestCase {
         
         XCTAssertFalse(sut.isEmpty)
     }
+    
+    func test_peek_shouldReturnHeadData() throws {
+        sut?.head = Node(data: 1)
+        let sut = try XCTUnwrap(sut)
+        
+        XCTAssertEqual(sut.peek(), 1)
+    }
 }

--- a/BankManagerConsoleApp/LinkedListTest/LinkedListTest.swift
+++ b/BankManagerConsoleApp/LinkedListTest/LinkedListTest.swift
@@ -46,4 +46,14 @@ class LinkedListTest: XCTestCase {
         
         XCTAssertNil(result.head)
     }
+    
+    func test_enqueue_shouldAddNode() throws {
+        sut?.enqueue(1)
+        sut?.enqueue(2)
+        sut?.enqueue(3)
+        let result = try XCTUnwrap(sut)
+        
+        XCTAssertEqual(result.head?.data, 1)
+        XCTAssertEqual(result.tail?.data, 3)
+    }
 }

--- a/BankManagerConsoleApp/LinkedListTest/LinkedListTest.swift
+++ b/BankManagerConsoleApp/LinkedListTest/LinkedListTest.swift
@@ -1,0 +1,31 @@
+//
+//  LinkedListTest.swift
+//  LinkedListTest
+//
+//  Created by 양호준 on 2021/12/21.
+//
+
+import XCTest
+
+class LinkedListTest: XCTestCase {
+    var sut: LinkedList<Int>?
+    
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        
+        sut = LinkedList<Int>()
+    }
+
+    override func tearDownWithError() throws {
+        try super.tearDownWithError()
+        
+        sut = nil
+    }
+
+    func test_isEmpty_shouldReturnExactBooleanType() throws {
+        sut?.head = Node(data: 1)
+        let sut = try XCTUnwrap(sut)
+        
+        XCTAssertFalse(sut.isEmpty)
+    }
+}

--- a/BankManagerConsoleApp/LinkedListTest/LinkedListTest.swift
+++ b/BankManagerConsoleApp/LinkedListTest/LinkedListTest.swift
@@ -44,6 +44,7 @@ class LinkedListTest: XCTestCase {
         linkedList.clear()
         
         XCTAssertNil(linkedList.head)
+        XCTAssertNil(linkedList.tail)
     }
     
     func test_enqueue_shouldAddNode() throws {

--- a/BankManagerConsoleApp/LinkedListTest/LinkedListTest.swift
+++ b/BankManagerConsoleApp/LinkedListTest/LinkedListTest.swift
@@ -22,21 +22,28 @@ class LinkedListTest: XCTestCase {
         sut = nil
     }
 
-    func test_isEmpty_shouldReturnExactBooleanType() throws {
+    func test_isEmpty_withEmptyLinkedList_shouldReturnTrue() throws {
         var linkedList = try XCTUnwrap(sut)
         linkedList.append(1)
+        linkedList.removeFirst()
 
-        XCTAssertFalse(linkedList.isEmpty)
+        XCTAssertTrue(linkedList.isEmpty)
     }
 
-    func test_peek_shouldReturnHeadData() throws {
+    func test_peek_withEmptyLinkedList_shouldReturnNil() throws {
+        let linkedList = try XCTUnwrap(sut)
+
+        XCTAssertNil(linkedList.peek())
+    }
+    
+    func test_peek_withLinkedListHavingNumberOne_shouldReturnNumberOne() throws {
         var linkedList = try XCTUnwrap(sut)
         linkedList.append(1)
-
+        
         XCTAssertEqual(linkedList.peek(), 1)
     }
 
-    func test_clear_shouldRemoveAll() throws {
+    func test_removeAll_shouldRemoveAll() throws {
         var linkedList = try XCTUnwrap(sut)
         linkedList.append(1)
         linkedList.append(2)
@@ -46,7 +53,7 @@ class LinkedListTest: XCTestCase {
         XCTAssertTrue(linkedList.isEmpty)
     }
     
-    func test_enqueue_shouldAddNode() throws {
+    func test_append_shouldAddNode() throws {
         var linkedList = try XCTUnwrap(sut)
         linkedList.append(1)
         linkedList.append(2)
@@ -55,7 +62,7 @@ class LinkedListTest: XCTestCase {
         XCTAssertEqual(linkedList.peek(), 1)
     }
     
-    func test_dequeue_shouldRemoveFirstNode() throws {
+    func test_removeFirst_shouldRemoveFirstNode() throws {
         var linkedList = try XCTUnwrap(sut)
         linkedList.append(1)
         linkedList.append(2)
@@ -65,7 +72,7 @@ class LinkedListTest: XCTestCase {
         XCTAssertEqual(linkedList.peek(), 2)
     }
     
-    func test_dequeue_withEmptyLinkedList_shouldReturnNil() throws {
+    func test_removeFirst_withEmptyLinkedList_shouldReturnNil() throws {
         var linkedList = try XCTUnwrap(sut)
         linkedList.removeFirst()
         


### PR DESCRIPTION
안녕하세요 도미닉! @AppleCEO 
은행 창구 매니저 Step 1 마무리되서 PR 보내드립니다! 

이번 프로젝트 잘 부탁드립니다 🙏 
감사합니다 🙇 

## 고민했던 점

### Singly Linked List 구현

- Linked List 맨 마지막에 원소를 조금 더 효율적으로 추가하기 위해 `tail` 변수를 생성했습니다.
- Linked List를 Queue의 타입으로 이용할 수 있게 스텝 요구사항이었던 `Enqueue, Dequeue, Clear, Peek, isEmpty` 를 Linked List 내부에 구현했습니다. 
후에 동료들과 이야기하다가 Queue 타입을 따로 구현하는게 맞다고 판단해서 Queue 타입을 추가로 구현했습니다. 
Linked List도 그에 맞추어 네이밍을 수정했습니다.
- Linked List의 `removeAll()` /  `removeFirst()`메서드의 로직을 고민했습니다.
    
   ```swift    
   mutating func clear() {
       while head != nil {
       	   head = nil
    	   head = head?.next
       }
   }
   ```
    
    처음에는 위 코드처럼 head가 nil이 아닐 때, head에 nil을 할당해주고 head를 `head?.next`로 이동시켜서 모든 원소를 돌며 일일히 삭제해주는 방법을 사용했습니다.
    하지만 LLDB를 통해 확인해보니 head에 nil을 할당한다면 이어지는 모든 Node도 nil이 할당되어 전부 비워지는 것을 확인했습니다. tail에는 저희가 직접 특정한 Node를 할당해주어 `head = nil` 만으로는 nil이 할당되지 않는 것을 확인할 수 있었습니다. 
    
   <img width="484" alt="스크린샷 2021-12-21 오후 5 04 47" src="https://user-images.githubusercontent.com/90880660/146898189-ee09f9bb-db52-43c2-970f-372186a0ad34.png">

   head에 추가한 Node가 전부 들어가 있는 것을 확인할 수 있었습니다.
   따라서 반복문을 사용하지 않고 head와 tail에 각각 nil을 할당해서 모든 LinkedList를 삭제하는 방법을 선택했습니다. 
    

### Unit Test

- 옵셔널 타입인 sut을 바인딩해주기 위해 `XCTUnwrap`을 사용했습니다.
    
    `setUpWithError()` 에서 sut을 할당해주고 `tearDownWithError()` 에서 다시 nil로 할당하려면 sut을 옵셔널 타입으로 선언해야 했습니다. 하지만 매번 이를 바인딩해줘야 하는 불편함이 있었는데, 이 때 사용할 수 있는 `XCTUnwrap`을 찾아 사용했습니다. 
    
    만약 강제 추출을 통해 바인딩을 해주게 되면 Fatal Error가 발생하며 앱이 아예 종료되는 문제가 있지만, `XCTUnwrap`을 사용하면 테스트가 실패했다고 알려줘서 테스트 코드에 사용하기 더 적합하다고 생각했습니다. 또한 `guard let`, `if let`을 통해 바인딩하는 것보다 간단하여 적합하다고 판단했습니다. 
    

---

## 해결이 되지 않은 점

- 이미 생성되어 있었지만, 이번 스텝에서 사용하지 않는 파일을 남겨두어도 괜찮을지 궁금합니다.
    - BankManager는 다음 스텝에서 이용할 것같아 남겨두었고, main은 삭제하면 Command Line Tool의 경우 main.swift에서 시작이 되기 때문에  에러가 나서 남겨두었습니다.

---

## 조언을 얻고 싶은 부분

- 테스트 코드도 기존의 배포 코드와 컨벤션을 동일하게 주는 것이 좋을지 궁금합니다.
- 저희는 변/상수에 할당해줄 때와 함수를 호출할 때 개행을 해주었습니다. 
도미닉은 어떤 방식을 선호하시는지 궁금합니다.