### PR TITLE
은행 창구 매니저 [STEP2] 요한, aCafela coffee, 호박

### DIFF
--- a/BankManager.swift
+++ b/BankManager.swift
@@ -5,3 +5,7 @@
 //
 
 import Foundation
+
+struct BankManager {
+    
+}

--- a/BankManager.swift
+++ b/BankManager.swift
@@ -3,9 +3,3 @@
 //  Created by yagom.
 //  Copyright © yagom academy. All rights reserved.
 //
-
-import Foundation
-
-struct BankManager {
-    
-}

--- a/BankManager.swift
+++ b/BankManager.swift
@@ -5,16 +5,23 @@
 //
 
 struct BankManager {
+    private enum MenuOption: String {
+        case startBusiness = "1"
+        case exit = "2"
+    }
+    
     static func runConsoleApp() {
         while true {
-            Self.printMenu()
-            switch readLine() {
-            case "1":
+            printMenu()
+            let userInput = readLine() ?? ""
+            let menuOption = MenuOption(rawValue: userInput)
+            switch menuOption {
+            case .startBusiness:
                 let randomNumber = Int.random(in: 10...30)
                 Bank(numberOfClients: randomNumber, numberOfBankTellers: 1).startBusiness()
-            case "2":
+            case .exit:
                 return
-            default:
+            case nil:
                 continue
             }
         }

--- a/BankManager.swift
+++ b/BankManager.swift
@@ -5,17 +5,12 @@
 //
 
 struct BankManager {
-    func runConsoleApp() {
-        let menu = """
-                   1 : 은행 개점
-                   2 : 종료
-                   입력 :
-                   """
+    static func runConsoleApp() {
         while true {
-            print(menu, terminator: " ")
-            let randomNumber = Int.random(in: 10...30)
+            Self.printMenu()
             switch readLine() {
             case "1":
+                let randomNumber = Int.random(in: 10...30)
                 Bank(numberOfClients: randomNumber, numberOfBankTellers: 1).startBusiness()
             case "2":
                 return
@@ -23,5 +18,14 @@ struct BankManager {
                 continue
             }
         }
+    }
+    
+    private static func printMenu() {
+        let menu = """
+                   1 : 은행 개점
+                   2 : 종료
+                   입력 :
+                   """
+        print(menu, terminator: " ")
     }
 }

--- a/BankManager.swift
+++ b/BankManager.swift
@@ -3,3 +3,25 @@
 //  Created by yagom.
 //  Copyright © yagom academy. All rights reserved.
 //
+
+struct BankManager {
+    func runConsoleApp() {
+        let menu = """
+                   1 : 은행 개점
+                   2 : 종료
+                   입력 :
+                   """
+        while true {
+            print(menu, terminator: " ")
+            let randomNumber = Int.random(in: 10...30)
+            switch readLine() {
+            case "1":
+                Bank(numberOfClients: randomNumber, numberOfBankTellers: 1).startBusiness()
+            case "2":
+                return
+            default:
+                continue
+            }
+        }
+    }
+}

--- a/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
+++ b/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
@@ -30,7 +30,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		25CB74EB2772F55F00A9BB49 /* Client.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = Client.swift; path = ../../../../../Downloads/Client.swift; sourceTree = "<group>"; };
+		25CB74EB2772F55F00A9BB49 /* Client.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Client.swift; sourceTree = "<group>"; };
 		25CB74ED2772F56E00A9BB49 /* BankTeller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BankTeller.swift; sourceTree = "<group>"; };
 		6058124E2770598C00DEFBEF /* Queue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Queue.swift; sourceTree = "<group>"; };
 		608A94D32770790C00C7E1A2 /* Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = Tests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };

--- a/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
+++ b/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		25CB74EC2772F55F00A9BB49 /* Client.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25CB74EB2772F55F00A9BB49 /* Client.swift */; };
+		25CB74EE2772F56E00A9BB49 /* BankTeller.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25CB74ED2772F56E00A9BB49 /* BankTeller.swift */; };
 		6058124F2770598C00DEFBEF /* Queue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6058124E2770598C00DEFBEF /* Queue.swift */; };
 		608A94D62770790C00C7E1A2 /* Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 608A94D52770790C00C7E1A2 /* Tests.swift */; };
 		60BA45B12771C084009ED1B9 /* QueueTestDouble.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60BA45AF2771C078009ED1B9 /* QueueTestDouble.swift */; };
@@ -28,6 +30,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		25CB74EB2772F55F00A9BB49 /* Client.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = Client.swift; path = ../../../../../Downloads/Client.swift; sourceTree = "<group>"; };
+		25CB74ED2772F56E00A9BB49 /* BankTeller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BankTeller.swift; sourceTree = "<group>"; };
 		6058124E2770598C00DEFBEF /* Queue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Queue.swift; sourceTree = "<group>"; };
 		608A94D32770790C00C7E1A2 /* Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = Tests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		608A94D52770790C00C7E1A2 /* Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tests.swift; sourceTree = "<group>"; };
@@ -88,6 +92,8 @@
 				C7D65D1A259C8190005510E0 /* BankManager.swift */,
 				6058124E2770598C00DEFBEF /* Queue.swift */,
 				C7694E79259C3EC00053667F /* main.swift */,
+				25CB74EB2772F55F00A9BB49 /* Client.swift */,
+				25CB74ED2772F56E00A9BB49 /* BankTeller.swift */,
 			);
 			path = BankManagerConsoleApp;
 			sourceTree = "<group>";
@@ -192,6 +198,8 @@
 			files = (
 				C7694E7A259C3EC00053667F /* main.swift in Sources */,
 				6058124F2770598C00DEFBEF /* Queue.swift in Sources */,
+				25CB74EC2772F55F00A9BB49 /* Client.swift in Sources */,
+				25CB74EE2772F56E00A9BB49 /* BankTeller.swift in Sources */,
 				C7D65D1B259C8190005510E0 /* BankManager.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
+++ b/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		25CB74EC2772F55F00A9BB49 /* Client.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25CB74EB2772F55F00A9BB49 /* Client.swift */; };
 		25CB74EE2772F56E00A9BB49 /* BankTeller.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25CB74ED2772F56E00A9BB49 /* BankTeller.swift */; };
+		3AF03F3C2772F92B00A7B702 /* Bank.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AF03F3B2772F92B00A7B702 /* Bank.swift */; };
 		6058124F2770598C00DEFBEF /* Queue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6058124E2770598C00DEFBEF /* Queue.swift */; };
 		608A94D62770790C00C7E1A2 /* Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 608A94D52770790C00C7E1A2 /* Tests.swift */; };
 		60BA45B12771C084009ED1B9 /* QueueTestDouble.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60BA45AF2771C078009ED1B9 /* QueueTestDouble.swift */; };
@@ -32,6 +33,7 @@
 /* Begin PBXFileReference section */
 		25CB74EB2772F55F00A9BB49 /* Client.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Client.swift; sourceTree = "<group>"; };
 		25CB74ED2772F56E00A9BB49 /* BankTeller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BankTeller.swift; sourceTree = "<group>"; };
+		3AF03F3B2772F92B00A7B702 /* Bank.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Bank.swift; sourceTree = "<group>"; };
 		6058124E2770598C00DEFBEF /* Queue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Queue.swift; sourceTree = "<group>"; };
 		608A94D32770790C00C7E1A2 /* Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = Tests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		608A94D52770790C00C7E1A2 /* Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tests.swift; sourceTree = "<group>"; };
@@ -94,6 +96,7 @@
 				C7694E79259C3EC00053667F /* main.swift */,
 				25CB74EB2772F55F00A9BB49 /* Client.swift */,
 				25CB74ED2772F56E00A9BB49 /* BankTeller.swift */,
+				3AF03F3B2772F92B00A7B702 /* Bank.swift */,
 			);
 			path = BankManagerConsoleApp;
 			sourceTree = "<group>";
@@ -199,6 +202,7 @@
 				C7694E7A259C3EC00053667F /* main.swift in Sources */,
 				6058124F2770598C00DEFBEF /* Queue.swift in Sources */,
 				25CB74EC2772F55F00A9BB49 /* Client.swift in Sources */,
+				3AF03F3C2772F92B00A7B702 /* Bank.swift in Sources */,
 				25CB74EE2772F56E00A9BB49 /* BankTeller.swift in Sources */,
 				C7D65D1B259C8190005510E0 /* BankManager.swift in Sources */,
 			);

--- a/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
+++ b/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
@@ -8,7 +8,6 @@
 
 /* Begin PBXBuildFile section */
 		25CB74EC2772F55F00A9BB49 /* Client.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25CB74EB2772F55F00A9BB49 /* Client.swift */; };
-		25CB74EE2772F56E00A9BB49 /* BankTeller.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25CB74ED2772F56E00A9BB49 /* BankTeller.swift */; };
 		3AF03F3C2772F92B00A7B702 /* Bank.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AF03F3B2772F92B00A7B702 /* Bank.swift */; };
 		6058124F2770598C00DEFBEF /* Queue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6058124E2770598C00DEFBEF /* Queue.swift */; };
 		608A94D62770790C00C7E1A2 /* Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 608A94D52770790C00C7E1A2 /* Tests.swift */; };
@@ -32,7 +31,6 @@
 
 /* Begin PBXFileReference section */
 		25CB74EB2772F55F00A9BB49 /* Client.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Client.swift; sourceTree = "<group>"; };
-		25CB74ED2772F56E00A9BB49 /* BankTeller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BankTeller.swift; sourceTree = "<group>"; };
 		3AF03F3B2772F92B00A7B702 /* Bank.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Bank.swift; sourceTree = "<group>"; };
 		6058124E2770598C00DEFBEF /* Queue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Queue.swift; sourceTree = "<group>"; };
 		608A94D32770790C00C7E1A2 /* Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = Tests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -95,7 +93,6 @@
 				6058124E2770598C00DEFBEF /* Queue.swift */,
 				C7694E79259C3EC00053667F /* main.swift */,
 				25CB74EB2772F55F00A9BB49 /* Client.swift */,
-				25CB74ED2772F56E00A9BB49 /* BankTeller.swift */,
 				3AF03F3B2772F92B00A7B702 /* Bank.swift */,
 			);
 			path = BankManagerConsoleApp;
@@ -203,7 +200,6 @@
 				6058124F2770598C00DEFBEF /* Queue.swift in Sources */,
 				25CB74EC2772F55F00A9BB49 /* Client.swift in Sources */,
 				3AF03F3C2772F92B00A7B702 /* Bank.swift in Sources */,
-				25CB74EE2772F56E00A9BB49 /* BankTeller.swift in Sources */,
 				C7D65D1B259C8190005510E0 /* BankManager.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
@@ -36,6 +36,6 @@ class Bank {
         }
         group.wait()
         let elapsedTime = String(format: "%.2f", Date().timeIntervalSince(startTime))
-        print("업무가 마감되었습니다. 오늘 업무를 처리한 고객은 총 \(self.numberOfClients) 명이며, 총 업무시간은 \(elapsedTime)초입니다.")
+        print("업무가 마감되었습니다. 오늘 업무를 처리한 고객은 총 \(self.numberOfClients)명이며, 총 업무시간은 \(elapsedTime)초입니다.")
     }
 }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
@@ -1,0 +1,11 @@
+struct Bank {
+    private var clients = Queue<Client>()
+    private let bankTellers: [BankTeller]
+    
+    mutating func admit(numberOfClients: Int) {
+        (1...numberOfClients).forEach {
+            let client = Client(waitingNumber: $0)
+            clients.enqueue(client)
+        }
+    }
+}

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
@@ -1,11 +1,39 @@
-struct Bank {
+import Foundation
+
+class Bank {
     private var clients = Queue<Client>()
-    private let bankTellers: [BankTeller]
+    private let numberOfClients: Int
+    private let semaphore: DispatchSemaphore
     
-    mutating func admit(numberOfClients: Int) {
+    init(numberOfClients: Int, numberOfBankTellers: Int) {
+        self.numberOfClients = numberOfClients
+        self.semaphore = DispatchSemaphore(value: numberOfBankTellers)
+        admit(numberOfClients: numberOfClients)
+    }
+    
+    private func admit(numberOfClients: Int) {
         (1...numberOfClients).forEach {
             let client = Client(waitingNumber: $0)
             clients.enqueue(client)
         }
+    }
+
+    private func workFor(_ client: Client) {
+        print("\(client.waitingNumber)번 고객 업무 시작")
+        Thread.sleep(forTimeInterval: 0.7)
+        print("\(client.waitingNumber)번 고객 업무 완료")
+    }
+    
+    func startBusiness() {
+        let group = DispatchGroup()
+        while let client = clients.dequeue() {
+            DispatchQueue.global().async(group: group) {
+                self.semaphore.wait()
+                self.workFor(client)
+                self.semaphore.signal()
+            }
+        }
+        group.wait()
+        print("업무가 마감되었습니다. 오늘 업무를 처리한 고객은 총 \(self.numberOfClients) 명입니다")
     }
 }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 class Bank {
-    private var clients = Queue<Client>()
+    private let clients = Queue<Client>()
     private let numberOfClients: Int
     private let semaphore: DispatchSemaphore
     

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
@@ -8,34 +8,36 @@ class Bank {
     init(numberOfClients: Int, numberOfBankTellers: Int) {
         self.numberOfClients = numberOfClients
         self.semaphore = DispatchSemaphore(value: numberOfBankTellers)
-        admit(numberOfClients: numberOfClients)
+        addClientsToQueue(by: numberOfClients)
     }
     
-    private func admit(numberOfClients: Int) {
+    func startBusiness() {
+        let startTime = Date()
+        
+        let group = DispatchGroup()
+        while let client = clients.dequeue() {
+            DispatchQueue.global().async(group: group) {
+                self.semaphore.wait()
+                self.respond(to: client)
+                self.semaphore.signal()
+            }
+        }
+        group.wait()
+        
+        let elapsedTime = String(format: "%.2f", Date().timeIntervalSince(startTime))
+        print("업무가 마감되었습니다. 오늘 업무를 처리한 고객은 총 \(self.numberOfClients)명이며, 총 업무시간은 \(elapsedTime)초입니다.")
+    }
+    
+    private func addClientsToQueue(by numberOfClients: Int) {
         (1...numberOfClients).forEach {
             let client = Client(waitingNumber: $0)
             clients.enqueue(client)
         }
     }
 
-    private func workFor(_ client: Client) {
+    private func respond(to client: Client) {
         print("\(client.waitingNumber)번 고객 업무 시작")
         Thread.sleep(forTimeInterval: 0.7)
         print("\(client.waitingNumber)번 고객 업무 완료")
-    }
-    
-    func startBusiness() {
-        let startTime = Date()
-        let group = DispatchGroup()
-        while let client = clients.dequeue() {
-            DispatchQueue.global().async(group: group) {
-                self.semaphore.wait()
-                self.workFor(client)
-                self.semaphore.signal()
-            }
-        }
-        group.wait()
-        let elapsedTime = String(format: "%.2f", Date().timeIntervalSince(startTime))
-        print("업무가 마감되었습니다. 오늘 업무를 처리한 고객은 총 \(self.numberOfClients)명이며, 총 업무시간은 \(elapsedTime)초입니다.")
     }
 }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
@@ -25,6 +25,7 @@ class Bank {
     }
     
     func startBusiness() {
+        let startTime = Date()
         let group = DispatchGroup()
         while let client = clients.dequeue() {
             DispatchQueue.global().async(group: group) {
@@ -34,6 +35,7 @@ class Bank {
             }
         }
         group.wait()
-        print("업무가 마감되었습니다. 오늘 업무를 처리한 고객은 총 \(self.numberOfClients) 명입니다")
+        let elapsedTime = String(format: "%.2f", Date().timeIntervalSince(startTime))
+        print("업무가 마감되었습니다. 오늘 업무를 처리한 고객은 총 \(self.numberOfClients) 명이며, 총 업무시간은 \(elapsedTime)초입니다.")
     }
 }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
@@ -16,8 +16,8 @@ class Bank {
         
         let group = DispatchGroup()
         while let client = clients.dequeue() {
+            semaphore.wait()
             DispatchQueue.global().async(group: group) {
-                self.semaphore.wait()
                 self.respond(to: client)
                 self.semaphore.signal()
             }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/BankTeller.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/BankTeller.swift
@@ -1,9 +1,0 @@
-import Foundation
-
-struct BankTeller {
-    func workFor(_ client: Client) {
-        print("\(client.waitingNumber)번 고객 업무 시작")
-        Thread.sleep(forTimeInterval: 0.7)
-        print("\(client.waitingNumber)번 고객 업무 완료")
-    }
-}

--- a/BankManagerConsoleApp/BankManagerConsoleApp/BankTeller.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/BankTeller.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+struct BankTeller {
+    func workFor(_ client: Client) {
+        print("\(client.waitingNumber)번 고객 업무 시작")
+        Thread.sleep(forTimeInterval: 0.7)
+        print("\(client.waitingNumber)번 고객 업무 완료")
+    }
+}

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Client.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Client.swift
@@ -1,0 +1,3 @@
+struct Client {
+    let waitingNumber: Int
+}

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Queue.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Queue.swift
@@ -1,4 +1,4 @@
-struct Queue<T> {
+class Queue<T> {
     private var head: Node<T>?
     private weak var tail: Node<T>?
     
@@ -6,7 +6,7 @@ struct Queue<T> {
         return head == nil
     }
     
-    mutating func enqueue(_ value: T) {
+    func enqueue(_ value: T) {
         let node = Node(value)
         if isEmpty {
             head = node
@@ -16,13 +16,13 @@ struct Queue<T> {
         tail = node
     }
 
-    mutating func dequeue() -> T? {
+    func dequeue() -> T? {
         let value = head?.value
         head = head?.next
         return value
     }
     
-    mutating func clear() {
+    func clear() {
         head = nil
     }
     

--- a/BankManagerConsoleApp/BankManagerConsoleApp/main.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/main.swift
@@ -4,4 +4,4 @@
 //  Copyright © yagom academy. All rights reserved.
 // 
 
-Bank(numberOfClients: 10, numberOfBankTellers: 2).startBusiness()
+Bank(numberOfClients: 10, numberOfBankTellers: 1).startBusiness()

--- a/BankManagerConsoleApp/BankManagerConsoleApp/main.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/main.swift
@@ -4,4 +4,4 @@
 //  Copyright © yagom academy. All rights reserved.
 // 
 
-import Foundation
+Bank(numberOfClients: 10, numberOfBankTellers: 2).startBusiness()

--- a/BankManagerConsoleApp/BankManagerConsoleApp/main.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/main.swift
@@ -4,4 +4,4 @@
 //  Copyright © yagom academy. All rights reserved.
 // 
 
-Bank(numberOfClients: 10, numberOfBankTellers: 1).startBusiness()
+BankManager().runConsoleApp()

--- a/BankManagerConsoleApp/BankManagerConsoleApp/main.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/main.swift
@@ -4,4 +4,4 @@
 //  Copyright © yagom academy. All rights reserved.
 // 
 
-BankManager().runConsoleApp()
+BankManager.runConsoleApp()

--- a/BankManagerConsoleApp/Tests/QueueTestDouble.swift
+++ b/BankManagerConsoleApp/Tests/QueueTestDouble.swift
@@ -1,4 +1,4 @@
-struct QueueTestDouble<T> {
+class QueueTestDouble<T> {
     var head: Node<T>?
     weak var tail: Node<T>?
     
@@ -6,7 +6,7 @@ struct QueueTestDouble<T> {
         return head == nil
     }
     
-    mutating func enqueue(_ value: T) {
+    func enqueue(_ value: T) {
         let node = Node(value)
         if isEmpty {
             head = node
@@ -16,13 +16,13 @@ struct QueueTestDouble<T> {
         tail = node
     }
 
-    mutating func dequeue() -> T? {
+    func dequeue() -> T? {
         let value = head?.value
         head = head?.next
         return value
     }
     
-    mutating func clear() {
+    func clear() {
         head = nil
     }
     

--- a/BankManagerConsoleApp/Tests/Tests.swift
+++ b/BankManagerConsoleApp/Tests/Tests.swift
@@ -6,7 +6,7 @@ class Tests: XCTestCase {
 
     func test_큐에_1과2를_enqueue하면_큐에는_1과2가_있다() {
         //given
-        var queue = Queue<Int>()
+        let queue = Queue<Int>()
         var result: [Int?] = []
         
         //when
@@ -21,7 +21,7 @@ class Tests: XCTestCase {
     
     func test_큐에_1을_enqueue후_dequeue하면_큐가_비어있는지() {
         //given
-        var queue = Queue<Int>()
+        let queue = Queue<Int>()
         
         //when
         queue.enqueue(1)
@@ -33,7 +33,7 @@ class Tests: XCTestCase {
     
     func test_큐에_1과2_enqueue후_clear하면_큐가_비어있는지() {
         //given
-        var queue = Queue<Int>()
+        let queue = Queue<Int>()
         
         //when
         queue.enqueue(1)
@@ -46,7 +46,7 @@ class Tests: XCTestCase {
     
     func test_큐에_값이_있을때_isEmpty가_false인지() {
         //given
-        var queue = Queue<Int>()
+        let queue = Queue<Int>()
         
         //when
         queue.enqueue(1)
@@ -57,7 +57,7 @@ class Tests: XCTestCase {
     
     func test_1과2를_enqueue후_peek을_하면_1이_반환된다() {
         //given
-        var queue = Queue<Int>()
+        let queue = Queue<Int>()
         
         //when
         queue.enqueue(1)
@@ -72,7 +72,7 @@ extension Tests {
     
     func test_큐에_1과2를_enqueue하고_dequeue를_두번하면_tail은_nil이다() {
         //given
-        var queue = QueueTestDouble<Int>()
+        let queue = QueueTestDouble<Int>()
         
         //when
         queue.enqueue(1)


### PR DESCRIPTION
@aCafela-coffee @hoBahk
 
안녕하세요 쿠마! @leejun6694 
두 번째 PR도 잘 부탁드립니다 🙏🏻

## 고민한 점

### 1. Queue를 class로 만든 이유

```swift
var queue = Queue<Int>()
queue.enqueue(1)
queue.enqueue(2)

var queue2 = queue
queue2.enqueue(3)
// dequeue 예상
queue.dequeue() // 1
queue.dequeue() // 2
queue.dequeue() // 3

// dequeue 예상
queue2.dequeue() // 1
queue2.dequeue() // 2
queue2.dequeue() // 3
```

`Queue`가 구조체라면 위 상황이 문제입니다.

`Queue`의 인스턴스는 다르지만 `Node`의 참조가 같아서, 다른 큐에 영향을 미치게 됩니다.

같은 이유로 `Bank`도 `class`여야 합니다.


### 2. 비동기작업 구현 방법

```swift
private let semaphore: DispatchSemaphore

let group = DispatchGroup()
while let client = clients.dequeue() {
	DispatchQueue.global().async(group: group) {
	  self.semaphore.wait()
	  self.respond(to: client)
	  self.semaphore.signal()
    }
}
group.wait()
```

은행 업무 로직을 `Dispatch Queue`를 사용하여 코드를 구현하였습니다.

`DispatchGroup`을 사용하여 비동기 작업들을 그룹화 해주고 모든 작업이 끝날 때 까지 프로그램이 종료되지 않고 기다리도록 하였습니다.
`semaphore`를 활용하여 은행원 수(쓰레드 수)를 제어할 수 있도록 했고, `Bank` 타입의 이니셜라이저를 통해 초기화 할 수 있도록 했습니다.


### 3. Bank와 BankManager로 역할분리

콘솔앱을 구동하기 위해 필요한 역할들을 핵심적인 역할이라 할 수 있는 **`은행 업무 처리`**와 사용자 입력을 받고 임의의 고객 수를 생성하는 등 `앱 구동`과 관련한 역할로 나누어 보았습니다 

두 역할이 구분된다고 판단되어 타입을 분리하였습니다. 은행 업무 처리는 `Bank`에서 앱구동과 관련한 동작들은 `BankManager`에서 수행하도록 구현하였습니다

### 4. Naming 관련 고민

#### 구체적인 이름을 정하려고 고민했습니다.

`admit(numberOfClients: Int)`

→ `addClientsToQueue(by numberOfClients: Int)`


#### Bank 타입의 work라고 하면 다소 추상적인듯하여 조금 더 구체적인 고객을 응대한다는 의미로 respond로 수정해보았습니다

`work(for: Client)`

→ `respond(to client: Client)`