### PR TITLE
은행 창구 매니저 [STEP 3] 제인, 차차

### DIFF
--- a/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
+++ b/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		C96C94BC277160240024CA10 /* Queue.swift in Sources */ = {isa = PBXBuildFile; fileRef = C96C94BB277160240024CA10 /* Queue.swift */; };
 		C9CF741B277452D800D15158 /* Customer.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9CF741A277452D800D15158 /* Customer.swift */; };
 		C9CF741D277474D200D15158 /* BankClerk.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9CF741C277474D200D15158 /* BankClerk.swift */; };
+		CEF5CAB6277B301D00EC5E20 /* Task.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEF5CAB5277B301D00EC5E20 /* Task.swift */; };
 		EA5DE3362771670600DE4B2A /* QueueTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA5DE3352771670600DE4B2A /* QueueTest.swift */; };
 		EA5DE33A2771678B00DE4B2A /* Queue.swift in Sources */ = {isa = PBXBuildFile; fileRef = C96C94BB277160240024CA10 /* Queue.swift */; };
 		EA5DE33B2771678E00DE4B2A /* LinkedList.swift in Sources */ = {isa = PBXBuildFile; fileRef = C96C94B92770A9020024CA10 /* LinkedList.swift */; };
@@ -42,6 +43,7 @@
 		C96C94BB277160240024CA10 /* Queue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Queue.swift; sourceTree = "<group>"; };
 		C9CF741A277452D800D15158 /* Customer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Customer.swift; sourceTree = "<group>"; };
 		C9CF741C277474D200D15158 /* BankClerk.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BankClerk.swift; sourceTree = "<group>"; };
+		CEF5CAB5277B301D00EC5E20 /* Task.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Task.swift; sourceTree = "<group>"; };
 		EA5DE3332771670600DE4B2A /* BankManagerTest.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = BankManagerTest.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		EA5DE3352771670600DE4B2A /* QueueTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QueueTest.swift; sourceTree = "<group>"; };
 		EA5DE365277456AD00DE4B2A /* Bank.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Bank.swift; sourceTree = "<group>"; };
@@ -104,6 +106,7 @@
 		EA5DE36E2775A2EB00DE4B2A /* Model */ = {
 			isa = PBXGroup;
 			children = (
+				CEF5CAB5277B301D00EC5E20 /* Task.swift */,
 				C9CF741A277452D800D15158 /* Customer.swift */,
 				EA5DE3A62779E9EA00DE4B2A /* BankFactory.swift */,
 				EA5DE365277456AD00DE4B2A /* Bank.swift */,
@@ -210,6 +213,7 @@
 				C7694E7A259C3EC00053667F /* main.swift in Sources */,
 				EA5DE366277456AD00DE4B2A /* Bank.swift in Sources */,
 				C7D65D1B259C8190005510E0 /* BankPrinter.swift in Sources */,
+				CEF5CAB6277B301D00EC5E20 /* Task.swift in Sources */,
 				C96C94BC277160240024CA10 /* Queue.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Model/Bank.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Model/Bank.swift
@@ -11,39 +11,23 @@ protocol BankDelegate: AnyObject {
     func printClosingMessage(customers: Int, processingTime: Double)
 }
 
-protocol BankTransactionable: AnyObject {
-    func dequeue() -> Customer?
-    func isCustomerQueueEmpty() -> Bool
-    func open()
-    func close(totalCustomers: Int, totalProcessingTime: Double)
-}
-
-class Bank: BankTransactionable {
+class Bank {
     private let customerQueue: Queue<Customer> = Queue<Customer>()
     private var bankClerk: BankClerk
     private weak var delegate: BankDelegate?
     
     init(bankClerk: BankClerk, delegatee: BankDelegate) {
         self.bankClerk = bankClerk
-        self.bankClerk.setBank(bank: self)
         self.delegate = delegatee
         setupCustomerQueue()
     }
     
     private func setupCustomerQueue() {
-        let randomCustomerCount: Int = 10//Int.random(in: 10...30)
+        let randomCustomerCount: Int = Int.random(in: 10...30)
         
         (1...randomCustomerCount).forEach { number in
             customerQueue.enqueue(value: Customer(turn: number))
         }
-    }
-    
-    func dequeue() -> Customer? {
-        return customerQueue.dequeue()
-    }
-    
-    func isCustomerQueueEmpty() -> Bool {
-        return customerQueue.isEmpty
     }
     
     func open() {

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Model/Bank.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Model/Bank.swift
@@ -37,7 +37,7 @@ class Bank {
         let bankGroup = DispatchGroup()
         
         var processedCustomers = 0
-        let startTime = CFAbsoluteTimeGetCurrent()
+        let startTime = DispatchTime.now()
         
         while let customer = customerQueue.dequeue() {
             switch customer.task {
@@ -57,8 +57,9 @@ class Bank {
         
         bankGroup.wait()
         
-        let endTime = CFAbsoluteTimeGetCurrent()
-        let totalProcessingTime = endTime - startTime
+        let endTime = DispatchTime.now()
+        
+        let totalProcessingTime = Double(endTime.uptimeNanoseconds - startTime.uptimeNanoseconds)
         close(totalCustomers: processedCustomers, totalProcessingTime: totalProcessingTime)
     }
     

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Model/Bank.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Model/Bank.swift
@@ -31,7 +31,7 @@ class Bank: BankTransactionable {
     }
     
     private func setupCustomerQueue() {
-        let randomCustomerCount: Int = Int.random(in: 10...30)
+        let randomCustomerCount: Int = 10//Int.random(in: 10...30)
         
         (1...randomCustomerCount).forEach { number in
             customerQueue.enqueue(value: Customer(turn: number))
@@ -47,7 +47,35 @@ class Bank: BankTransactionable {
     }
     
     func open() {
-        bankClerk.work()
+        let semaphore = DispatchSemaphore(value: 2)
+        let depositQueue = DispatchQueue(label: "deposit", attributes: .concurrent)
+        let loanQueue = DispatchQueue(label: "loan")
+        let bankGroup = DispatchGroup()
+        
+        var processedCustomers = 0
+        let startTime = CFAbsoluteTimeGetCurrent()
+        
+        while let customer = customerQueue.dequeue() {
+            switch customer.task {
+            case .deposit:
+                depositQueue.async(group: bankGroup) {
+                    semaphore.wait()
+                    self.bankClerk.work(with: customer)
+                    semaphore.signal()
+                }
+            case .loan:
+                loanQueue.async(group: bankGroup) {
+                    self.bankClerk.work(with: customer)
+                }
+            }
+            processedCustomers += 1
+        }
+        
+        bankGroup.wait()
+        
+        let endTime = CFAbsoluteTimeGetCurrent()
+        let totalProcessingTime = endTime - startTime
+        close(totalCustomers: processedCustomers, totalProcessingTime: totalProcessingTime)
     }
     
     func close(totalCustomers: Int, totalProcessingTime: Double) {

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Model/BankClerk.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Model/BankClerk.swift
@@ -38,7 +38,7 @@ class BankClerk {
             
             self.processWork(of: customer, group: bankWorkGroup)
             customerCount += 1
-            totalProcessingTime += customer.processingTime
+            totalProcessingTime += customer.task.processingTime
         }
         
         while bank?.isCustomerQueueEmpty() == false {
@@ -52,7 +52,7 @@ class BankClerk {
     
     private func processWork(of customer: Customer, group: DispatchGroup) {
         delegate?.printBeginWorkMessage(of: customer)
-        group.wait(timeout: .now() + customer.processingTime)
+        group.wait(timeout: .now() + customer.task.processingTime)
         delegate?.printFinishWorkMessage(of: customer)
     }
 }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Model/BankClerk.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Model/BankClerk.swift
@@ -16,7 +16,7 @@ class BankClerk {
     private weak var bank: BankTransactionable?
     private weak var delegate: BankClerkDelegate?
     
-    init(delegatee: BankClerkDelegate) {        
+    init(delegatee: BankClerkDelegate) {
         self.delegate = delegatee
     }
     
@@ -24,30 +24,14 @@ class BankClerk {
         self.bank = bank
     }
     
-    func work() {
-        let bankWorkGroup = DispatchGroup()
-        let bankWorkQueue = DispatchQueue(label: "BankWork")
+    func work(with customer: Customer) {
+        let workGroup = DispatchGroup()
         
-        var customerCount: Int = 0
-        var totalProcessingTime: Double = 0
+        workGroup.enter()
+        self.processWork(of: customer, group: workGroup)
+        workGroup.leave()
         
-        let bankWorkItem = DispatchWorkItem {
-            guard let customer = self.bank?.dequeue() else {
-                return
-            }
-            
-            self.processWork(of: customer, group: bankWorkGroup)
-            customerCount += 1
-            totalProcessingTime += customer.task.processingTime
-        }
-        
-        while bank?.isCustomerQueueEmpty() == false {
-            bankWorkQueue.async(group: bankWorkGroup, execute: bankWorkItem)
-        }
-        
-        bankWorkGroup.wait()
-        
-        bank?.close(totalCustomers: customerCount, totalProcessingTime: totalProcessingTime)
+        workGroup.wait()
     }
     
     private func processWork(of customer: Customer, group: DispatchGroup) {
@@ -56,4 +40,3 @@ class BankClerk {
         delegate?.printFinishWorkMessage(of: customer)
     }
 }
-    

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Model/BankClerk.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Model/BankClerk.swift
@@ -13,15 +13,10 @@ protocol BankClerkDelegate: AnyObject {
 }
 
 class BankClerk {
-    private weak var bank: BankTransactionable?
     private weak var delegate: BankClerkDelegate?
     
     init(delegatee: BankClerkDelegate) {
         self.delegate = delegatee
-    }
-    
-    func setBank(bank: BankTransactionable) {
-        self.bank = bank
     }
     
     func work(with customer: Customer) {

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Model/BankPrinter.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Model/BankPrinter.swift
@@ -16,11 +16,11 @@ extension BankPrinter: BankDelegate {
 
 extension BankPrinter: BankClerkDelegate {
     func printBeginWorkMessage(of customer: Customer) {
-        print("\(customer.turn)번 고객 업무 시작")
+        print("\(customer.turn)번 고객 \(customer.task.description)업무 시작")
     }
     
     func printFinishWorkMessage(of customer: Customer) {
-        print("\(customer.turn)번 고객 업무 완료")
+        print("\(customer.turn)번 고객 \(customer.task.description)업무 완료")
     }
 }
 

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Model/BankPrinter.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Model/BankPrinter.swift
@@ -10,7 +10,7 @@ class BankPrinter { }
 
 extension BankPrinter: BankDelegate {
     func printClosingMessage(customers: Int, processingTime: Double) {
-        print("업무가 마감되었습니다. 오늘 업무를 처리한 고객은 총 \(customers)명이며, 총 업무시간은 \(processingTime.formatted)초입니다.")
+        print("업무가 마감되었습니다. 오늘 업무를 처리한 고객은 총 \(customers)명이며, 총 업무시간은 \(processingTime.formattedToSecond)초입니다.")
     }
 }
 
@@ -25,7 +25,8 @@ extension BankPrinter: BankClerkDelegate {
 }
 
 private extension Double {
-    var formatted : String {
-        return String(format: "%.2f", self)
+    var formattedToSecond : String {
+        let second = self / 1000000000
+        return String(format: "%.2f", second)
     }
 }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Model/Customer.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Model/Customer.swift
@@ -17,9 +17,18 @@ struct Customer {
     }
 }
 
-enum Task: CaseIterable {
+enum Task: CustomStringConvertible {
     case deposit
     case loan
+    
+    var description: String {
+        switch self {
+        case .deposit:
+            return "예금"
+        case .loan:
+            return "대출"
+        }
+    }
     
     var processingTime: Double {
         switch self {
@@ -29,7 +38,9 @@ enum Task: CaseIterable {
             return 0.7
         }
     }
-    
+}
+
+extension Task: CaseIterable {
     static func createRandomTask() -> Self {
         guard let task = Self.allCases.randomElement() else {
             fatalError()

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Model/Customer.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Model/Customer.swift
@@ -16,35 +16,3 @@ struct Customer {
         self.task = Task.createRandomTask()
     }
 }
-
-enum Task: CustomStringConvertible {
-    case deposit
-    case loan
-    
-    var description: String {
-        switch self {
-        case .deposit:
-            return "예금"
-        case .loan:
-            return "대출"
-        }
-    }
-    
-    var processingTime: Double {
-        switch self {
-        case .deposit:
-            return 1.1
-        case .loan:
-            return 0.7
-        }
-    }
-}
-
-extension Task: CaseIterable {
-    static func createRandomTask() -> Self {
-        guard let task = Self.allCases.randomElement() else {
-            fatalError()
-        }
-        return task
-    }
-}

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Model/Customer.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Model/Customer.swift
@@ -9,5 +9,31 @@ import Foundation
 
 struct Customer {
     var turn: Int
-    var processingTime: Double = 0.7
+    var task: Task
+    
+    init(turn: Int) {
+        self.turn = turn
+        self.task = Task.createRandomTask()
+    }
+}
+
+enum Task: CaseIterable {
+    case deposit
+    case loan
+    
+    var processingTime: Double {
+        switch self {
+        case .deposit:
+            return 1.1
+        case .loan:
+            return 0.7
+        }
+    }
+    
+    static func createRandomTask() -> Self {
+        guard let task = Self.allCases.randomElement() else {
+            fatalError()
+        }
+        return task
+    }
 }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Model/Task.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Model/Task.swift
@@ -1,0 +1,40 @@
+//
+//  Task.swift
+//  BankManagerConsoleApp
+//
+//  Created by user on 2021/12/28.
+//
+
+import Foundation
+
+enum Task: CustomStringConvertible {
+    case deposit
+    case loan
+    
+    var description: String {
+        switch self {
+        case .deposit:
+            return "예금"
+        case .loan:
+            return "대출"
+        }
+    }
+    
+    var processingTime: Double {
+        switch self {
+        case .deposit:
+            return 1.1
+        case .loan:
+            return 0.7
+        }
+    }
+}
+
+extension Task: CaseIterable {
+    static func createRandomTask() -> Self {
+        guard let task = Self.allCases.randomElement() else {
+            fatalError()
+        }
+        return task
+    }
+}

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Model/Task.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Model/Task.swift
@@ -33,7 +33,7 @@ enum Task: CustomStringConvertible {
 extension Task: CaseIterable {
     static func createRandomTask() -> Self {
         guard let task = Self.allCases.randomElement() else {
-            fatalError()
+            fatalError("랜덤한 Task를 생성할 수 없습니다.")
         }
         return task
     }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/main.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/main.swift
@@ -17,9 +17,9 @@ func printMenu() {
 
 func runProgram() {
     let bankPrinter = BankPrinter()
-    let bank = BankFactory.createBank(with: bankPrinter)
     
     while true {
+        let bank = BankFactory.createBank(with: bankPrinter)
         printMenu()
         let userInput = readLine()
         


### PR DESCRIPTION
안녕하세요 찰리 @kcharliek 🙇‍♀️
은행 창구 매니저 Step 3 완료하여 PR 보내드립니다.
잘 부탁드립니다! 👍



# 고민했던 부분

## 1. 동시성 프로그래밍 

은행원의 수를 쓰레드라고 생각하였고, 고객의 업무 종류에 따라 depositQueue, loanQueue를 만들어주었습니다. 
depositQueue는 concurrent하게 loanQueue는 serial하게 만들었습니다.

while문의 조건으로 customerQueue에서 customer을 dequeue하는 것을 설정하여 공유자원에는 한 번씩만 접근하도록 설계하였습니다. 

deposit 케이스에서는 비동기적으로 동작하는 concurrent 큐에서
semaphore를 사용하여 동시에 접근가능한 스레드의 수를 2로 두어서 deposit을 처리하는 은행원이 동시에 두명이 되도록 구현하였습니다. 

반면에 loan 케이스에서는 일을 처리하는 은행원이 한 명이기때문에 비동기적으로 동작하는 serial큐를 사용하였습니다. 



## 2. fatalError를 사용한 이유 
```swift
static func createRandomTask() -> Self {
    guard let task = Self.allCases.randomElement() else {
        fatalError("랜덤한 Task를 생성할 수 없습니다.")
    }
    return task
}
```
`Task` enum 에서 랜덤한 task를 열거형의 모든 case에서 골라서 리턴해주는 메서드에서 `fatalError()`을 사용하였는데요, 처음에는 error enum을 따로 만들어줘서 에러처리를 해주려고 했지만, 로직상 절대 발생할 수 없는 에러이기때문에 에러처리가 불필요하다고 생각하여 fatalError로 구현하였습니다. (apple이 검증한 메서드라고 생각했습니다!)

## 3. BankClerk의 역할

앞서 고민했던 부분에 따라 구현하다 보니 `BankClerk`가 delegate 패턴을 통해 `Bank`를 알게하는 방식이 필요없게 되었습니다. 이에 이 관계를 제거해주었고, 기존 customer queue에서 dequeue하던 부분을 Bank가 하도록 이전하였습니다.

## 4. 총 업무 시간 측정하는 방식 

기존에는 BankClerk가 처리하는 고객의 소요 시간을 일일이 합하여 이를 계산했었는데, 시스템 시간을 활용하여 개선하였습니다. `CFAbsoluteTimeGetCurrent()` 메서드를 사용하여 시작/끝 시간을 기록하고 이 시간들의 차를 총 업무시간으로 하였습니다.

# 질문드리고 싶은 부분 

## 1. `Queue`의 `peek()` 메서드

`Queue` 타입의 `peek()` 메서드를 사용해보려고 시도하였다 실패했습니다.
아래에서 질문드린 부분처럼 처음에는 `peek()`를 통해 customer의 task를 확인하고 각각의 queue에 할당 한 후 각 쓰레드 내에서 customerQueue에 접근하여 dequeue하는 방식으로 구현해보려했습니다...

```swift
func open() {
    let group = DispatchGroup()
    let depositQueue = DispatchQueue(label: "deposit", attributes: .concurrent)
    let loanQueue = DispatchQueue(label: "loan")
    let semaphore = DispatchSemaphore(value: 2)

    while !customerQueue.isEmpty {
        switch customerQueue.peek()?.task {
        case .deposit:
            depositQueue.async(group: group) {
                semaphore.wait()
                self.bankClerk.work() //여기서 dequeue를 한다.
                semaphore.signal()
            }
        case .loan:
            loanQueue.async {
                self.bankClerk.work() //여기서 dequeue를 한다.
            }

        default:
            return
        }
    }

    group.wait()
}
```

```swift
func work() {
    guard let customer = self.bank?.dequeue() else {
        return
    }
    self.processWork(of: customer)
}
```

이렇게 시도해보다가 race condition을 해결하지 못하여, 아예 외부에서 dequeue하여 각 큐에 넣어주는 방식으로 변경하게 되었습니다. 이에 `peek()` 메서드의 필요성을 느끼지 못하여 사용하지 않게 되었습니다. 

혹시.. 이 코드를 개선할 수 있는 방법이 있는지 궁금합니다... 


## 2. Race condition을 피하는 동시성 프로그래밍

기존에 `BankClerk`의 `work()` 메서드에서 공유 자원에 접근하는 부분(customerQueue에서 dequeue)이 있었는데요, 이 때문에 동시성 프로그래밍과 race condition을 해결해주기 어려워서 공유 자원에 접근하는 부분을 제거하여 해결해주었습니다. 

이에 조금은 꼼수(?)같은 방식으로 해결한 것 같은데요. 처음에는 semaphore를 통해 접근 가능한 쓰레드의 수를 제어해주려고 했으나, semaphore가 1이 넘게 되는 순간 race condition이 발생할 가능성이 생기게 될 것이라고 생각했습니다. 

이에 race condition을 해결하기 위해 serial queue를 만드는 방법도 생각해보았으나 비동기적으로 동작해야하는 요구사항과는 조금 다른 부분이 있어 결국 앞서 말씀드린 것 처럼 해결하게 되었습니다. 

현재와 같은 상황에서 공유자원에 접근도 하면서 동시성 프로그래밍을 하려면 어떻게 설계해야 할 지 느낌이 잘 오지 않아서, 현재 저희가 구현한 방법이 적합한지, 혹은 다른 좋은 방법이 있다면 조금의 힌트를 주실 수 있을지 궁금합니다!


## 3. `LocalizedError` 프로토콜의 사용 목적에 대해

얼핏 듣기로는 `LocalizedError` 프로토콜은 사용자의 기기 언어 설정과 관련된 이슈를 처리하기위해 사용된다는 말을 들었던 것 같습니다. 기존에는 `LocalizedError`에서 지원하는 기본적인 description을 사용하기 위해 여러 환경에서 채택하여 사용했었는데, 현업에서는 어떤 식으로 사용하시는지 궁금합니다!