### PR TITLE
은행 창구 매니저 [STEP 3] 릴리, 숲재

### DIFF
--- a/BankManager.swift
+++ b/BankManager.swift
@@ -4,7 +4,11 @@ struct BankManager {
     static private var bank: Bank?
     
     static func createBank(delegate: BankDelegate) {
-        self.bank = Bank(delegate: delegate)
+        self.bank = Bank(
+            delegate: delegate,
+            numberOfBankClerkForDeposit: 1,
+            numberOfBankClerkForLoan: 2
+        )
     }
     
     static func openBank() {

--- a/BankManager.swift
+++ b/BankManager.swift
@@ -4,7 +4,7 @@ struct BankManager {
     static private var bank: Bank?
     
     static func createBank(delegate: BankDelegate) {
-        self.bank = Bank(numberOfBankClerk: 1, delegate: delegate)
+        self.bank = Bank(delegate: delegate)
     }
     
     static func openBank() {

--- a/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
+++ b/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		6309E243277176B700ECCD50 /* Queue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33B3602E2770850400EE24A6 /* Queue.swift */; };
 		633A4B7D2779DFF100498FCC /* ConsoleManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 633A4B7C2779DFF100498FCC /* ConsoleManager.swift */; };
 		637F51B92775BA32009DD2F7 /* NumberFormatter+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 637F51B82775BA32009DD2F7 /* NumberFormatter+Extension.swift */; };
+		63BF0E8C277C44BF002AE5FA /* BankTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63BF0E8B277C44BF002AE5FA /* BankTask.swift */; };
 		63C112EE27705B6700BB79CF /* LinkedList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63C112ED27705B6600BB79CF /* LinkedList.swift */; };
 		C7694E7A259C3EC00053667F /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7694E79259C3EC00053667F /* main.swift */; };
 		C7D65D1B259C8190005510E0 /* BankManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7D65D1A259C8190005510E0 /* BankManager.swift */; };
@@ -46,6 +47,7 @@
 		6309E23D277176AF00ECCD50 /* QueueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QueueTests.swift; sourceTree = "<group>"; };
 		633A4B7C2779DFF100498FCC /* ConsoleManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConsoleManager.swift; sourceTree = "<group>"; };
 		637F51B82775BA32009DD2F7 /* NumberFormatter+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NumberFormatter+Extension.swift"; sourceTree = "<group>"; };
+		63BF0E8B277C44BF002AE5FA /* BankTask.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BankTask.swift; sourceTree = "<group>"; };
 		63C112ED27705B6600BB79CF /* LinkedList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkedList.swift; sourceTree = "<group>"; };
 		C7694E76259C3EC00053667F /* BankManagerConsoleApp */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = BankManagerConsoleApp; sourceTree = BUILT_PRODUCTS_DIR; };
 		C7694E79259C3EC00053667F /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
@@ -79,6 +81,7 @@
 				3358D76E27746F4F004A442D /* Client.swift */,
 				3358D77027746F59004A442D /* BankClerk.swift */,
 				33B70F472779A66A005459ED /* ConsoleBundle.swift */,
+				63BF0E8B277C44BF002AE5FA /* BankTask.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -228,6 +231,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				63BF0E8C277C44BF002AE5FA /* BankTask.swift in Sources */,
 				3358D77127746F59004A442D /* BankClerk.swift in Sources */,
 				63C112EE27705B6700BB79CF /* LinkedList.swift in Sources */,
 				C7694E7A259C3EC00053667F /* main.swift in Sources */,

--- a/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
+++ b/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
@@ -9,7 +9,6 @@
 /* Begin PBXBuildFile section */
 		3358D76D27746F49004A442D /* Bank.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3358D76C27746F49004A442D /* Bank.swift */; };
 		3358D76F27746F4F004A442D /* Client.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3358D76E27746F4F004A442D /* Client.swift */; };
-		3358D77127746F59004A442D /* BankClerk.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3358D77027746F59004A442D /* BankClerk.swift */; };
 		335998B5277AEA8100573933 /* BankDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 335998B4277AEA8100573933 /* BankDelegate.swift */; };
 		33B3602F2770850400EE24A6 /* Queue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33B3602E2770850400EE24A6 /* Queue.swift */; };
 		33B70F482779A66A005459ED /* ConsoleBundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33B70F472779A66A005459ED /* ConsoleBundle.swift */; };
@@ -39,7 +38,6 @@
 /* Begin PBXFileReference section */
 		3358D76C27746F49004A442D /* Bank.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Bank.swift; sourceTree = "<group>"; };
 		3358D76E27746F4F004A442D /* Client.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Client.swift; sourceTree = "<group>"; };
-		3358D77027746F59004A442D /* BankClerk.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BankClerk.swift; sourceTree = "<group>"; };
 		335998B4277AEA8100573933 /* BankDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BankDelegate.swift; sourceTree = "<group>"; };
 		33B3602E2770850400EE24A6 /* Queue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Queue.swift; sourceTree = "<group>"; };
 		33B70F472779A66A005459ED /* ConsoleBundle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConsoleBundle.swift; sourceTree = "<group>"; };
@@ -79,7 +77,6 @@
 				63C112ED27705B6600BB79CF /* LinkedList.swift */,
 				3358D76C27746F49004A442D /* Bank.swift */,
 				3358D76E27746F4F004A442D /* Client.swift */,
-				3358D77027746F59004A442D /* BankClerk.swift */,
 				33B70F472779A66A005459ED /* ConsoleBundle.swift */,
 				63BF0E8B277C44BF002AE5FA /* BankTask.swift */,
 			);
@@ -232,7 +229,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				63BF0E8C277C44BF002AE5FA /* BankTask.swift in Sources */,
-				3358D77127746F59004A442D /* BankClerk.swift in Sources */,
 				63C112EE27705B6700BB79CF /* LinkedList.swift in Sources */,
 				C7694E7A259C3EC00053667F /* main.swift in Sources */,
 				3358D76F27746F4F004A442D /* Client.swift in Sources */,

--- a/BankManagerConsoleApp/BankManagerConsoleApp/ConsoleManager.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/ConsoleManager.swift
@@ -38,10 +38,10 @@ extension ConsoleManager: BankDelegate {
     }
     
     func startWork(for client: Client) {
-        print(ConsoleBundle.TaskMessage.startMessage(clientNumber: client.waitingNumber))        
+        print(ConsoleBundle.TaskMessage.startMessage(client: client))
     }
     
     func finishWork(for client: Client) {
-        print(ConsoleBundle.TaskMessage.completeMessage(clientNumber: client.waitingNumber))
+        print(ConsoleBundle.TaskMessage.completeMessage(client: client))
     }
 }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Model/Bank.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Model/Bank.swift
@@ -3,12 +3,9 @@ import Foundation
 class Bank {
     private var clientQueue: Queue<Client> = Queue<Client>()
     private var completedClientCount: Int = 0
-    private var bankClerks: [BankClerk] = []
-    private var numberOfBankClerk: Int?
-    private let semaphore = DispatchSemaphore(value: 1)
     var delegate: BankDelegate?
     
-    init(numberOfBankClerk: Int, delegate: BankDelegate) {
+    init(delegate: BankDelegate) {
         self.receiveClient()
         self.delegate = delegate
     }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Model/Bank.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Model/Bank.swift
@@ -1,9 +1,11 @@
 import Foundation
 
 class Bank {
+    private var delegate: BankDelegate?
     private var clientQueue: Queue<Client> = Queue<Client>()
     private var completedClientCount: Int = 0
-    var delegate: BankDelegate?
+    private let numberOfBankClerkForDeposit = 2
+    private let numberOfBankClerkForLoan = 1
     
     init(delegate: BankDelegate) {
         self.receiveClient()
@@ -20,7 +22,10 @@ class Bank {
     
     func open() {
         let workHours = measureTime() {
-            self.distributeWork(numberOfBankClerkForDeposit: 2, numberOfBankClerkForLoan: 1)
+            self.distributeWork(
+                inChargeOfDeposits: numberOfBankClerkForDeposit,
+                inChargeOfLoan: numberOfBankClerkForLoan
+            )
         }
         delegate?.closeBusiness(by: completedClientCount, workHours: workHours)
     }
@@ -35,9 +40,9 @@ class Bank {
         return duration
     }
     
-    private func distributeWork(numberOfBankClerkForDeposit: Int, numberOfBankClerkForLoan: Int) {
-        let depositSemaphore = DispatchSemaphore(value: numberOfBankClerkForDeposit)
-        let loanSemaphore = DispatchSemaphore(value: numberOfBankClerkForLoan)
+    private func distributeWork(inChargeOfDeposits: Int, inChargeOfLoan: Int) {
+        let depositSemaphore = DispatchSemaphore(value: inChargeOfDeposits)
+        let loanSemaphore = DispatchSemaphore(value: inChargeOfLoan)
         let group = DispatchGroup()
         
         while let client = self.clientQueue.dequeue() {

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Model/Bank.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Model/Bank.swift
@@ -25,7 +25,7 @@ class Bank {
     
     func open() {
         let workHours = measureTime() {
-            self.distributeWork(
+            self.allocateClientToBankClerk(
                 inChargeOfDeposits: numberOfBankClerkForDeposit,
                 inChargeOfLoan: numberOfBankClerkForLoan
             )
@@ -43,7 +43,7 @@ class Bank {
         return duration
     }
     
-    private func distributeWork(inChargeOfDeposits: Int, inChargeOfLoan: Int) {
+    private func allocateClientToBankClerk(inChargeOfDeposits: Int, inChargeOfLoan: Int) {
         let depositSemaphore = DispatchSemaphore(value: inChargeOfDeposits)
         let loanSemaphore = DispatchSemaphore(value: inChargeOfLoan)
         let group = DispatchGroup()

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Model/Bank.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Model/Bank.swift
@@ -15,7 +15,10 @@ class Bank {
     private func receiveClient() {
         let numberOfClient = Int.random(in: 10...30)
         for number in 1...numberOfClient {
-            let client = Client(waitingNumber: number)
+            guard let bankTask = BankTask.allCases.randomElement() else {
+                return
+            }
+            let client = Client(waitingNumber: number, bankTask: bankTask)
             clientQueue.enqueue(client)
         }
     }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Model/Bank.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Model/Bank.swift
@@ -27,7 +27,7 @@ class Bank {
         let workHours = measureTime() {
             self.allocateClientToBankClerk(
                 inChargeOfDeposits: numberOfBankClerkForDeposit,
-                inChargeOfLoan: numberOfBankClerkForLoan
+                inChargeOfLoans: numberOfBankClerkForLoan
             )
         }
         delegate?.closeBusiness(by: completedClientCount, workHours: workHours)
@@ -43,9 +43,9 @@ class Bank {
         return duration
     }
     
-    private func allocateClientToBankClerk(inChargeOfDeposits: Int, inChargeOfLoan: Int) {
+    private func allocateClientToBankClerk(inChargeOfDeposits: Int, inChargeOfLoans: Int) {
         let depositSemaphore = DispatchSemaphore(value: inChargeOfDeposits)
-        let loanSemaphore = DispatchSemaphore(value: inChargeOfLoan)
+        let loanSemaphore = DispatchSemaphore(value: inChargeOfLoans)
         let group = DispatchGroup()
         
         while let client = self.clientQueue.dequeue() {

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Model/Bank.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Model/Bank.swift
@@ -4,12 +4,18 @@ class Bank {
     private var delegate: BankDelegate?
     private var clientQueue: Queue<Client> = Queue<Client>()
     private var completedClientCount: Int = 0
-    private let numberOfBankClerkForDeposit = 2
-    private let numberOfBankClerkForLoan = 1
+    private let numberOfBankClerkForDeposit: Int
+    private let numberOfBankClerkForLoan: Int
     
-    init(delegate: BankDelegate) {
-        self.receiveClient()
+    init(
+        delegate: BankDelegate,
+        numberOfBankClerkForDeposit: Int,
+        numberOfBankClerkForLoan: Int
+    ) {
         self.delegate = delegate
+        self.numberOfBankClerkForDeposit = numberOfBankClerkForDeposit
+        self.numberOfBankClerkForLoan = numberOfBankClerkForLoan
+        self.receiveClient()
     }
     
     private func receiveClient() {

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Model/BankClerk.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Model/BankClerk.swift
@@ -1,7 +1,0 @@
-import Foundation
-
-struct BankClerk {
-    func work(for client: Client) {
-        Thread.sleep(forTimeInterval: 0.7)
-    }
-}

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Model/BankTask.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Model/BankTask.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+enum BankTask {
+    case deposit
+    case loan
+    
+    var requiredTime: Double {
+        switch self {
+        case .deposit:
+            return 0.7
+        case .loan:
+            return 1.1
+        }
+    }
+}
+
+extension BankTask: CustomStringConvertible {
+    var description: String {
+        switch self {
+        case .deposit:
+            return "예금"
+        case .loan:
+            return "대출"
+        }
+    }
+}

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Model/BankTask.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Model/BankTask.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-enum BankTask {
+enum BankTask: CaseIterable {
     case deposit
     case loan
     

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Model/Client.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Model/Client.swift
@@ -1,5 +1,12 @@
 import Foundation
 
 struct Client {
-    var waitingNumber: Int
+    let waitingNumber: Int
+    let bankTask: BankTask
+    
+    init(waitingNumber: Int) {
+        self.waitingNumber = waitingNumber
+        let task: BankTask! = BankTask.allCases.randomElement()
+        self.bankTask = task
+    }
 }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Model/Client.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Model/Client.swift
@@ -4,9 +4,8 @@ struct Client {
     let waitingNumber: Int
     let bankTask: BankTask
     
-    init(waitingNumber: Int) {
+    init(waitingNumber: Int, bankTask: BankTask) {
         self.waitingNumber = waitingNumber
-        let task: BankTask! = BankTask.allCases.randomElement()
-        self.bankTask = task
+        self.bankTask = bankTask
     }
 }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Model/ConsoleBundle.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Model/ConsoleBundle.swift
@@ -10,11 +10,11 @@ enum ConsoleBundle {
     }
     
     enum TaskMessage {
-        static func startMessage(clientNumber: Int) -> String {
-            return "\(clientNumber)번 고객 업무 시작"
+        static func startMessage(client: Client) -> String {
+            return "\(client.waitingNumber)번 고객 \(client.bankTask)업무 시작"
         }
-        static func completeMessage(clientNumber: Int) -> String {
-            return "\(clientNumber)번 고객 업무 완료"
+        static func completeMessage(client: Client) -> String {
+            return "\(client.waitingNumber)번 고객 \(client.bankTask)업무 완료"
         }
         static func closeMessage(count: Int, duration: String) -> String {
             return "업무가 마감되었습니다. 오늘 업무를 처리한 고객은 총 \(count)명이며, 총 업무시간은 \(duration)초입니다."


### PR DESCRIPTION
안녕하세요! 그린 @GREENOVER 
릴리, 숲재입니다! 
스텝3 구현완료하여 PR요청드립니다😊

# 고민한 점
## 1. BankClerk 타입의 사용
- 시도했던 방법
`distributeClient`메서드에서는 BankClerk객체가 클라이언트 Queue를 순회하며 BankClerk이 가지고 있는 `workType`과 Client의 `workType`이 동일할때만 `remove`메서드를 사용하여 꺼내옵니다. BankClerk 객체를 순회하며 서로 다른 쓰레드에서 비동기적으로 `distributeClient`메서드를 수행하도록 시키는 방법으로 구현했습니다. "예금-예금-예금-대출" 이런 순서로 고객이 존재할때 대출 담당 은행원이 놀고있는 시간을 방지하기 위해서 이렇게 구현하였는데, 고객의 수가 많아지는 경우 탐색 시간이 길어져 불완전한 설계라고 판단하였습니다.(고객이 5만명 정도를 넘어가면 유의미하게 실행시간이 길어지는 것을 확인하였습니다.) 

```swift
     private func makeBankClerksWork() {
        let group = DispatchGroup()
        for bankClerk in bankClerks {
            DispatchQueue.global().async(group: group) {
                self.distributeClient(to: bankClerk)
            }
        }
        group.wait()
    }

    private func distributeClient(to bankClerk: BankClerk) {
        while !self.clientQueue.isEmpty {
            semaphore.wait()
            var i = 0
            while let client = self.clientQueue.peek(i) {
                if client.workType == bankClerk.workType {
                    break
                }
                i += 1
            }
            if let client = self.clientQueue.remove(at: i) {
                semaphore.signal()
                bankClerk.work(for: client)
                semaphore.wait()
                completedClientCount += 1
                semaphore.signal()
            } else {
            semaphore.signal()
            }
        }
    }

```

- 결정한 방법
DispatchSemaphore의 value를 해당 업무를 할 수 있는 은행원의 수라고 정의하고 아래와 같이 구현했습니다. 각각의 업무마다 DispatchSemaphore를 생성하여 배정된 은행원의 수 만큼 value를 부여했습니다.
```swift
let depositSemaphore = DispatchSemaphore(value: inChargeOfDeposits)
let loanSemaphore = DispatchSemaphore(value: inChargeOfLoan)
let group = DispatchGroup()
        
while let client = self.clientQueue.dequeue() {
    DispatchQueue.global().async(group: group) {
        switch client.bankTask {
        case .deposit:
            depositSemaphore.wait()
            self.makeBankClerkWork(for: client)
            depositSemaphore.signal()
        case .loan:
            loanSemaphore.wait()
            self.makeBankClerkWork(for: client)
            loanSemaphore.signal()
            }
        }
    }
group.wait()
}
```
위와 같은 구현을 통해 기존 방법에서 겪었던 문제는 해결이 되는데, BankClerk타입을 살리면서 위와 같은 구현을 유지하는 방법을 찾는데 실패했습니다. 

<br>

# 궁금한 점

## 1. `init()`에서 묵시적 해제 옵셔널로 초기화하는 것
`BankTask.allCases.randomElement()`는 리턴값이 항상 보장되는 상황이기때문에,
리턴값을 저장하는 변수를 묵시적 옵셔널 타입(Implicitly Unwrapped Optional)으로 정의해준 다음 `bankTask`프로퍼티에 할당해주었습니다. 
```swift
struct Client {
    let waitingNumber: Int
    let bankTask: BankTask
    
    init(waitingNumber: Int) {
        self.waitingNumber = waitingNumber
        let task: BankTask! = BankTask.allCases.randomElement()
        self.bankTask = task
    }
}
```
항상 값이 보장되어있는 값을 받는 변수 타입에 대해서는 Implicitly Unwrapped Optional타입을 사용해도 문제가 없을까요? 항상 @IBOutlet 프로퍼티 선언에서만 사용을 해서 이렇게 이니셜라이져에서 사용해주려하니 괜찮은 방법인가 하는 의구심이 들었습니다 (솔직히 말하면 조금 쫄렸습니다..😰)

<br>

읽어주셔서 감사합니다!😄
