### PR TITLE
은행 창구 매니저 [STEP3] 호랭이, 니콜라스

### DIFF
--- a/BankManager.swift
+++ b/BankManager.swift
@@ -50,17 +50,11 @@ struct BankManager {
   
   private mutating func prepareBanker(numberOfDepositBankers: Int,
                                       numberOfLoanBankers: Int) -> [Banker] {
-    var bankers: [Banker] = []
-
-    (0..<numberOfDepositBankers).forEach {_ in
-      let banker = Banker(assignedTask: .deposit)
-      bankers.append(banker)
-    }
-    (0..<numberOfLoanBankers).forEach {_ in
-      let banker = Banker(assignedTask: .loan)
-      bankers.append(banker)
-    }
-    return bankers
+    let depositeBankers = Array.init(repeating: Banker(assignedTask: .deposit),
+                                     count: numberOfDepositBankers)
+    let loanBankers = Array.init(repeating: Banker(assignedTask: .loan),
+                                 count: numberOfLoanBankers)
+    return depositeBankers + loanBankers
   }
 }
                               

--- a/BankManager.swift
+++ b/BankManager.swift
@@ -42,7 +42,7 @@ struct BankManager {
   
   private mutating func operateBank (numberOfBankers: Int) {
     let bankers = prepareBanker(numberOfBankers: numberOfBankers)
-    var bank: Bank = Bank(bankers: bankers, operatingTimeManager: OperatingTimeManager())
+    let bank: Bank = Bank(bankers: bankers, operatingTimeManager: OperatingTimeManager())
     bank.doBanking()
   }
   

--- a/BankManager.swift
+++ b/BankManager.swift
@@ -44,7 +44,7 @@ struct BankManager {
   private mutating func operateBank (numberOfDepositBankers: Int, numberOfLoanBankers: Int) {
     let bankers = prepareBanker(numberOfDepositBankers: numberOfDepositBankers,
                                 numberOfLoanBankers: numberOfLoanBankers)
-    let bank: Bank = Bank(bankers: bankers, operatingTimeManager: OperatingTimeManager())
+    let bank = Bank(bankers: bankers, operatingTimeManager: OperatingTimeManager())
     bank.doBanking()
   }
   

--- a/BankManager.swift
+++ b/BankManager.swift
@@ -42,9 +42,11 @@ struct BankManager {
   }
   
   private mutating func operateBank (numberOfDepositBankers: Int, numberOfLoanBankers: Int) {
+    let numberOfClients = Int.random(in: 10...30)
     let bankers = prepareBanker(numberOfDepositBankers: numberOfDepositBankers,
                                 numberOfLoanBankers: numberOfLoanBankers)
-    let bank = Bank(bankers: bankers, operatingTimeManager: OperatingTimeManager())
+    let clients = clientLineUp(numberOfClients: numberOfClients)
+    let bank = Bank(numberOfClients: numberOfClients, bankers: bankers, clientQueue: clients,  operatingTimeManager: OperatingTimeManager())
     bank.doBanking()
   }
   
@@ -55,6 +57,15 @@ struct BankManager {
     let loanBankers = Array.init(repeating: Banker(assignedTask: .loan),
                                  count: numberOfLoanBankers)
     return depositeBankers + loanBankers
+  }
+  
+  private func clientLineUp(numberOfClients: Int) -> Queue<Client> {
+    let numberOfClients = numberOfClients
+    var clientQueue = Queue<Client>()
+    for sequence in 0..<numberOfClients {
+      clientQueue.enqueue(Client(sequence: sequence))
+    }
+    return clientQueue
   }
 }
                               

--- a/BankManager.swift
+++ b/BankManager.swift
@@ -25,13 +25,14 @@ struct BankManager {
     return input
   }
   
-  mutating func runBankManager(numberOfBankers: Int) {
+  mutating func runBankManager(numberOfDepositBankers: Int, numberOfLoanBankers: Int) {
     while true {
       let choiceMenu = self.chooseMenu()
       
       switch choiceMenu {
       case Menu.openBank.rawValue :
-        operateBank(numberOfBankers: numberOfBankers)
+        operateBank(numberOfDepositBankers: numberOfDepositBankers,
+                    numberOfLoanBankers: numberOfLoanBankers)
       case Menu.exit.rawValue :
         return
       default :
@@ -40,17 +41,23 @@ struct BankManager {
     }
   }
   
-  private mutating func operateBank (numberOfBankers: Int) {
-    let bankers = prepareBanker(numberOfBankers: numberOfBankers)
+  private mutating func operateBank (numberOfDepositBankers: Int, numberOfLoanBankers: Int) {
+    let bankers = prepareBanker(numberOfDepositBankers: numberOfDepositBankers,
+                                numberOfLoanBankers: numberOfLoanBankers)
     let bank: Bank = Bank(bankers: bankers, operatingTimeManager: OperatingTimeManager())
     bank.doBanking()
   }
   
-  private mutating func prepareBanker(numberOfBankers: Int) -> [Banker] {
+  private mutating func prepareBanker(numberOfDepositBankers: Int,
+                                      numberOfLoanBankers: Int) -> [Banker] {
     var bankers: [Banker] = []
 
-    (0..<numberOfBankers).forEach {_ in
-      let banker = Banker()
+    (0..<numberOfDepositBankers).forEach {_ in
+      let banker = Banker(assignedTask: .deposit)
+      bankers.append(banker)
+    }
+    (0..<numberOfLoanBankers).forEach {_ in
+      let banker = Banker(assignedTask: .loan)
       bankers.append(banker)
     }
     return bankers

--- a/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
+++ b/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		481E82172779B20400C8BB4E /* BankingType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 481E82162779B20400C8BB4E /* BankingType.swift */; };
 		4843121E277461A0003423B6 /* Banker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4843121D277461A0003423B6 /* Banker.swift */; };
 		48BED40C277055F70088A04C /* LinkedList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48BED40B277055F70088A04C /* LinkedList.swift */; };
 		48BED40E2770630A0088A04C /* Queue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48BED40D2770630A0088A04C /* Queue.swift */; };
@@ -33,6 +34,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		481E82162779B20400C8BB4E /* BankingType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BankingType.swift; sourceTree = "<group>"; };
 		4843121D277461A0003423B6 /* Banker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Banker.swift; sourceTree = "<group>"; };
 		48BED40B277055F70088A04C /* LinkedList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkedList.swift; sourceTree = "<group>"; };
 		48BED40D2770630A0088A04C /* Queue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Queue.swift; sourceTree = "<group>"; };
@@ -101,6 +103,7 @@
 				897A370A277466E600431A6A /* Bank.swift */,
 				89A9F1BC277588430045E5BC /* OperatingTimeManager.swift */,
 				897A370C2774675700431A6A /* Client.swift */,
+				481E82162779B20400C8BB4E /* BankingType.swift */,
 			);
 			path = BankManagerConsoleApp;
 			sourceTree = "<group>";
@@ -208,6 +211,7 @@
 				C7694E7A259C3EC00053667F /* main.swift in Sources */,
 				897A370D2774675700431A6A /* Client.swift in Sources */,
 				4843121E277461A0003423B6 /* Banker.swift in Sources */,
+				481E82172779B20400C8BB4E /* BankingType.swift in Sources */,
 				897A370B277466E600431A6A /* Bank.swift in Sources */,
 				C7D65D1B259C8190005510E0 /* BankManager.swift in Sources */,
 				48BED40E2770630A0088A04C /* Queue.swift in Sources */,

--- a/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
+++ b/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
@@ -152,7 +152,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 1310;
-				LastUpgradeCheck = 1210;
+				LastUpgradeCheck = 1300;
 				TargetAttributes = {
 					89F1689C27716AFC00F12029 = {
 						CreatedOnToolsVersion = 13.1;
@@ -383,6 +383,7 @@
 		C7694E7E259C3EC00053667F /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CODE_SIGN_IDENTITY = "-";
 				CODE_SIGN_STYLE = Automatic;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
@@ -392,6 +393,7 @@
 		C7694E7F259C3EC00053667F /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CODE_SIGN_IDENTITY = "-";
 				CODE_SIGN_STYLE = Automatic;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;

--- a/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/xcshareddata/xcschemes/QueueTest.xcscheme
+++ b/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/xcshareddata/xcschemes/QueueTest.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1310"
+   LastUpgradeVersion = "1300"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
@@ -36,17 +36,18 @@ class Bank {
 
   private func doWork() {
     let doWorkDispatchgroup = DispatchGroup()
-
+    
     for bankerNumber in 0..<bankers.count {
       DispatchQueue.global().async(group: doWorkDispatchgroup) {
-        (0..<self.numberOfClients).forEach() { _ in
-          self.semaphore.wait()
-          guard let dequeueClient = self.clientQueue.dequeue() else {
-            self.semaphore.signal()
-            return
+        while !self.clientQueue.isEmpty() {
+          if self.clientQueue.peek()?.requiredBankingType == self.bankers[bankerNumber].assignedTask {
+            self.semaphore.wait()
+            guard let dequeueClient = self.clientQueue.dequeue() else {
+              return
+            }
+            self.bankers[bankerNumber].doTask(client: dequeueClient)
           }
           self.semaphore.signal()
-          self.bankers[bankerNumber].doTask(client: dequeueClient)
         }
       }
     }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
@@ -18,14 +18,14 @@ class Bank {
     self.bankers = bankers
     self.operatingTimeManager = operatingTimeManager
   }
-
+  
   func doBanking() {
-      operatingTimeManager.openTime = CFAbsoluteTimeGetCurrent()
-      clientLineUp()
-      doWork()
-      operatingTimeManager.closeTime = CFAbsoluteTimeGetCurrent()
-      print("업무가 마감되었습니다. 오늘 업무를 처리한 고객은 총 \(numberOfClients)명이며,"
-            + "총 업무시간은 \(operatingTimeManager.workingTime())초입니다.")
+    operatingTimeManager.openTime = CFAbsoluteTimeGetCurrent()
+    clientLineUp()
+    doWork()
+    operatingTimeManager.closeTime = CFAbsoluteTimeGetCurrent()
+    print("업무가 마감되었습니다. 오늘 업무를 처리한 고객은 총 \(numberOfClients)명이며,"
+          + "총 업무시간은 \(operatingTimeManager.workingTime())초입니다.")
   }
 
   private func clientLineUp() {

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
@@ -8,30 +8,25 @@
 import Foundation
 
 class Bank {
+  private let numberOfClients: Int
   private var bankers: [Banker]
-  private let numberOfClients = Int.random(in: 10...30)
   private var clientQueue = Queue<Client>()
   private var operatingTimeManager: OperatingTimeManager
   private let semaphore = DispatchSemaphore(value: 1)
 
-  init(bankers: [Banker], operatingTimeManager: OperatingTimeManager) {
+  init(numberOfClients: Int, bankers: [Banker], clientQueue: Queue<Client>, operatingTimeManager: OperatingTimeManager) {
+    self.numberOfClients = numberOfClients
     self.bankers = bankers
+    self.clientQueue = clientQueue
     self.operatingTimeManager = operatingTimeManager
   }
   
   func doBanking() {
     operatingTimeManager.openTime = CFAbsoluteTimeGetCurrent()
-    clientLineUp()
     doWork()
     operatingTimeManager.closeTime = CFAbsoluteTimeGetCurrent()
     print("업무가 마감되었습니다. 오늘 업무를 처리한 고객은 총 \(numberOfClients)명이며,"
           + "총 업무시간은 \(operatingTimeManager.workingTime())초입니다.")
-  }
-
-  private func clientLineUp() {
-    for sequence in 0..<numberOfClients {
-      clientQueue.enqueue(Client(sequence: sequence))
-    }
   }
   
   private func doWork() {

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
@@ -7,40 +7,49 @@
 
 import Foundation
 
-struct Bank {
+class Bank {
   private var bankers: [Banker]
   private let numberOfClients = Int.random(in: 10...30)
   private var clientQueue = Queue<Client>()
   private var operatingTimeManager: OperatingTimeManager
-  
+  private let semaphore = DispatchSemaphore(value: 1)
+
   init(bankers: [Banker], operatingTimeManager: OperatingTimeManager) {
     self.bankers = bankers
     self.operatingTimeManager = operatingTimeManager
   }
-  
-  mutating func doBanking() {
-    operatingTimeManager.openTime = CFAbsoluteTimeGetCurrent()
-    clientLineUp()
-    doWork()
-    operatingTimeManager.closeTime = CFAbsoluteTimeGetCurrent()
-    print("업무가 마감되었습니다. 오늘 업무를 처리한 고객은 총 \(numberOfClients)명이며,"
-          + "총 업무시간은 \(operatingTimeManager.workingTime())초입니다.")
+
+  func doBanking() {
+      operatingTimeManager.openTime = CFAbsoluteTimeGetCurrent()
+      clientLineUp()
+      doWork()
+      operatingTimeManager.closeTime = CFAbsoluteTimeGetCurrent()
+      print("업무가 마감되었습니다. 오늘 업무를 처리한 고객은 총 (numberOfClients)명이며,"
+            + "총 업무시간은 (operatingTimeManager.workingTime())초입니다.")
   }
-  
-  private mutating func clientLineUp() {
+
+  private func clientLineUp() {
     for sequence in 0..<numberOfClients {
       clientQueue.enqueue(Client(sequence: sequence))
     }
   }
-  
-  private mutating func doWork() {
+
+  private func doWork() {
+    let doWorkDispatchgroup = DispatchGroup()
+
     for bankerNumber in 0..<bankers.count {
-      (0..<numberOfClients).forEach() { _ in
-        guard let dequeueClient = clientQueue.dequeue() else {
-          return
+      DispatchQueue.global().async(group: doWorkDispatchgroup) {
+        (0..<self.numberOfClients).forEach() { _ in
+          self.semaphore.wait()
+          guard let dequeueClient = self.clientQueue.dequeue() else {
+            self.semaphore.signal()
+            return
+          }
+          self.semaphore.signal()
+          self.bankers[bankerNumber].doTask(client: dequeueClient)
         }
-        bankers[bankerNumber].doTask(client: dequeueClient)
       }
     }
+    doWorkDispatchgroup.wait()
   }
 }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
@@ -46,8 +46,8 @@ class Bank {
   }
   
   private func provideService(bankerNumber: Int) {
-    while !self.clientQueue.isEmpty() {
-      if self.clientQueue.peek()?.requiredBankingType == self.bankers[bankerNumber].assignedTask {
+    while let firstClient = clientQueue.peek() {
+      if firstClient.requiredBankingType == self.bankers[bankerNumber].assignedTask {
         self.semaphore.wait()
         guard let dequeueClient = self.clientQueue.dequeue() else {
           return

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
@@ -33,24 +33,28 @@ class Bank {
       clientQueue.enqueue(Client(sequence: sequence))
     }
   }
-
+  
   private func doWork() {
     let doWorkDispatchgroup = DispatchGroup()
     
     for bankerNumber in 0..<bankers.count {
       DispatchQueue.global().async(group: doWorkDispatchgroup) {
-        while !self.clientQueue.isEmpty() {
-          if self.clientQueue.peek()?.requiredBankingType == self.bankers[bankerNumber].assignedTask {
-            self.semaphore.wait()
-            guard let dequeueClient = self.clientQueue.dequeue() else {
-              return
-            }
-            self.bankers[bankerNumber].doTask(client: dequeueClient)
-          }
-          self.semaphore.signal()
-        }
+        self.provideService(bankerNumber: bankerNumber)
       }
     }
     doWorkDispatchgroup.wait()
+  }
+  
+  private func provideService(bankerNumber: Int) {
+    while !self.clientQueue.isEmpty() {
+      if self.clientQueue.peek()?.requiredBankingType == self.bankers[bankerNumber].assignedTask {
+        self.semaphore.wait()
+        guard let dequeueClient = self.clientQueue.dequeue() else {
+          return
+        }
+        self.bankers[bankerNumber].doTask(client: dequeueClient)
+      }
+      self.semaphore.signal()
+    }
   }
 }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
@@ -24,8 +24,8 @@ class Bank {
       clientLineUp()
       doWork()
       operatingTimeManager.closeTime = CFAbsoluteTimeGetCurrent()
-      print("업무가 마감되었습니다. 오늘 업무를 처리한 고객은 총 (numberOfClients)명이며,"
-            + "총 업무시간은 (operatingTimeManager.workingTime())초입니다.")
+      print("업무가 마감되었습니다. 오늘 업무를 처리한 고객은 총 \(numberOfClients)명이며,"
+            + "총 업무시간은 \(operatingTimeManager.workingTime())초입니다.")
   }
 
   private func clientLineUp() {

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Banker.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Banker.swift
@@ -8,14 +8,24 @@
 import Foundation
 
 struct Banker {
-  private let task = DispatchWorkItem {
-    Thread.sleep(forTimeInterval: 0.7)
+  let assignedTask: BankingType
+  private let task: DispatchWorkItem
+  
+  init(assignedTask: BankingType) {
+    self.assignedTask = assignedTask
+    task = DispatchWorkItem {
+      Thread.sleep(forTimeInterval: assignedTask.requiredTime)
+    }
   }
   
   func doTask(client: Client) {
     let clientNumber = client.sequence + 1
-    print("\(clientNumber)번 고객 업무 시작")
+    guard let requiredBankingType = client.requiredBankingType?.rawValue else {
+      return
+    }
+    
+    print("\(clientNumber)번 고객 \(requiredBankingType)업무 시작")
     DispatchQueue.global().sync(execute: task)
-    print("\(clientNumber)번 고객 업무 완료")
+    print("\(clientNumber)번 고객 \(requiredBankingType)업무 완료")
   }
 }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Banker.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Banker.swift
@@ -20,9 +20,7 @@ struct Banker {
   
   func doTask(client: Client) {
     let clientNumber = client.sequence + 1
-    guard let requiredBankingType = client.requiredBankingType?.rawValue else {
-      return
-    }
+    let requiredBankingType = client.requiredBankingType.rawValue
     
     print("\(clientNumber)번 고객 \(requiredBankingType)업무 시작")
     DispatchQueue.global().sync(execute: task)

--- a/BankManagerConsoleApp/BankManagerConsoleApp/BankingType.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/BankingType.swift
@@ -1,0 +1,22 @@
+//
+//  BankingType.swift
+//  BankManagerConsoleApp
+//
+//  Created by 서녕 on 2021/12/27.
+//
+
+import Foundation
+
+enum BankingType: String, CaseIterable {
+  case deposit = "예금"
+  case loan = "대출"
+  
+  var requiredTime : Double {
+    switch self {
+    case .deposit:
+      return 0.7
+    case .loan:
+      return 1.1
+    }
+  }
+}

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Client.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Client.swift
@@ -9,10 +9,10 @@ import Foundation
 
 struct Client {
   let sequence: Int
-  let requiredBankingType: BankingType?
+  let requiredBankingType: BankingType
   
   init(sequence: Int) {
     self.sequence = sequence
-    self.requiredBankingType = BankingType.allCases.randomElement()
+    self.requiredBankingType = BankingType.allCases.randomElement() ?? .deposit
   }
 }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Client.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Client.swift
@@ -9,4 +9,10 @@ import Foundation
 
 struct Client {
   let sequence: Int
+  let requiredBankingType: BankingType?
+  
+  init(sequence: Int) {
+    self.sequence = sequence
+    self.requiredBankingType = BankingType.allCases.randomElement()
+  }
 }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/main.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/main.swift
@@ -8,4 +8,4 @@ import Foundation
 
 var bankManger = BankManager()
 
-bankManger.runBankManager(numberOfBankers: 1)
+bankManger.runBankManager(numberOfDepositBankers: 2, numberOfLoanBankers: 1)


### PR DESCRIPTION
@protocorn93 
@Kim-EunsooSilver

안녕하세요 콘! 
step3 PR 제출합니다
목표기한이 아직 남기는 했지만, 
더 많은 조언을 받으면서 수정할 부분을 찾아보고 싶어서 조금 일찍 PR을 제출하게됐습니당😊
항상 최고의 리뷰 감사해요 👍
이번에도 잘부탁드리겠습니다!!

---
## 고민했던 점

- Bank타입 내부의 `doWork()` 메서드의 로직 구현에 많은 고민을 했습니다. for문, async 코드 블럭, while문, if문 등이 한 메서드 내에서 쓰이다 보니까 안그래도 어려운 로직짜기가 더 헷갈려서 많은 시간이...걸렸습니다...
- 은행 업무에 대해서 타입으로 구현하고 사용하는 방법에 대해서 고민을 했습니다.
    - Banker 내부의 `task`를 두개 (예금, 대출) 만들어, 실행 하는 부분에서 분기를 이용하여 선택된 `task` 내부에서 `sleep`을 주는 의견
    - Banker 타입 내부의 `task`를 한개 만들어, 내부에서 전달받은 고객의 업무를 이용해 분기하여 `sleep`을 주는 의견
    
    → 우리의 결론...
    
    1. 소요시간을 타입 내부에서 정의
    `BankingType`에 따른 소요시간은 `BankingType`과 함께 정해져있는 것이기 때문에, 코드에서 사용하면서 분기문 등에서 숫자로 입력해주는 것보다는 `BankingType`내부에서 정의해놓고 이 타입을 이용해서 가져다 쓰는 것이 바람직하다는 생각에 현재와 같이 구현했습니다.
    2. `Banker` 타입 자체에 `assignedTask` 프로퍼티를 만들어서 사용
        
        `Banker` 타입 자체에 `assignedTask(BankingType타입) 프로퍼티`를 만들어서 이를 `task`라는 하나의 `DispatchWorkItem`에서 사용한다면 `task` 내부에서는 `assignedTask.requiredTime`을 이용하면 되기 때문에 분기를 사용할 필요가 없다고 판단했습니다.
        
- `bankers` 2차원 배열 사용에 대한 고민
    - `bankers`를 2차원 배열로 사용하여 [[예금은행원1,예금은행원2], [대출은행원1]]과 같은 형식으로 구현하는 것은 어떨까 하는 고민을 했습니다.
        
        → 2차원 배열을 사용한다면 `dequeue`를 하며 미리 업무별로 손님을 분류해놓아서 업무를 처리하는 것을 구현하기는 편리하겠지만, `index`를 이용해서 자료에 접근해야하기 때문에 위험한 방식이라고 생각했습니다. 따라서 현재와 같이 `clientQueue`의 `dequeueItem`과 `banker`의 업무를 비교하여 같은 경우 업무를 처리하며 반복문을 실행하는 방식으로 구현했습니다.
        
- `clientQueue` 접근에 대한 **Race Condition** 방지 고민
    - 총 은행원의 수대로 스레드를 생성 한 후, 해당 스레드가 동시에 `clientQueue`의 `dequeue()`를 실행 할 경우 동일한 값이 처리되는 현상이 이었습니다.
    - 상위 현상을 방지하고자 은행원의 업무타입과 `clientQueue`의 첫번째 값을 라턴해주는 `peek()`함수를 이용하여 결과를 비교한 후, 동일하면 `DispatchSemaphore.wait()`을 이용하여 `dequeue()`에 대해서 동시 접근이 되지 않도록 제한 하였습니다.


## 해결이 되지 않은 점

- Bank타입의 `doWork()` 메서드 내부의 async 코드블럭을 `DispatchWorkItem`으로 사용하고 싶었는데, 코드 블럭 내부에서 외부의 요소를 사용하는 부분에서 어려움을 겪었습니다.

```swift
for bankerNumber in 0..<bankers.count {
      DispatchQueue.global().async(group: doWorkDispatchgroup) {
        self.provideService(bankerNumber: bankerNumber)
      }
    }
```

→ 위의 코드에서 표시한 부분을 `DispatchWorkItem`으로 분리하여 excute로 이용하는 방식으로 사용하고 싶었습니다. 하지만 `bankerNumber`라는 전달인자를 `DispatchWorkItem` 내부로 전달하는 방법을 찾지 못해서 현재와 같은 방식으로 구현하였습니다. `DispatchWorkItem`은 인자를 전달하는 것이 불가능한 것인지, 혹시 방법이 따로 있는 건지 궁금합니다.

## 조언을 얻고 싶은 부분
- `Bank` ****class로 변경한 이유
    
![](https://i.imgur.com/Llin0Bv.png)

    
→ struct타입인 상태로 위의 코드를 작성하니 오류가 발생해서 이에 대해 알아보았습니다.  이스케이핑 클로저는 mutating을 암시적으로 캡쳐할 수 없다. 따라서 값타입에서 사용하는 이스케이핑 클로저는 내부 값을 변경할 수 없다.는 의미로 해석을 했는데, 이게 무슨 소린지...이해가 가지 않고...너무 어려웠습니다.....
    이 부분은 값 타입이나 클로저에 대한 공부가 더 필요할 것 같다는 생각이 들었는데 저희가 놓치고 있는 부분이나 공부할 때 참고하기 좋은 자료가 있을까요? 😭
    
- `task`라는 `DispatchWorkItem`의 값을 `init()` 내부에 구현한 이유
    
![](https://i.imgur.com/AVtlQst.png)
    
→ 상위 그림과 같이 `init()` 외부에서 값을 할당해 줄때 오류가 발생했습니다. 해당 에러 문구를 확인 후에`, task 프로퍼티`는 initialize 되기전에 실행된다? 라는 문구에 초점을 맞추어 `init()` 내부에서 `task`에 값을 할당해주었습니다. 이 부분에 대해서 왜 안되는지에 대해 찾아 보려고 했는데 관련되 키워드를 알 수 없어 여쭤 봅니다.. 이부분에 대한 공부 키워드를 알 수 있을까요??