### PR TITLE
은행 창구 매니저 [STEP 3] 아샌, 신나

### DIFF
--- a/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
+++ b/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		4747860F2774594D005DF6C4 /* Bank.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4747860E2774594D005DF6C4 /* Bank.swift */; };
 		47478611277565FE005DF6C4 /* BankManagerConsole.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47478610277565FE005DF6C4 /* BankManagerConsole.swift */; };
+		475B04EE277AE308006D70B6 /* BankClerk.swift in Sources */ = {isa = PBXBuildFile; fileRef = 475B04ED277AE308006D70B6 /* BankClerk.swift */; };
 		4788F785277066120067596D /* LinkedList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4788F784277066120067596D /* LinkedList.swift */; };
 		4788F79027716F840067596D /* CustomerQueueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4788F78F27716F840067596D /* CustomerQueueTests.swift */; };
 		4788F79427716F8E0067596D /* LinkedListTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C132FF7C2770702D0054DE4B /* LinkedListTests.swift */; };
@@ -40,6 +41,7 @@
 /* Begin PBXFileReference section */
 		4747860E2774594D005DF6C4 /* Bank.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Bank.swift; sourceTree = "<group>"; };
 		47478610277565FE005DF6C4 /* BankManagerConsole.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BankManagerConsole.swift; sourceTree = "<group>"; };
+		475B04ED277AE308006D70B6 /* BankClerk.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BankClerk.swift; sourceTree = "<group>"; };
 		4788F784277066120067596D /* LinkedList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkedList.swift; sourceTree = "<group>"; };
 		4788F78D27716F840067596D /* BankManagerConsoleAppTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = BankManagerConsoleAppTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		4788F78F27716F840067596D /* CustomerQueueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomerQueueTests.swift; sourceTree = "<group>"; };
@@ -115,6 +117,7 @@
 				C7694E79259C3EC00053667F /* main.swift */,
 				47478610277565FE005DF6C4 /* BankManagerConsole.swift */,
 				4747860E2774594D005DF6C4 /* Bank.swift */,
+				475B04ED277AE308006D70B6 /* BankClerk.swift */,
 				C1E99DB72774580A00ADF963 /* Customer.swift */,
 				C168CF7A277166490055560E /* CustomerQueue.swift */,
 				C168CF7C2771747D0055560E /* LinkedList */,
@@ -233,6 +236,7 @@
 				4788F785277066120067596D /* LinkedList.swift in Sources */,
 				C7D65D1B259C8190005510E0 /* BankManager.swift in Sources */,
 				C168CF7E277174AB0055560E /* LinkedListError.swift in Sources */,
+				475B04EE277AE308006D70B6 /* BankClerk.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
+++ b/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		C168CF7B277166490055560E /* CustomerQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = C168CF7A277166490055560E /* CustomerQueue.swift */; };
 		C168CF7E277174AB0055560E /* LinkedListError.swift in Sources */ = {isa = PBXBuildFile; fileRef = C168CF7D277174AB0055560E /* LinkedListError.swift */; };
 		C168CF7F277174B40055560E /* LinkedListError.swift in Sources */ = {isa = PBXBuildFile; fileRef = C168CF7D277174AB0055560E /* LinkedListError.swift */; };
+		C1D7AE5F277AE8290061C273 /* BankService.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1D7AE5E277AE8290061C273 /* BankService.swift */; };
 		C1E99DB82774580A00ADF963 /* Customer.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1E99DB72774580A00ADF963 /* Customer.swift */; };
 		C7694E7A259C3EC00053667F /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7694E79259C3EC00053667F /* main.swift */; };
 		C7D65D1B259C8190005510E0 /* BankManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7D65D1A259C8190005510E0 /* BankManager.swift */; };
@@ -49,6 +50,7 @@
 		C132FF7C2770702D0054DE4B /* LinkedListTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkedListTests.swift; sourceTree = "<group>"; };
 		C168CF7A277166490055560E /* CustomerQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomerQueue.swift; sourceTree = "<group>"; };
 		C168CF7D277174AB0055560E /* LinkedListError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkedListError.swift; sourceTree = "<group>"; };
+		C1D7AE5E277AE8290061C273 /* BankService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BankService.swift; sourceTree = "<group>"; };
 		C1E99DB72774580A00ADF963 /* Customer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Customer.swift; sourceTree = "<group>"; };
 		C7694E76259C3EC00053667F /* BankManagerConsoleApp */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = BankManagerConsoleApp; sourceTree = BUILT_PRODUCTS_DIR; };
 		C7694E79259C3EC00053667F /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
@@ -119,6 +121,7 @@
 				4747860E2774594D005DF6C4 /* Bank.swift */,
 				475B04ED277AE308006D70B6 /* BankClerk.swift */,
 				C1E99DB72774580A00ADF963 /* Customer.swift */,
+				C1D7AE5E277AE8290061C273 /* BankService.swift */,
 				C168CF7A277166490055560E /* CustomerQueue.swift */,
 				C168CF7C2771747D0055560E /* LinkedList */,
 			);
@@ -233,6 +236,7 @@
 				C7694E7A259C3EC00053667F /* main.swift in Sources */,
 				47478611277565FE005DF6C4 /* BankManagerConsole.swift in Sources */,
 				C168CF7B277166490055560E /* CustomerQueue.swift in Sources */,
+				C1D7AE5F277AE8290061C273 /* BankService.swift in Sources */,
 				4788F785277066120067596D /* LinkedList.swift in Sources */,
 				C7D65D1B259C8190005510E0 /* BankManager.swift in Sources */,
 				C168CF7E277174AB0055560E /* LinkedListError.swift in Sources */,

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
@@ -39,19 +39,17 @@ struct Bank {
         }
     }
     
-    private func operateTask() {
-        let bankTaskQueue = DispatchQueue(label: "Bank")
+    private mutating func operateTask() {
         for _ in numberOfCustomerRange {
-            bankTaskQueue.sync {
-                takeTask()
-            }
+            takeTask()
         }
+        taskGroup.wait()
     }
     
-    private func takeTask() {
+    private mutating func takeTask() {
         do {
             let customer = try customerQueue.dequeue()
-            task(of: customer)
+            enqueueTask(of: customer)
         } catch LinkedListError.dataDoesNotExist {
             print(LinkedListError.dataDoesNotExist.description)
         } catch {

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
@@ -12,6 +12,7 @@ struct Bank {
     private var customerQueue: CustomerQueue<Customer>
     private var numberOfCustomer: Int
     private var clerk: BankClerk
+    private let taskGroup: DispatchGroup
     
     private var numberOfCustomerRange: ClosedRange<Int> {
         return 1...numberOfCustomer
@@ -21,6 +22,7 @@ struct Bank {
         self.customerQueue = CustomerQueue()
         self.numberOfCustomer = Int.random(in: numberOfCustomerRange)
         self.clerk = BankClerk(depositClerkCount: 2, loanClerkCount: 1)
+        self.taskGroup = DispatchGroup()
     }
     
     mutating func open() {
@@ -54,6 +56,13 @@ struct Bank {
             print(LinkedListError.dataDoesNotExist.description)
         } catch {
             print(error.localizedDescription)
+        }
+    }
+    
+    private mutating func enqueueTask(of customer: Customer) {
+        let clerk = clerk.assignClerk(of: customer.task)
+        clerk.async(group: taskGroup) { [self] in
+            self.task(of: customer)
         }
     }
     

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
@@ -61,7 +61,7 @@ struct Bank {
         let number = customer.turn
         let task = customer.task.koreanDescription
         print(Message.taskStart(turn: number, service: task).description)
-        Thread.sleep(forTimeInterval: DefaultValue.taskTimeInterval)
+        Thread.sleep(forTimeInterval: customer.task.processingTime)
         print(Message.taskEnd(turn: number, service: task).description)
     }
     
@@ -97,7 +97,6 @@ private extension Bank {
     
     struct DefaultValue {
         static let numberOfCustomerRange = 10...30
-        static let taskTimeInterval = 0.7
     }
     
 }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
@@ -68,11 +68,11 @@ struct Bank {
     private mutating func enqueueTask(of customer: Customer) {
         let clerk = clerks.assignClerk(of: customer.task)
         clerk.async(group: taskGroup) { [self] in
-            self.task(of: customer)
+            self.executeTask(of: customer)
         }
     }
     
-    private func task(of customer: Customer) {
+    private func executeTask(of customer: Customer) {
         printTaskStartMessage(of: customer)
         Thread.sleep(forTimeInterval: customer.task.processingTime)
         printTaskEndMessage(of: customer)

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
@@ -27,7 +27,9 @@ struct Bank {
     
     mutating func open() {
         enqueueCustomer()
+        let startTime = Date()
         operateTask()
+        let totalTime = checkTotalTime(from: startTime)
         printTaskEndMessage()
         resetBank()
     }
@@ -37,6 +39,12 @@ struct Bank {
             let customer = Customer(turn: count)
             customerQueue.enqueue(data: customer)
         }
+    }
+    
+    private func checkTotalTime(from startTime: Date) -> String {
+        let totalTime = abs(startTime.timeIntervalSinceNow)
+        let timeDescription = String(format: "%.2f", totalTime)
+        return timeDescription
     }
     
     private mutating func operateTask() {

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
@@ -59,13 +59,14 @@ struct Bank {
     
     private func task(of customer: Customer) {
         let number = customer.turn
-        print(Message.taskStart(turn: number).description)
+        let task = customer.task.koreanDescription
+        print(Message.taskStart(turn: number, service: task).description)
         Thread.sleep(forTimeInterval: DefaultValue.taskTimeInterval)
-        print(Message.taskEnd(turn: number).description)
+        print(Message.taskEnd(turn: number, service: task).description)
     }
     
     private func printTaskEndMessage() {
-        print(Message.totalTaskEnd(count: numberOfCustomer, time: 10))
+        print(Message.totalTaskEnd(count: numberOfCustomer, time: "10"))
     }
     
     private mutating func resetBank() {
@@ -78,16 +79,16 @@ struct Bank {
 private extension Bank {
     
     enum Message {
-        case taskStart(turn: Int)
-        case taskEnd(turn: Int)
-        case totalTaskEnd(count: Int, time: Decimal)
+        case taskStart(turn: Int, service: String)
+        case taskEnd(turn: Int, service: String)
+        case totalTaskEnd(count: Int, time: String)
         
         var description: String {
             switch self {
-            case .taskStart(let turn):
-                return "\(turn)번 고객 업무 시작"
-            case .taskEnd(let turn):
-                return "\(turn)번 고객 업무 완료"
+            case .taskStart(let turn, let service):
+                return "\(turn)번 고객 \(service)업무 시작"
+            case .taskEnd(let turn, let service):
+                return "\(turn)번 고객 \(service)업무 완료"
             case .totalTaskEnd(let count, let time):
                 return "업무가 마감되었습니다. 오늘 업무를 처리한 고객은 총 \(count)명이며, 총 업무시간은 \(time)초입니다."
             }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
@@ -11,19 +11,16 @@ struct Bank {
     
     private var customerQueue: CustomerQueue<Customer>
     private var numberOfCustomer: Int
-    private let taskTime: TimeInterval
+    private var clerk: BankClerk
     
     private var numberOfCustomerRange: ClosedRange<Int> {
         return 1...numberOfCustomer
     }
-    private var totalTaskTime: Decimal {
-        return Decimal(taskTime) * Decimal(numberOfCustomer)
-    }
     
-    init(numberOfCustomerRange: ClosedRange<Int> = DefaultValue.numberOfCustomerRange, taskTime: TimeInterval = DefaultValue.taskTimeInterval) {
+    init(numberOfCustomerRange: ClosedRange<Int> = DefaultValue.numberOfCustomerRange) {
         self.customerQueue = CustomerQueue()
         self.numberOfCustomer = Int.random(in: numberOfCustomerRange)
-        self.taskTime = taskTime
+        self.clerk = BankClerk(depositClerkCount: 2, loanClerkCount: 1)
     }
     
     mutating func open() {
@@ -63,12 +60,12 @@ struct Bank {
     private func task(of customer: Customer) {
         let number = customer.turn
         print(Message.taskStart(turn: number).description)
-        Thread.sleep(forTimeInterval: taskTime)
+        Thread.sleep(forTimeInterval: DefaultValue.taskTimeInterval)
         print(Message.taskEnd(turn: number).description)
     }
     
     private func printTaskEndMessage() {
-        print(Message.totalTaskEnd(count: numberOfCustomer, time: totalTaskTime).description)
+        print(Message.totalTaskEnd(count: numberOfCustomer, time: 10))
     }
     
     private mutating func resetBank() {

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
@@ -30,7 +30,7 @@ struct Bank {
         let startTime = Date()
         operateTask()
         let totalTime = checkTotalTime(from: startTime)
-        printTaskEndMessage()
+        printTaskEndMessage(time: totalTime)
         resetBank()
     }
     
@@ -80,8 +80,8 @@ struct Bank {
         print(Message.taskEnd(turn: number, service: task).description)
     }
     
-    private func printTaskEndMessage() {
-        print(Message.totalTaskEnd(count: numberOfCustomer, time: "10"))
+    private func printTaskEndMessage(time: String) {
+        print(Message.totalTaskEnd(count: numberOfCustomer, time: time).description)
     }
     
     private mutating func resetBank() {

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
@@ -30,7 +30,7 @@ struct Bank {
         let startTime = Date()
         operateTask()
         let totalTime = checkTotalTime(from: startTime)
-        printTaskEndMessage(time: totalTime)
+        printTotalTaskEndMessage(time: totalTime)
         resetBank()
     }
     
@@ -73,14 +73,22 @@ struct Bank {
     }
     
     private func task(of customer: Customer) {
-        let number = customer.turn
-        let task = customer.task.koreanDescription
-        print(Message.taskStart(turn: number, service: task).description)
+        printTaskStartMessage(of: customer)
         Thread.sleep(forTimeInterval: customer.task.processingTime)
-        print(Message.taskEnd(turn: number, service: task).description)
+        printTaskEndMessage(of: customer)
     }
     
-    private func printTaskEndMessage(time: String) {
+    private func printTaskStartMessage(of customer: Customer) {
+        let message = Message.taskStart(turn: customer.turn, service: customer.task)
+        print(message)
+    }
+    
+    private func printTaskEndMessage(of customer: Customer) {
+        let message = Message.taskEnd(turn: customer.turn, service: customer.task)
+        print(message)
+    }
+    
+    private func printTotalTaskEndMessage(time: String) {
         print(Message.totalTaskEnd(count: numberOfCustomer, time: time).description)
     }
     
@@ -93,17 +101,17 @@ struct Bank {
 
 private extension Bank {
     
-    enum Message {
-        case taskStart(turn: Int, service: String)
-        case taskEnd(turn: Int, service: String)
+    enum Message: CustomStringConvertible {
+        case taskStart(turn: Int, service: BankService)
+        case taskEnd(turn: Int, service: BankService)
         case totalTaskEnd(count: Int, time: String)
         
         var description: String {
             switch self {
             case .taskStart(let turn, let service):
-                return "\(turn)번 고객 \(service)업무 시작"
+                return "\(turn)번 고객 \(service.koreanDescription)업무 시작"
             case .taskEnd(let turn, let service):
-                return "\(turn)번 고객 \(service)업무 완료"
+                return "\(turn)번 고객 \(service.koreanDescription)업무 완료"
             case .totalTaskEnd(let count, let time):
                 return "업무가 마감되었습니다. 오늘 업무를 처리한 고객은 총 \(count)명이며, 총 업무시간은 \(time)초입니다."
             }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
@@ -11,7 +11,7 @@ struct Bank {
     
     private var customerQueue: CustomerQueue<Customer>
     private var numberOfCustomer: Int
-    private var clerk: BankClerk
+    private var clerks: BankClerk
     private let taskGroup: DispatchGroup
     
     private var numberOfCustomerRange: ClosedRange<Int> {
@@ -21,7 +21,7 @@ struct Bank {
     init(numberOfCustomerRange: ClosedRange<Int> = DefaultValue.numberOfCustomerRange) {
         self.customerQueue = CustomerQueue()
         self.numberOfCustomer = Int.random(in: numberOfCustomerRange)
-        self.clerk = BankClerk(depositClerkCount: 2, loanClerkCount: 1)
+        self.clerks = BankClerk(depositClerkCount: 2, loanClerkCount: 1)
         self.taskGroup = DispatchGroup()
     }
     
@@ -66,7 +66,7 @@ struct Bank {
     }
     
     private mutating func enqueueTask(of customer: Customer) {
-        let clerk = clerk.assignClerk(of: customer.task)
+        let clerk = clerks.assignClerk(of: customer.task)
         clerk.async(group: taskGroup) { [self] in
             self.task(of: customer)
         }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/BankClerk.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/BankClerk.swift
@@ -15,8 +15,14 @@ struct BankClerk {
     private var loanClerkNumber: Int
     
     init(depositClerkCount: Int, loanClerkCount: Int) {
-        self.depositDepartment = BankClerk.setDepartment(count: depositClerkCount, department: "deposit")
-        self.loanDepartment = BankClerk.setDepartment(count: loanClerkCount, department: "loan")
+        self.depositDepartment = BankClerk.setDepartment(
+            count: depositClerkCount,
+            department: BankService.deposit.englishDescription
+        )
+        self.loanDepartment = BankClerk.setDepartment(
+            count: loanClerkCount,
+            department: BankService.loan.englishDescription
+        )
         self.depositClerkNumber = 0
         self.loanClerkNumber = 0
     }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/BankClerk.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/BankClerk.swift
@@ -1,0 +1,17 @@
+//
+//  BankClerk.swift
+//  BankManagerConsoleApp
+//
+//  Created by Seul Mac on 2021/12/28.
+//
+
+import Foundation
+
+struct BankClerk {
+    
+    let depositDepartment: [DispatchQueue]
+    let loanDepartment: [DispatchQueue]
+    private var depositClerkNumber: Int
+    private var loanClerkNumber: Int
+
+}

--- a/BankManagerConsoleApp/BankManagerConsoleApp/BankClerk.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/BankClerk.swift
@@ -13,5 +13,14 @@ struct BankClerk {
     let loanDepartment: [DispatchQueue]
     private var depositClerkNumber: Int
     private var loanClerkNumber: Int
-
+    
+    private static func setDepartment(count: Int, department: String) -> [DispatchQueue] {
+        var clerkQueue: [DispatchQueue] = []
+        for number in 1...count {
+            let clerk = DispatchQueue(label: "\(department)Clerk\(number)")
+            clerkQueue.append(clerk)
+        }
+        return clerkQueue
+    }
+    
 }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/BankClerk.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/BankClerk.swift
@@ -14,6 +14,13 @@ struct BankClerk {
     private var depositClerkNumber: Int
     private var loanClerkNumber: Int
     
+    init(depositClerkCount: Int, loanClerkCount: Int) {
+        self.depositDepartment = BankClerk.setDepartment(count: depositClerkCount, department: "deposit")
+        self.loanDepartment = BankClerk.setDepartment(count: loanClerkCount, department: "loan")
+        self.depositClerkNumber = 0
+        self.loanClerkNumber = 0
+    }
+    
     private static func setDepartment(count: Int, department: String) -> [DispatchQueue] {
         var clerkQueue: [DispatchQueue] = []
         for number in 1...count {

--- a/BankManagerConsoleApp/BankManagerConsoleApp/BankClerk.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/BankClerk.swift
@@ -30,4 +30,17 @@ struct BankClerk {
         return clerkQueue
     }
     
+    mutating func assignClerk(of department: BankService) -> DispatchQueue {
+        switch department {
+        case .deposit:
+            let clerk = depositDepartment[depositClerkNumber]
+            depositClerkNumber = (depositClerkNumber + 1) % depositDepartment.count
+            return clerk
+        case .loan:
+            let clerk = loanDepartment[loanClerkNumber]
+            loanClerkNumber = (loanClerkNumber + 1) % loanDepartment.count
+            return clerk
+        }
+    }
+    
 }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/BankService.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/BankService.swift
@@ -7,9 +7,14 @@
 
 import Foundation
 
-enum BankService {
+enum BankService: CaseIterable {
     
     case deposit
     case loan
     
+    static func selectRandom() -> BankService {
+        let serviceIndex = Int.random(in: BankService.allCases.indices)
+        let service = BankService.allCases[serviceIndex]
+        return service
+    }
 }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/BankService.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/BankService.swift
@@ -12,6 +12,24 @@ enum BankService: CaseIterable {
     case deposit
     case loan
     
+    var processingTime: Double {
+        switch self {
+        case .deposit:
+            return 0.7
+        case .loan:
+            return 1.1
+        }
+    }
+    
+    var koreanDescription: String {
+        switch self {
+        case .deposit:
+            return "예금"
+        case .loan:
+            return "대출"
+        }
+    }
+    
     static func selectRandom() -> BankService {
         let serviceIndex = Int.random(in: BankService.allCases.indices)
         let service = BankService.allCases[serviceIndex]

--- a/BankManagerConsoleApp/BankManagerConsoleApp/BankService.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/BankService.swift
@@ -30,6 +30,15 @@ enum BankService: CaseIterable {
         }
     }
     
+    var englishDescription: String {
+        switch self {
+        case .deposit:
+            return "deposit"
+        case .loan:
+            return "loan"
+        }
+    }
+    
     static func selectRandom() -> BankService {
         let serviceIndex = Int.random(in: BankService.allCases.indices)
         let service = BankService.allCases[serviceIndex]

--- a/BankManagerConsoleApp/BankManagerConsoleApp/BankService.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/BankService.swift
@@ -1,0 +1,15 @@
+//
+//  BankService.swift
+//  BankManagerConsoleApp
+//
+//  Created by JeongTaek Han on 2021/12/28.
+//
+
+import Foundation
+
+enum BankService {
+    
+    case deposit
+    case loan
+    
+}

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Customer.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Customer.swift
@@ -10,5 +10,6 @@ import Foundation
 struct Customer {
     
     let turn: Int
+    let task: BankService
     
 }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Customer.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Customer.swift
@@ -12,4 +12,8 @@ struct Customer {
     let turn: Int
     let task: BankService
     
+    init(turn: Int) {
+        self.turn = turn
+        self.task = BankService.selectRandom()
+    }
 }


### PR DESCRIPTION
안녕하세요. 흰! @daheenallwhite
아샌(@ICS-Asan), 신나(@smart8612) 입니다. 

프로젝트 STEP3 PR 올립니다! 

이번 스텝은 지적할 부분이 많을 것 같다고 생각이 됩니다😭

어떠한 피드백이라도 저희에게 도움이 많이 될 것 같습니다.

많은 지적과 조언해주시면 같이 고민하고 공부해보겠습니다.

감사합니다!!

### 💻  주요 구현 내용

### <BankService 타입>

- 은행 업무에 대한 타입을 생성
    - 업무에 따른 작업시간이 다르기 때문에 각 작업별로 걸리는 시간을 연산프로퍼티로 구현
    - 출력문에서 해당 업무에 대한 문자열을 받기 위한 연산 프로퍼티 구현
    - Customer인스턴스 생성시 작업을 random하게 갖도록 하기 위해 타입 메서드 구현

### <Customer 타입>

- 손님이 어떠한 업무를 보고싶은지 가지고 있어야 한다고 판단하여 task프로퍼티를 생성
    - 손님이 생성될 때 생성자 내부에서 랜덤한 은행 업무를 갖도록 구현

### <BankClerk 타입>

- 업무별 은행원(DispatchQueue)을 관리하기 위해 DispatchQueue의 배열을 타입으로 갖는 프로퍼티를 생성
    - `예금부서(depositDepartment)`, `대출부서(loanDepartment)`로 구분
- 생성자를 통해 부서별 은행원의 수를 지정하여 은행원(DispatchQueue)을 생성
    - 은행원의 수가 변경되는 경우를 고려하여 코드 구현
    - 내부에서 반복되는 코드를 줄이기 위해 DispatchQueue의 배열을 생성하는 부분을 private 타입메서드를 통해 구현
    - 은행원 1명은 한번에 1가지 일을 하도록 하기 위해 Serial로 생성
- 업무에 따른 은행원(DispatchQueue)을 배정하기 위해 `assignClerk` 구현
    - 각 업무에 해당하는 DispatchQueue에 손님을 고르게 분배하기 위해서 나머지(%) 연산을 활용
        - depositClerkNumber == 해당 부서에서 가져올 은행원의 Index
        - ex) 부서원 3명 → depositClerkNumber = 0 or 1 or 2
        

### < Bank 타입 >

- 업무를 처리하는 과정을 하나로 묶어 관리하기 위해 DispatchGroup(taskGroup)생성
    - 특정 Queue에 비동기로 작업을 전달할 때 taskGroup을 지정
    - operateTask내부의 반복문 밖에 `taskGroup.wait`를 사용하여 그룹의 모든 업무가 끝날때 까지 대기하도록 구현
- 작업 수행 시간을 계산하기 위해 Date 클래스 활용
    - taskGroup의 모든 작업이 수행되는 시간을 측정
    - operateTask가 수행되기 직전 Date 인스턴스를 생성하여 시작 시간을 할당
    - 작업이 끝난 후 Date의 `timeIntervalSinceNow` 프로퍼티로 총 소요 시간을 계산
    - String 생성자의 포멧팅 기능을 사용하여 소수점아래 두자리 출력하도록 설정
- Message의 case에 연관값 추가 구현
    - 요구사항에 맞는 문자열을 출력하기 위해 해당 업무를 문자열으로 받도록 구현

### <  Serial Queue생성 VS Semaphore>

- 요구사항에 은행원이 총 3명 근무한다고 되어있어 이 지점을 명확하게 구현하고 싶었습니다.

> SerialQueue는 한번에 한가지 일을 수행하기 때문에 은행원 1명으로 대입하여 생각하였습니다.
은행원 수에 따라 SerialQueue를 생성해야하는 불편함은 있지만 은행원의 수를 확실하게 관리할 수 있다고 판단했습니다.
> 

> Semaphore를 통해 구현하는 경우 실제 작업하는 스레드는 2개 이지만 여러 스레드가 생성된 것을 확인할 수 있었습니다.
이러한 경우 은행원은 n명이고 동시에 일하는 사람만 2명이라고 판단했습니다.
> 
- 그래서 저희의 의도를 반영하기 위해 Serial Queue를 은행원의 수만큼 생성하여 구현하였습니다.

## 💡   조언 받고 싶은 내용

### < 축약어의 사용 >

> 열거형 케이스 별로 한글 문자열을 반환하는 연산프로퍼티의 이름을 `koreanDescription` 으로 지어주었습니다.
변수명이 너무 길어지기도 하고 실제로 해당 국가의 언어를 출력하는 경우 축약어(ex: kor, eng, jp)를 사용하는 경우가 있는 것 같았습니다.
그래서 고민을 했었는데 축약어는 Swift에서 자주 사용하는 것이 아닌 것 같아 위의 네이밍으로 진행을 하였습니다.
이러한 경우 어떻게 지어주는 것이 좋은지 흰은 어떠한 방식의 네이밍을 선호하는지 궁금합니다.
> 

```swift
// koreanDescription? kor?
var koreanDescription: String { 
}
var kor: String { 
}
```

## ❓   질문할 내용

### < 고려해볼 확장성의 범위 >

> 현재 은행원의 수 만큼 DispatchQueue를 생성 및 관리하기 위해 Clerk라는 타입을 추가로 구현하였습니다.
이번 스텝의 요구사항에서는 2명의 예금 은행원과 1명의 대출 은행원을 요구하고 있습니다.
> 
- 기존엔 Clerk 타입에 2명의 예금 은행원과 1명의 대출 은행원을 갖도록 직접 구현해주었습니다
- 하지만 확장성을 고려하여 은행원을 생성할 수를 지정할 수 있도록 구현하면 좋을 것 같다는 생각으로 현재의 Clerk타입을 구현하였습니다.

> 현재 코드의 경우 작성할 코드의 양이 늘어나지만 요구사항의 변동상황에 유리한 코드라고 생각합니다.
반면 현재 요구사항 내의 측면에서는 불필요하게 많은 코드가 작성되었다고 생각해보았습니다.
> 
- 이러한 경우 확장성을 고려하는 것과 현재 요구사항을 간단하게 구현하는 것에 대한 흰의 의견이 궁금합니다.
- 확장성을 얼마나 고려해야하는 지도 의견이 궁금합니다.

```swift
// 기존 코드
let depositClerk = DispatchQueue(label: "deposit")
let depositClerk1 = DispatchQueue(label: "deposit1")
lazy var deposit: [DispatchQueue] = [depositClerk, depositClerk1]
let loanClerk = DispatchQueue(label: "loan")

```

감사합니다👍