### PR TITLE
은행 창구 매니저 [STEP2] 호랭이, 니콜라스

### DIFF
--- a/BankManager.swift
+++ b/BankManager.swift
@@ -48,8 +48,8 @@ struct BankManager {
   
   mutating func prepareBanker(numberOfBankers: Int) -> [Banker] {
     var bankers: [Banker] = []
-    
-    for _ in 0..<numberOfBankers {
+
+    (0..<numberOfBankers).forEach {_ in
       let banker = Banker()
       bankers.append(banker)
     }

--- a/BankManager.swift
+++ b/BankManager.swift
@@ -7,6 +7,11 @@
 import Foundation
 
 struct BankManager {
+  enum Menu: String {
+    case openBank = "1"
+    case exit = "2"
+  }
+  
   private func chooseMenu() -> String {
     print("""
           1 : 은행 개점
@@ -27,12 +32,12 @@ struct BankManager {
       let choiceMenu = self.chooseMenu()
       
       switch choiceMenu {
-      case "1" :
+      case Menu.openBank.rawValue :
         var bank: Bank = Bank(numberOfBankers: 1)
         bank.doBanking()
         print("업무가 마감되었습니다. 오늘 업무를 처리한 고객은 총 \(bank.numberOfClients)명이며,"
               + "총 업무시간은 \(bank.workingTime())초입니다.")
-      case "2" :
+      case Menu.exit.rawValue :
         isExit = true
       default :
         print("잘못된 입력입니다. 확인해주세요.")

--- a/BankManager.swift
+++ b/BankManager.swift
@@ -26,22 +26,25 @@ struct BankManager {
   }
   
   mutating func runBankManager(numberOfBankers: Int) {
-    var isExit: Bool = false
-    
-    while isExit == false {
+    while true {
       let choiceMenu = self.chooseMenu()
       
       switch choiceMenu {
       case Menu.openBank.rawValue :
-        let bankers = prepareBanker(numberOfBankers: numberOfBankers)
-        var bank: Bank = Bank(bankers: bankers, operatingTimeManager: OperatingTimeManager())
-        bank.doBanking()
+        operateBank(numberOfBankers: numberOfBankers)
       case Menu.exit.rawValue :
-        isExit = true
+        return
       default :
         print("잘못된 입력입니다. 확인해주세요.")
       }
     }
+    
+  }
+  
+  mutating func operateBank (numberOfBankers: Int) {
+    let bankers = prepareBanker(numberOfBankers: numberOfBankers)
+    var bank: Bank = Bank(bankers: bankers, operatingTimeManager: OperatingTimeManager())
+    bank.doBanking()
   }
   
   mutating func prepareBanker(numberOfBankers: Int) -> [Banker] {

--- a/BankManager.swift
+++ b/BankManager.swift
@@ -5,3 +5,38 @@
 //
 
 import Foundation
+
+struct BankManager {
+  private func chooseMenu() -> String {
+    print("""
+          1 : 은행 개점
+          2 : 종료
+          입력 :
+          """, terminator: "")
+    
+    guard let input = readLine() else {
+      return ""
+    }
+    return input
+  }
+  
+  mutating func runBankManager() {
+    var isExit: Bool = false
+
+    while isExit == false {
+      let choiceMenu = self.chooseMenu()
+      
+      switch choiceMenu {
+      case "1" :
+        var bank = Bank()
+        bank.doBanking()
+        print("업무가 마감되었습니다. 오늘 업무를 처리한 고객은 총 \(bank.numberOfClients)명이며,"
+              + "총 업무시간은 \(bank.workingTime())초입니다.")
+      case "2" :
+        isExit = true
+      default :
+        print("잘못된 입력입니다. 확인해주세요.")
+      }
+    }
+  }
+}

--- a/BankManager.swift
+++ b/BankManager.swift
@@ -38,7 +38,6 @@ struct BankManager {
         print("잘못된 입력입니다. 확인해주세요.")
       }
     }
-    
   }
   
   private mutating func operateBank (numberOfBankers: Int) {

--- a/BankManager.swift
+++ b/BankManager.swift
@@ -28,7 +28,7 @@ struct BankManager {
       
       switch choiceMenu {
       case "1" :
-        var bank = Bank()
+        var bank: Bank = Bank(numberOfBankers: 1)
         bank.doBanking()
         print("업무가 마감되었습니다. 오늘 업무를 처리한 고객은 총 \(bank.numberOfClients)명이며,"
               + "총 업무시간은 \(bank.workingTime())초입니다.")

--- a/BankManager.swift
+++ b/BankManager.swift
@@ -25,15 +25,16 @@ struct BankManager {
     return input
   }
   
-  mutating func runBankManager() {
+  mutating func runBankManager(numberOfBankers: Int) {
     var isExit: Bool = false
-
+    
     while isExit == false {
       let choiceMenu = self.chooseMenu()
       
       switch choiceMenu {
       case Menu.openBank.rawValue :
-        var bank: Bank = Bank(numberOfBankers: 1)
+        let bankers = prepareBanker(numberOfBankers: numberOfBankers)
+        var bank: Bank = Bank(bankers: bankers)
         bank.doBanking()
         print("업무가 마감되었습니다. 오늘 업무를 처리한 고객은 총 \(bank.numberOfClients)명이며,"
               + "총 업무시간은 \(bank.workingTime())초입니다.")
@@ -44,4 +45,15 @@ struct BankManager {
       }
     }
   }
+  
+  mutating func prepareBanker(numberOfBankers: Int) -> [Banker] {
+    var bankers: [Banker] = []
+    
+    for _ in 0..<numberOfBankers {
+      let banker = Banker()
+      bankers.append(banker)
+    }
+    return bankers
+  }
 }
+                              

--- a/BankManager.swift
+++ b/BankManager.swift
@@ -34,10 +34,8 @@ struct BankManager {
       switch choiceMenu {
       case Menu.openBank.rawValue :
         let bankers = prepareBanker(numberOfBankers: numberOfBankers)
-        var bank: Bank = Bank(bankers: bankers)
+        var bank: Bank = Bank(bankers: bankers, operatingTimeManager: OperatingTimeManager())
         bank.doBanking()
-        print("업무가 마감되었습니다. 오늘 업무를 처리한 고객은 총 \(bank.numberOfClients)명이며,"
-              + "총 업무시간은 \(bank.workingTime())초입니다.")
       case Menu.exit.rawValue :
         isExit = true
       default :

--- a/BankManager.swift
+++ b/BankManager.swift
@@ -41,13 +41,13 @@ struct BankManager {
     
   }
   
-  mutating func operateBank (numberOfBankers: Int) {
+  private mutating func operateBank (numberOfBankers: Int) {
     let bankers = prepareBanker(numberOfBankers: numberOfBankers)
     var bank: Bank = Bank(bankers: bankers, operatingTimeManager: OperatingTimeManager())
     bank.doBanking()
   }
   
-  mutating func prepareBanker(numberOfBankers: Int) -> [Banker] {
+  private mutating func prepareBanker(numberOfBankers: Int) -> [Banker] {
     var bankers: [Banker] = []
 
     (0..<numberOfBankers).forEach {_ in

--- a/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
+++ b/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		48BED40E2770630A0088A04C /* Queue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48BED40D2770630A0088A04C /* Queue.swift */; };
 		897A370B277466E600431A6A /* Bank.swift in Sources */ = {isa = PBXBuildFile; fileRef = 897A370A277466E600431A6A /* Bank.swift */; };
 		897A370D2774675700431A6A /* Client.swift in Sources */ = {isa = PBXBuildFile; fileRef = 897A370C2774675700431A6A /* Client.swift */; };
+		89A9F1BD277588430045E5BC /* OperatingTimeManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89A9F1BC277588430045E5BC /* OperatingTimeManager.swift */; };
 		89F168A027716AFC00F12029 /* QueueTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89F1689F27716AFC00F12029 /* QueueTest.swift */; };
 		89F168A427716C4D00F12029 /* Queue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48BED40D2770630A0088A04C /* Queue.swift */; };
 		89F168A527716D9300F12029 /* LinkedList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48BED40B277055F70088A04C /* LinkedList.swift */; };
@@ -37,6 +38,7 @@
 		48BED40D2770630A0088A04C /* Queue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Queue.swift; sourceTree = "<group>"; };
 		897A370A277466E600431A6A /* Bank.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Bank.swift; sourceTree = "<group>"; };
 		897A370C2774675700431A6A /* Client.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Client.swift; sourceTree = "<group>"; };
+		89A9F1BC277588430045E5BC /* OperatingTimeManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OperatingTimeManager.swift; sourceTree = "<group>"; };
 		89F1689D27716AFC00F12029 /* QueueTest.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = QueueTest.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		89F1689F27716AFC00F12029 /* QueueTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QueueTest.swift; sourceTree = "<group>"; };
 		C7694E76259C3EC00053667F /* BankManagerConsoleApp */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = BankManagerConsoleApp; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -97,6 +99,7 @@
 				48BED40D2770630A0088A04C /* Queue.swift */,
 				4843121D277461A0003423B6 /* Banker.swift */,
 				897A370A277466E600431A6A /* Bank.swift */,
+				89A9F1BC277588430045E5BC /* OperatingTimeManager.swift */,
 				897A370C2774675700431A6A /* Client.swift */,
 			);
 			path = BankManagerConsoleApp;
@@ -200,6 +203,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				89A9F1BD277588430045E5BC /* OperatingTimeManager.swift in Sources */,
 				48BED40C277055F70088A04C /* LinkedList.swift in Sources */,
 				C7694E7A259C3EC00053667F /* main.swift in Sources */,
 				897A370D2774675700431A6A /* Client.swift in Sources */,

--- a/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
+++ b/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		4843121E277461A0003423B6 /* Banker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4843121D277461A0003423B6 /* Banker.swift */; };
 		48BED40C277055F70088A04C /* LinkedList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48BED40B277055F70088A04C /* LinkedList.swift */; };
 		48BED40E2770630A0088A04C /* Queue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48BED40D2770630A0088A04C /* Queue.swift */; };
 		89F168A027716AFC00F12029 /* QueueTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89F1689F27716AFC00F12029 /* QueueTest.swift */; };
@@ -29,6 +30,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		4843121D277461A0003423B6 /* Banker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Banker.swift; sourceTree = "<group>"; };
 		48BED40B277055F70088A04C /* LinkedList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkedList.swift; sourceTree = "<group>"; };
 		48BED40D2770630A0088A04C /* Queue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Queue.swift; sourceTree = "<group>"; };
 		89F1689D27716AFC00F12029 /* QueueTest.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = QueueTest.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -89,6 +91,7 @@
 				C7694E79259C3EC00053667F /* main.swift */,
 				48BED40B277055F70088A04C /* LinkedList.swift */,
 				48BED40D2770630A0088A04C /* Queue.swift */,
+				4843121D277461A0003423B6 /* Banker.swift */,
 			);
 			path = BankManagerConsoleApp;
 			sourceTree = "<group>";
@@ -193,6 +196,7 @@
 			files = (
 				48BED40C277055F70088A04C /* LinkedList.swift in Sources */,
 				C7694E7A259C3EC00053667F /* main.swift in Sources */,
+				4843121E277461A0003423B6 /* Banker.swift in Sources */,
 				C7D65D1B259C8190005510E0 /* BankManager.swift in Sources */,
 				48BED40E2770630A0088A04C /* Queue.swift in Sources */,
 			);

--- a/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
+++ b/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
@@ -10,6 +10,8 @@
 		4843121E277461A0003423B6 /* Banker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4843121D277461A0003423B6 /* Banker.swift */; };
 		48BED40C277055F70088A04C /* LinkedList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48BED40B277055F70088A04C /* LinkedList.swift */; };
 		48BED40E2770630A0088A04C /* Queue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48BED40D2770630A0088A04C /* Queue.swift */; };
+		897A370B277466E600431A6A /* Bank.swift in Sources */ = {isa = PBXBuildFile; fileRef = 897A370A277466E600431A6A /* Bank.swift */; };
+		897A370D2774675700431A6A /* Client.swift in Sources */ = {isa = PBXBuildFile; fileRef = 897A370C2774675700431A6A /* Client.swift */; };
 		89F168A027716AFC00F12029 /* QueueTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89F1689F27716AFC00F12029 /* QueueTest.swift */; };
 		89F168A427716C4D00F12029 /* Queue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48BED40D2770630A0088A04C /* Queue.swift */; };
 		89F168A527716D9300F12029 /* LinkedList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48BED40B277055F70088A04C /* LinkedList.swift */; };
@@ -33,6 +35,8 @@
 		4843121D277461A0003423B6 /* Banker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Banker.swift; sourceTree = "<group>"; };
 		48BED40B277055F70088A04C /* LinkedList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkedList.swift; sourceTree = "<group>"; };
 		48BED40D2770630A0088A04C /* Queue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Queue.swift; sourceTree = "<group>"; };
+		897A370A277466E600431A6A /* Bank.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Bank.swift; sourceTree = "<group>"; };
+		897A370C2774675700431A6A /* Client.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Client.swift; sourceTree = "<group>"; };
 		89F1689D27716AFC00F12029 /* QueueTest.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = QueueTest.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		89F1689F27716AFC00F12029 /* QueueTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QueueTest.swift; sourceTree = "<group>"; };
 		C7694E76259C3EC00053667F /* BankManagerConsoleApp */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = BankManagerConsoleApp; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -92,6 +96,8 @@
 				48BED40B277055F70088A04C /* LinkedList.swift */,
 				48BED40D2770630A0088A04C /* Queue.swift */,
 				4843121D277461A0003423B6 /* Banker.swift */,
+				897A370A277466E600431A6A /* Bank.swift */,
+				897A370C2774675700431A6A /* Client.swift */,
 			);
 			path = BankManagerConsoleApp;
 			sourceTree = "<group>";
@@ -196,7 +202,9 @@
 			files = (
 				48BED40C277055F70088A04C /* LinkedList.swift in Sources */,
 				C7694E7A259C3EC00053667F /* main.swift in Sources */,
+				897A370D2774675700431A6A /* Client.swift in Sources */,
 				4843121E277461A0003423B6 /* Banker.swift in Sources */,
+				897A370B277466E600431A6A /* Bank.swift in Sources */,
 				C7D65D1B259C8190005510E0 /* BankManager.swift in Sources */,
 				48BED40E2770630A0088A04C /* Queue.swift in Sources */,
 			);

--- a/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/xcshareddata/xcschemes/QueueTest.xcscheme
+++ b/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/xcshareddata/xcschemes/QueueTest.xcscheme
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1310"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "89F1689C27716AFC00F12029"
+               BuildableName = "QueueTest.xctest"
+               BlueprintName = "QueueTest"
+               ReferencedContainer = "container:BankManagerConsoleApp.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "89F1689C27716AFC00F12029"
+               BuildableName = "QueueTest.xctest"
+               BlueprintName = "QueueTest"
+               ReferencedContainer = "container:BankManagerConsoleApp.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "89F1689C27716AFC00F12029"
+            BuildableName = "QueueTest.xctest"
+            BlueprintName = "QueueTest"
+            ReferencedContainer = "container:BankManagerConsoleApp.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
@@ -9,9 +9,9 @@ import Foundation
 
 struct Bank {
   private var bankers: [Banker]
-  let numberOfClients = Int.random(in: 10...30)
+  private let numberOfClients = Int.random(in: 10...30)
   private var clientQueue = Queue<Client>()
-  var operatingTimeManager: OperatingTimeManager
+  private var operatingTimeManager: OperatingTimeManager
   
   init(bankers: [Banker], operatingTimeManager: OperatingTimeManager) {
     self.bankers = bankers

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
@@ -44,7 +44,7 @@ struct Bank {
   
   private mutating func doWork() {
     for bankerNumber in 0..<bankers.count {
-      for _ in 1...numberOfClients {
+      (1...numberOfClients).forEach { _ in
         guard let dequeueClient = clientQueue.dequeue() else {
           return
         }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
@@ -8,30 +8,21 @@
 import Foundation
 
 struct Bank {
-  private var bankers: [Banker] = []
-  private let numberOfBankers: Int
+  private var bankers: [Banker]
   let numberOfClients = Int.random(in: 10...30)
   private var clientQueue = Queue<Client>()
   private var openTime = CFAbsoluteTime()
   private var closeTime = CFAbsoluteTime()
   
-  init(numberOfBankers: Int) {
-    self.numberOfBankers = numberOfBankers
+  init(bankers: [Banker]) {
+    self.bankers = bankers
   }
   
   mutating func doBanking() {
     openTime = CFAbsoluteTimeGetCurrent()
-    prepareBanker()
     clientLineUp()
     doWork()
     closeTime = CFAbsoluteTimeGetCurrent()
-  }
-  
-  mutating func prepareBanker() {
-    for _ in 0..<numberOfBankers {
-      let banker = Banker()
-      bankers.append(banker)
-    }
   }
   
   func workingTime() -> String {
@@ -52,7 +43,7 @@ struct Bank {
   }
   
   private mutating func doWork() {
-    for bankerNumber in 0..<numberOfBankers {
+    for bankerNumber in 0..<bankers.count {
       for _ in 1...numberOfClients {
         guard let dequeueClient = clientQueue.dequeue() else {
           return

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
@@ -11,29 +11,20 @@ struct Bank {
   private var bankers: [Banker]
   let numberOfClients = Int.random(in: 10...30)
   private var clientQueue = Queue<Client>()
-  private var openTime = CFAbsoluteTime()
-  private var closeTime = CFAbsoluteTime()
+  var operatingTimeManager: OperatingTimeManager
   
-  init(bankers: [Banker]) {
+  init(bankers: [Banker], operatingTimeManager: OperatingTimeManager) {
     self.bankers = bankers
+    self.operatingTimeManager = operatingTimeManager
   }
   
   mutating func doBanking() {
-    openTime = CFAbsoluteTimeGetCurrent()
+    operatingTimeManager.openTime = CFAbsoluteTimeGetCurrent()
     clientLineUp()
     doWork()
-    closeTime = CFAbsoluteTimeGetCurrent()
-  }
-  
-  func workingTime() -> String {
-    let timeInterval = closeTime - openTime
-    
-    let numberFormatter = NumberFormatter()
-    numberFormatter.roundingMode = .floor
-    numberFormatter.maximumSignificantDigits = 3
-    
-    let workingTime = numberFormatter.string(for: Double(timeInterval)) ?? ""
-    return workingTime
+    operatingTimeManager.closeTime = CFAbsoluteTimeGetCurrent()
+    print("업무가 마감되었습니다. 오늘 업무를 처리한 고객은 총 \(numberOfClients)명이며,"
+          + "총 업무시간은 \(operatingTimeManager.workingTime())초입니다.")
   }
   
   private mutating func clientLineUp() {
@@ -44,7 +35,7 @@ struct Bank {
   
   private mutating func doWork() {
     for bankerNumber in 0..<bankers.count {
-      (1...numberOfClients).forEach { _ in
+      (1...numberOfClients).forEach() { _ in
         guard let dequeueClient = clientQueue.dequeue() else {
           return
         }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
@@ -8,17 +8,30 @@
 import Foundation
 
 struct Bank {
-  private let banker: Banker = Banker()
+  private var bankers: [Banker] = []
+  private let numberOfBankers: Int
   let numberOfClients = Int.random(in: 10...30)
   private var clientQueue = Queue<Client>()
   private var openTime = CFAbsoluteTime()
   private var closeTime = CFAbsoluteTime()
   
+  init(numberOfBankers: Int) {
+    self.numberOfBankers = numberOfBankers
+  }
+  
   mutating func doBanking() {
     openTime = CFAbsoluteTimeGetCurrent()
+    prepareBanker()
     clientLineUp()
     doWork()
     closeTime = CFAbsoluteTimeGetCurrent()
+  }
+  
+  mutating func prepareBanker() {
+    for _ in 0..<numberOfBankers {
+      let banker = Banker()
+      bankers.append(banker)
+    }
   }
   
   func workingTime() -> String {
@@ -39,11 +52,13 @@ struct Bank {
   }
   
   private mutating func doWork() {
-    for _ in 1...numberOfClients {
-      guard let dequeueClient = clientQueue.dequeue() else {
-        return
+    for bankerNumber in 0..<numberOfBankers {
+      for _ in 1...numberOfClients {
+        guard let dequeueClient = clientQueue.dequeue() else {
+          return
+        }
+        bankers[bankerNumber].doTask(client: dequeueClient)
       }
-      banker.doTask(client: dequeueClient)
     }
   }
 }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
@@ -28,14 +28,14 @@ struct Bank {
   }
   
   private mutating func clientLineUp() {
-    for sequence in 1...numberOfClients {
+    for sequence in 0..<numberOfClients {
       clientQueue.enqueue(Client(sequence: sequence))
     }
   }
   
   private mutating func doWork() {
     for bankerNumber in 0..<bankers.count {
-      (1...numberOfClients).forEach() { _ in
+      (0..<numberOfClients).forEach() { _ in
         guard let dequeueClient = clientQueue.dequeue() else {
           return
         }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
@@ -8,27 +8,42 @@
 import Foundation
 
 struct Bank {
-  let banker: Banker = Banker()
+  private let banker: Banker = Banker()
   let numberOfClients = Int.random(in: 10...30)
-  var clientQueue = Queue<Client>()
+  private var clientQueue = Queue<Client>()
+  private var openTime = CFAbsoluteTime()
+  private var closeTime = CFAbsoluteTime()
   
-  mutating func openBank() {
+  mutating func doBanking() {
+    openTime = CFAbsoluteTimeGetCurrent()
     clientLineUp()
     doWork()
+    closeTime = CFAbsoluteTimeGetCurrent()
   }
   
-  mutating func clientLineUp() {
+  func workingTime() -> String {
+    let timeInterval = closeTime - openTime
+    
+    let numberFormatter = NumberFormatter()
+    numberFormatter.roundingMode = .floor
+    numberFormatter.maximumSignificantDigits = 3
+    
+    let workingTime = numberFormatter.string(for: Double(timeInterval)) ?? ""
+    return workingTime
+  }
+  
+  private mutating func clientLineUp() {
     for sequence in 1...numberOfClients {
       clientQueue.enqueue(Client(sequence: sequence))
     }
   }
   
-  mutating func doWork() {
+  private mutating func doWork() {
     for _ in 1...numberOfClients {
-      guard let client = clientQueue.dequeue() else {
+      guard let dequeueClient = clientQueue.dequeue() else {
         return
       }
-      banker.doTask(clientSequence: client.sequence)
+      banker.doTask(client: dequeueClient)
     }
   }
 }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
@@ -1,0 +1,34 @@
+//
+//  Bank.swift
+//  BankManagerConsoleApp
+//
+//  Created by Eunsoo KIM on 2021/12/23.
+//
+
+import Foundation
+
+struct Bank {
+  let banker: Banker = Banker()
+  let numberOfClients = Int.random(in: 10...30)
+  var clientQueue = Queue<Client>()
+  
+  mutating func openBank() {
+    clientLineUp()
+    doWork()
+  }
+  
+  mutating func clientLineUp() {
+    for sequence in 1...numberOfClients {
+      clientQueue.enqueue(Client(sequence: sequence))
+    }
+  }
+  
+  mutating func doWork() {
+    for _ in 1...numberOfClients {
+      guard let client = clientQueue.dequeue() else {
+        return
+      }
+      banker.doTask(clientSequence: client.sequence)
+    }
+  }
+}

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Banker.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Banker.swift
@@ -13,8 +13,9 @@ struct Banker {
   }
   
   func doTask(client: Client) {
-    print("\(client.sequence)번 고객 업무 시작")
+    let clientNumber = client.sequence + 1
+    print("\(clientNumber)번 고객 업무 시작")
     DispatchQueue.global().sync(execute: task)
-    print("\(client.sequence)번 고객 업무 완료")
+    print("\(clientNumber)번 고객 업무 완료")
   }
 }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Banker.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Banker.swift
@@ -7,12 +7,14 @@
 
 import Foundation
 
-struct Banker() {
+struct Banker {
   func doTask(clientSequence: Int) {
     print("\(clientSequence)번 고객 업무 시작")
+    
     DispatchQueue.global().sync {
-      sleep(0.7)
+      sleep(UInt32(0.7))
     }
+    
     print("\(clientSequence)번 고객 업무 완료")
   }
 }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Banker.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Banker.swift
@@ -1,0 +1,18 @@
+//
+//  Bank.swift
+//  BankManagerConsoleApp
+//
+//  Created by 서녕 on 2021/12/23.
+//
+
+import Foundation
+
+struct Banker() {
+  func doTask(clientSequence: Int) {
+    print("\(clientSequence)번 고객 업무 시작")
+    DispatchQueue.global().sync {
+      sleep(0.7)
+    }
+    print("\(clientSequence)번 고객 업무 완료")
+  }
+}

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Banker.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Banker.swift
@@ -8,13 +8,13 @@
 import Foundation
 
 struct Banker {
-  func doTask(clientSequence: Int) {
-    print("\(clientSequence)번 고객 업무 시작")
-    
-    DispatchQueue.global().sync {
-      sleep(UInt32(0.7))
-    }
-    
-    print("\(clientSequence)번 고객 업무 완료")
+  private let task = DispatchWorkItem {
+    Thread.sleep(forTimeInterval: 0.7)
+  }
+  
+  func doTask(client: Client) {
+    print("\(client.sequence)번 고객 업무 시작")
+    DispatchQueue.global().sync(execute: task)
+    print("\(client.sequence)번 고객 업무 완료")
   }
 }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Client.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Client.swift
@@ -1,0 +1,12 @@
+//
+//  Clent.swift
+//  BankManagerConsoleApp
+//
+//  Created by Eunsoo KIM on 2021/12/23.
+//
+
+import Foundation
+
+struct Client {
+  let sequence: Int
+}

--- a/BankManagerConsoleApp/BankManagerConsoleApp/OperatingTimeManager.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/OperatingTimeManager.swift
@@ -1,0 +1,24 @@
+//
+//  OperatingTimeManager.swift
+//  BankManagerConsoleApp
+//
+//  Created by Eunsoo KIM on 2021/12/24.
+//
+
+import Foundation
+
+struct OperatingTimeManager {
+  var openTime = CFAbsoluteTime()
+  var closeTime = CFAbsoluteTime()
+  
+  func workingTime() -> String {
+    let timeInterval = closeTime - openTime
+    
+    let numberFormatter = NumberFormatter()
+    numberFormatter.roundingMode = .floor
+    numberFormatter.maximumSignificantDigits = 3
+    
+    let workingTime = numberFormatter.string(for: Double(timeInterval)) ?? ""
+    return workingTime
+  }
+}

--- a/BankManagerConsoleApp/BankManagerConsoleApp/main.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/main.swift
@@ -8,4 +8,4 @@ import Foundation
 
 var bankManger = BankManager()
 
-bankManger.runBankManager()
+bankManger.runBankManager(numberOfBankers: 1)

--- a/BankManagerConsoleApp/BankManagerConsoleApp/main.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/main.swift
@@ -5,3 +5,7 @@
 // 
 
 import Foundation
+
+var bankManger = BankManager()
+
+bankManger.runBankManager()


### PR DESCRIPTION
@protocorn93 
@Kim-EunsooSilver

step2 PR제출합니다!
많은 고민과 시행착오가 있었는데 PR에 잘 담겼는지 모르겠네요 😂
이번 리뷰도 잘부탁드립니다!
감사합니다☺️


---
## 1. 고민했던 점

- Banker타입을 처음에는 인원수를 고려하지 않고 구현했다가, n명의 은행원이 있다는 요구사항을 확인하고 Bank타입 안에서 bankers라는 배열로 정의했습니다.
- 은행의 업무시간을 계산하기 위해 Timer 클래스 사용에 대한 고민을 했습니다. 저희가 수시간 동안 연구(?) 해본 결과 저희의 상황에는 맞지 않는 방식으로 결론을 내렸고 `CFAbsoluteTimeGetCurrent()` 를 사용하여 은행의 업무시간을 계산하였습니다.
    - Timer클래스를 사용한다면 프로그램을 실행하는 내내 0.01초마다 timeCount라는 변수에 0.01씩을 더해주는 방식을 생각했었는데, 이렇게 된다면 실행하는 동안 계속적으로 0.01초마다 연산이 반복되기 때문에 지금처럼 처음과 끝시간만을 이용해서 한번만 계산하는 것이 더 효율적이라고 생각했습니다.
- BankManager와 Main의 역할에 대한 고민을 했습니다. 프로젝트 포크시에 기본 생성된 파일이기에 파일명에 맞게끔 설계했습니다.
- 총업무시간 계산결과를 소수점둘째자리까지 나타내기 위해서 NumberFormatter를 사용했습니다.
- 메뉴에서 1을 선택했을 때 작업을 실행하고 2를 선택했을 때 종료를 하는 부분에서 wile문을 사용한 이유
    - 1을 선택해서 작업이 수행이 끝난 뒤에 다시 메뉴를 호출해서 새롭게 은행을 개점해야할 수도 있는데, 이부분을 isExit와 wile문을 사용해서 2가 입력되기 전까지 반복해서 메뉴를 선택할 수 있도록 설계하였습니다. switch문에서 2를 선택했을 경우에만 isExit가 true로 바뀌기 때문에 wile문이 종료되고 프로그램이 종료됩니다.

## 2. 조언을 얻고 싶은 부분

- 메뉴가 은행개점/종료 두개뿐인데 이렇게 갯수가 적은 경우에도 enum으로 관리하는게 좋을까요?
- 은행 업무를 위해 은행원 객체를 생성하고, 고객을 clientQueue에 넣고, 총 영업시간을 계산하는 등의 일이 매니저의 역할인지 은행의 역할인지 그 경계에 대해서 고민을 했습니다. 고민의 결과로는 영업시간을 계산해서 출력하는 일만 매니저에서 수행하게 하고, 나머지는 은행 업무의 일종이라고 생각해서 지금과 같이 코드를 짜봤는데 이런 부분은 주관적인 판단으로 해야하는 건지, 나름의 기준이 있는 건지 궁금합니다.

## 3. 트러블 슈팅

- `sleep` 에 대한 잘못된 사용
    - 예시: `sleep(UInt32(0.7))`
        - 이유: sleep은 파라미터로 UInt32, UInt64등 Int으로만 설정이 가능하다.
    - 개선사항: `Thread.sleep(forTimeInterval: 0.7)`