### PR TITLE
은행 창구 매니저 [STEP 3] 아리, 허황

### DIFF
--- a/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
+++ b/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
@@ -11,7 +11,7 @@
 		08BCF51A27709A6900CF04B9 /* QueueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08BCF51927709A6900CF04B9 /* QueueTests.swift */; };
 		08BCF51C2770A02300CF04B9 /* Queue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08BCF51B2770A02300CF04B9 /* Queue.swift */; };
 		08BCF51E2770A04300CF04B9 /* Queue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08BCF51B2770A02300CF04B9 /* Queue.swift */; };
-		08BF9F282772FB6A00B0D371 /* BankClerk.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08BF9F272772FB6A00B0D371 /* BankClerk.swift */; };
+		08BF9F282772FB6A00B0D371 /* Banker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08BF9F272772FB6A00B0D371 /* Banker.swift */; };
 		9A1FD40B2770545B003EE34C /* LinkedList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A1FD40A2770545B003EE34C /* LinkedList.swift */; };
 		9A1FD4132770549D003EE34C /* LinkedListTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A1FD4122770549D003EE34C /* LinkedListTests.swift */; };
 		9A1FD41727705513003EE34C /* LinkedList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A1FD40A2770545B003EE34C /* LinkedList.swift */; };
@@ -38,7 +38,7 @@
 		085287692778938500EEE020 /* Double+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Double+Extension.swift"; sourceTree = "<group>"; };
 		08BCF51927709A6900CF04B9 /* QueueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QueueTests.swift; sourceTree = "<group>"; };
 		08BCF51B2770A02300CF04B9 /* Queue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Queue.swift; sourceTree = "<group>"; };
-		08BF9F272772FB6A00B0D371 /* BankClerk.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BankClerk.swift; sourceTree = "<group>"; };
+		08BF9F272772FB6A00B0D371 /* Banker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Banker.swift; sourceTree = "<group>"; };
 		9A1FD40A2770545B003EE34C /* LinkedList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkedList.swift; sourceTree = "<group>"; };
 		9A1FD4102770549D003EE34C /* BankManagerConsoleAppTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = BankManagerConsoleAppTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		9A1FD4122770549D003EE34C /* LinkedListTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkedListTests.swift; sourceTree = "<group>"; };
@@ -84,7 +84,7 @@
 				9A1FD40A2770545B003EE34C /* LinkedList.swift */,
 				08BCF51B2770A02300CF04B9 /* Queue.swift */,
 				9AC7C4682772F99700559E56 /* Customer.swift */,
-				08BF9F272772FB6A00B0D371 /* BankClerk.swift */,
+				08BF9F272772FB6A00B0D371 /* Banker.swift */,
 				9AC7C46A2772FDA200559E56 /* Bank.swift */,
 			);
 			path = Model;
@@ -227,7 +227,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				C7694E7A259C3EC00053667F /* main.swift in Sources */,
-				08BF9F282772FB6A00B0D371 /* BankClerk.swift in Sources */,
+				08BF9F282772FB6A00B0D371 /* Banker.swift in Sources */,
 				0852876A2778938500EEE020 /* Double+Extension.swift in Sources */,
 				9AC7C4692772F99700559E56 /* Customer.swift in Sources */,
 				9A3DC9DE27745B840082C8D6 /* BankManagerMessage.swift in Sources */,

--- a/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/xcshareddata/xcschemes/BankManagerConsoleApp.xcscheme
+++ b/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/xcshareddata/xcschemes/BankManagerConsoleApp.xcscheme
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1310"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "C7694E75259C3EC00053667F"
+               BuildableName = "BankManagerConsoleApp"
+               BlueprintName = "BankManagerConsoleApp"
+               ReferencedContainer = "container:BankManagerConsoleApp.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "C7694E75259C3EC00053667F"
+            BuildableName = "BankManagerConsoleApp"
+            BlueprintName = "BankManagerConsoleApp"
+            ReferencedContainer = "container:BankManagerConsoleApp.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "C7694E75259C3EC00053667F"
+            BuildableName = "BankManagerConsoleApp"
+            BlueprintName = "BankManagerConsoleApp"
+            ReferencedContainer = "container:BankManagerConsoleApp.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Model/Bank.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Model/Bank.swift
@@ -50,7 +50,7 @@ final class Bank {
         DispatchQueue.global().async(group: group) {
             while customers.isEmpty == false {
                 guard let customer = customers.dequeue() else {
-                    continue
+                    fatalError()
                 }
                 self.numberOfCustomers += 1
                 banker.work(for: customer)

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Model/Bank.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Model/Bank.swift
@@ -49,10 +49,7 @@ struct Bank {
     private func workBanker(customers: Queue<Customer>, group: DispatchGroup) {
         let banker = Banker()
         DispatchQueue.global().async(group: group) {
-            while customers.isEmpty == false {
-                guard let customer = customers.dequeue() else {
-                    fatalError()
-                }
+            while let customer = customers.dequeue() {
                 banker.work(for: customer)
             }
         }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Model/Bank.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Model/Bank.swift
@@ -47,7 +47,7 @@ final class Bank {
     
     private func workBanker(customers: Queue<Customer>, group: DispatchGroup) {
         let banker = Banker()
-        let workItem = DispatchWorkItem {
+        DispatchQueue.global().async(group: group) {
             while customers.isEmpty == false {
                 guard let customer = customers.dequeue() else {
                     continue
@@ -55,10 +55,7 @@ final class Bank {
                 self.numberOfCustomers += 1
                 banker.work(for: customer)
             }
-            group.leave()
         }
-        group.enter()
-        DispatchQueue.global().async(execute: workItem)
     }
     
     private func closeBank(_ numberOfCustomers: Int, from openTime: Date) {

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Model/Bank.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Model/Bank.swift
@@ -1,10 +1,10 @@
 import Foundation
 
 final class Bank {
-    private let bankClerk: BankClerk
+    private let bankClerk: Banker
     private var customerQueue = Queue<Customer>()
     
-    init(bankClerk: BankClerk) {
+    init(bankClerk: Banker) {
         self.bankClerk = bankClerk
     }
     

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Model/Bank.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Model/Bank.swift
@@ -3,13 +3,13 @@ import Foundation
 final class Bank {
     private var loanCustomerQueue = Queue<Customer>()
     private var depositCustomerQueue = Queue<Customer>()
-    private let loanBankersNumber: Int
-    private let depositBankersNumber: Int
+    private let loanBankersCount: Int
+    private let depositBankersCount: Int
     private var numberOfCustomers = 0
     
     init(loanBankersCount: Int = 1, depositBankersCount: Int = 2) {
-        self.loanBankersNumber = loanBankersCount
-        self.depositBankersNumber = depositBankersCount
+        self.loanBankersCount = loanBankersCount
+        self.depositBankersCount = depositBankersCount
     }
     
     func handOutWaitingNumber(from customerNumber: Int) {
@@ -32,8 +32,8 @@ final class Bank {
         let bankGroup = DispatchGroup()
         let openTime = Date()
         
-        workBankers(loanBankersNumber, customers: loanCustomerQueue, group: bankGroup)
-        workBankers(depositBankersNumber, customers: depositCustomerQueue, group: bankGroup)
+        workBankers(loanBankersCount, customers: loanCustomerQueue, group: bankGroup)
+        workBankers(depositBankersCount, customers: depositCustomerQueue, group: bankGroup)
         
         bankGroup.wait()
         closeBank(numberOfCustomers, from: openTime)

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Model/Bank.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Model/Bank.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-final class Bank {
+struct Bank {
     private var loanCustomerQueue = Queue<Customer>()
     private var depositCustomerQueue = Queue<Customer>()
     private let loanBankersCount: Int
@@ -12,7 +12,8 @@ final class Bank {
         self.depositBankersCount = depositBankersCount
     }
     
-    func handOutWaitingNumber(from customerNumber: Int) {
+    mutating func handOutWaitingNumber(from customerNumber: Int) {
+        numberOfCustomers = customerNumber
         for number in 1...customerNumber {
             let customer = Customer(waitingNumber: number)
             customerQueue(customer.banking).enqueue(customer)
@@ -28,7 +29,7 @@ final class Bank {
         }
     }
     
-    func openBank() {
+    mutating func openBank() {
         let bankGroup = DispatchGroup()
         let openTime = Date()
         
@@ -52,13 +53,12 @@ final class Bank {
                 guard let customer = customers.dequeue() else {
                     fatalError()
                 }
-                self.numberOfCustomers += 1
                 banker.work(for: customer)
             }
         }
     }
     
-    private func closeBank(_ numberOfCustomers: Int, from openTime: Date) {
+    private mutating func closeBank(_ numberOfCustomers: Int, from openTime: Date) {
         let durationTime = -openTime.timeIntervalSinceNow
         print("업무가 마감되었습니다. 오늘 업무를 처리한 고객은 총 \(numberOfCustomers)명이며, 총 업무시간은 \(durationTime.roundedOffDescription(for: 2))초 입니다.")
         self.numberOfCustomers = 0

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Model/BankManager.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Model/BankManager.swift
@@ -8,7 +8,7 @@ enum Menu {
 struct BankManager {
     private let bank: Bank
     
-    init(bank: Bank) {
+    init(bank: Bank = Bank()) {
         self.bank = bank
     }
     

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Model/BankManager.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Model/BankManager.swift
@@ -6,7 +6,7 @@ enum Menu {
 }
 
 struct BankManager {
-    private let bank: Bank
+    private var bank: Bank
     
     init(bank: Bank = Bank()) {
         self.bank = bank
@@ -30,7 +30,7 @@ struct BankManager {
         }
     }
     
-    private func setUpBankCustomers(to range: ClosedRange<Int> = 10...30) {
+    private mutating func setUpBankCustomers(to range: ClosedRange<Int> = 10...30) {
         let numberOfCustomers = Int.random(in: range)
         bank.handOutWaitingNumber(from: numberOfCustomers)
     }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Model/Banker.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Model/Banker.swift
@@ -7,7 +7,6 @@ struct Banker {
     
     func work(for customer: Customer) {
         let banking = customer.banking
-        
         print("\(customer.waitingNumber)번 고객 \(banking.description)업무 시작")
         Thread.sleep(forTimeInterval: workSpeed(customer.banking))
         print("\(customer.waitingNumber)번 고객 \(banking.description)업무 완료")

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Model/Banker.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Model/Banker.swift
@@ -1,14 +1,10 @@
 import Foundation
 
 struct Banker {
-    private func workSpeed(_ banking: Banking) -> TimeInterval {
-        return banking.speed
-    }
-    
     func work(for customer: Customer) {
         let banking = customer.banking
         print("\(customer.waitingNumber)번 고객 \(banking.description)업무 시작")
-        Thread.sleep(forTimeInterval: workSpeed(customer.banking))
+        Thread.sleep(forTimeInterval: banking.speed)
         print("\(customer.waitingNumber)번 고객 \(banking.description)업무 완료")
     }
 }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Model/Banker.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Model/Banker.swift
@@ -1,15 +1,13 @@
 import Foundation
 
-final class BankClerk {
-    private let workSpeed: TimeInterval
-    
-    init(workSpeed: TimeInterval = 0.7) {
-        self.workSpeed = workSpeed
+struct Banker {
+    private func workSpeed(_ banking: Banking) -> TimeInterval {
+        return banking.speed
     }
     
     func work(for customer: Customer) {
         print("\(customer.waitingNumber)번 고객 업무 시작")
-        Thread.sleep(forTimeInterval: workSpeed)
+        Thread.sleep(forTimeInterval: workSpeed(customer.banking))
         print("\(customer.waitingNumber)번 고객 업무 완료")
     }
 }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Model/Banker.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Model/Banker.swift
@@ -6,8 +6,10 @@ struct Banker {
     }
     
     func work(for customer: Customer) {
-        print("\(customer.waitingNumber)번 고객 업무 시작")
+        let banking = customer.banking
+        
+        print("\(customer.waitingNumber)번 고객 \(banking.description)업무 시작")
         Thread.sleep(forTimeInterval: workSpeed(customer.banking))
-        print("\(customer.waitingNumber)번 고객 업무 완료")
+        print("\(customer.waitingNumber)번 고객 \(banking.description)업무 완료")
     }
 }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Model/Customer.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Model/Customer.swift
@@ -1,5 +1,29 @@
 import Foundation
 
+enum Banking: CaseIterable {
+    case loan
+    case deposit
+    
+    static var random: Banking {
+        return .allCases.randomElement() ?? .loan
+    }
+    
+    var speed: TimeInterval {
+        switch self {
+        case .loan:
+            return 1.1
+        case .deposit:
+            return 0.7
+        }
+    }
+}
+
 struct Customer {
+    let banking: Banking
     let waitingNumber: Int
+    
+    init(banking: Banking = .random, waitingNumber: Int) {
+        self.banking = banking
+        self.waitingNumber = waitingNumber
+    }
 }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Model/Customer.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Model/Customer.swift
@@ -1,8 +1,8 @@
 import Foundation
 
-enum Banking: CaseIterable {
-    case loan
-    case deposit
+enum Banking: String, CaseIterable {
+    case loan = "대출"
+    case deposit = "예금"
     
     static var random: Banking {
         return .allCases.randomElement() ?? .loan
@@ -15,6 +15,10 @@ enum Banking: CaseIterable {
         case .deposit:
             return 0.7
         }
+    }
+    
+    var description: String {
+        return self.rawValue
     }
 }
 

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Model/LinkedList.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Model/LinkedList.swift
@@ -12,6 +12,7 @@ final class LinkedList<Element> {
     
     private var head: Node<Element>?
     private var tail: Node<Element>?
+    private let serialQueue = DispatchQueue(label: "LinkedListDispatchQueue")
     
     var first: Element? {
         return head?.value
@@ -35,12 +36,14 @@ final class LinkedList<Element> {
     
     @discardableResult
     func removeFirst() -> Element? {
-        guard isEmpty == false else {
-            return nil
+        var result: Element?
+        serialQueue.sync {
+            guard isEmpty == false else {
+                return
+            }
+            result = head?.value
+            head = head?.next
         }
-        let result = head?.value
-        head = head?.next
-        
         return result
     }
     

--- a/BankManagerConsoleApp/BankManagerConsoleApp/main.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/main.swift
@@ -1,8 +1,7 @@
 import Foundation
 
 func run() {
-    let bank = Bank()
-    var bankManager = BankManager(bank: bank)
+    var bankManager = BankManager()
     var isRunning = true
     while isRunning {
         bankManager.showMenu()

--- a/BankManagerConsoleApp/BankManagerConsoleApp/main.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/main.swift
@@ -1,8 +1,7 @@
 import Foundation
 
 func run() {
-    let bankClerk = Banker()
-    let bank = Bank(bankClerk: bankClerk)
+    let bank = Bank()
     var bankManager = BankManager(bank: bank)
     var isRunning = true
     while isRunning {

--- a/BankManagerConsoleApp/BankManagerConsoleApp/main.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/main.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 func run() {
-    let bankClerk = BankClerk(workSpeed: 0.7)
+    let bankClerk = Banker()
     let bank = Bank(bankClerk: bankClerk)
     var bankManager = BankManager(bank: bank)
     var isRunning = true


### PR DESCRIPTION
안녕하세요 델마 @delmaSong  🙌🏻
아리 @leeari95 , 허황 @hwangjeha입니다.
은행 창구 매니저 프로젝트 STEP 3 구현 완료해서 PR 보냅니다. 
저번에 와주셔서 직접 코드리뷰해주셔서 덕분에 많은 도움이 되었어요. 감사했습니다! 😆 
궁금했던 점, 조언이 필요한 부분 이 외에 저희가 놓친 부분이나 부족한 부분이 있다면 번거롭더라도 한번 더 짚어주시면 감사하겠습니다.🙏🏻

## 고민했던 점

### 1. 다중 처리

- 여러 은행원이 동시에 고객의 일을 처리하는 로직을 고민해봤습니다.
1. `global() 큐`에 은행원의 수 만큼 `task`를 만들고 각각의 `task`에서 고객을 `dequeue`해서 처리하는 방식
2. 하나의 while 구문에서 dequeue 해주고 고객의 은행 업무에 따라 예금 고객은 `DispatchQueue.global()`에 세마포어를 이용해 `은행원 수 == 접근 가능한 스레드 수`  만드는 방식
    - `DispatchSemaphore`의 `value`를 1이 아닌 2나 3으로 줄 경우 `Race Condition`이 발생할 수 있다는 가능성이 존재하기 때문에 해당 방법은 적절하지 못하다는 생각이 들었습니다.
    - `Banker`가 가지고 있는 `work()` 메소드는 현재 공유자원에 접근하고 있지 않지만, 추후 해당 메소드가 공유자원에 접근하지 않을거라는 보장이 없다라는 생각이 들었습니다.
- 추후 은행원의 수가 변경되더라도 대응할 수 있도록 은행원 수 만큼 `DispatchQueue.global()`에 `task`를 만드는 `1번 방식`으로 구현했습니다.
    - `은행원 수` == `DispatchQueue의 수`

### 2. 대기번호 오름차순으로 업무를 할 수 있도록 처리

- 프로젝트 실행예시에는 대기번호 순으로 실행되고 있지 않은 점을 발견하게 되었습니다.
    - 이 부분을 야곰에게 질문해보았고, 순차적으로 업무를 할 수 있도록 구현해보라고 하셔서 고민하게 되었습니다.
- 저희는 대기번호 순으로 `차례대로 업무가 처리되야 된다고 생각`했기 때문에 대출업무와 예금업무를 보는 고객들을 `두개의 고객큐`로 나누어 관리하도록 구현했습니다.

### 3. CustomStringConvertible을 사용하지 않고 연산프로퍼티를 사용

- `Banking`의 경우 `rawValue`를 `String`으로 가지고 있는 형태인데, 이 부분을 은행원이 어떤 업무를 처리했는지 알려주기 위해 사용하려는 의도로 구현하게 되었습니다. `프로토콜 채택`과 `연산프로퍼티` 중에 어떤 방식으로 활용할 지 고민해보았습니다.
    - `CustomStringConvertible`의 경우 인스턴스를 원하는 형태의 문자열로 반환하고 싶을 때 채택하여 사용하는 프로토콜로 저희가 활용하고자 하였던 부분이랑은 적합하지 않다는 생각이 들었습니다.
    - 따라서 description이라는 연산프로퍼티를 활용하여 rawValue를 반환하도록 구현해주었습니다.

## 궁금했던 점 / 조언이 필요한 부분

### 들여쓰기 vs 함수 호출 단계

- `Bank` 타입 `workBanker()` 메소드에서 들여쓰기가 가독성을 해치는것 같아 따로 `Dispatch.global().async` 클로져 부분을 따로 함수로 분리해주면 어떨까라는 고민을 했습니다.
- 현재 코드 구조는 `openBank()`내부에서 `workBankers()`를 호출하고 `workBankers()`내부에서 `workBanker()`를 호출하는 3단계의 구조를 가지고 있어 함수를 또 분리할 경우 오히려 가독성을 해치는게 아닌가 라는 고민을 했습니다.
    
    ```swift
    // 현재 코드
    private func workBanker(customers: Queue<Customer>, group: DispatchGroup) {
        let banker = Banker()
        DispatchQueue.global().async(group: group) {
            while customers.isEmpty == false {
                guard let customer = customers.dequeue() else {
                    fatalError()
                }
                self.numberOfCustomers += 1
                banker.work(for: customer)
            }
        }
    }
    ```
    
    ```swift
    // 들여쓰기 개선하려고 별도의 함수로 분리
    // 함수를 분리할 경우 함수 호출 구조가 4단계가 됨.
    private func workBanker(customers: Queue<Customer>, group: DispatchGroup) {
        DispatchQueue.global().async(group: group) {
            self.createBankerTask(customers: customers)
        }
    }
        
    private func createBankerTask(customers: Queue<Customer>) {
        let banker = Banker()
            
        while customers.isEmpty == false {
            guard let customer = customers.dequeue() else {
                fatalError()
            }
            self.numberOfCustomers += 1
            banker.work(for: customer)
        }
    }
    ```
    

## 해결이 되지 않은 점

### 구조체 프로퍼티는 클로저 내부에서 변경할 수 없음

```swift
// 간단한 코드 예시
struct SomeStruct {
    var num = 0
    
    private mutating func test() {
        let closure = { // Escaping closure captures mutating 'self' parameter
            self.num += 1
        }
        closure()
    }
}
```

- `Escaping closure`의 경우 구조체에서는 캡쳐가 불가능하기 때문에, 프로퍼티를 변경하려고 하면 위와 같은 에러가 발생하게 됩니다.
    
    > class와 같은 참조 타입이 아닌 Struct, enum과 같은 값타입에서는 mutating reference의 캡쳐를 허용하지 않기 때문에 self 사용이 불가능 하다.
    > 
- 저희가 `Bank`가 `구조체`였을 때 은행원이 일을 할 때, 처리한 고객의 수를 `Dispatch.global().async` 클로저 내에서 카운트(`numberOfCustomers`) 해주도록 하려고 했으나 위와 같은 에러가 발생하여 구조체일 때 개선해보고자 하였지만 방법을 찾지 못해서 결국엔 클래스로 구현을 해주었는데요.
- 이러한 상황일 경우 클래스 말고 다른 방법으로 개선할 수 있는 방법은 없을까요?

이번 피드백도 잘 부탁드립니다! 😆 🙌🏻