### PR TITLE
은행 창구 매니저 [STEP3] Zoe, 고사리

### DIFF
--- a/BankManager.swift
+++ b/BankManager.swift
@@ -11,7 +11,18 @@ class BankManager {
     var bank: WaitingLineManageable?
     private let speaker = Speaker()
     private let calculator = Calculator()
-    private let randomNumber = Int.random(in: 10...30)
+    private var randomNumber = 0
+    
+    let firstEmployeeQueue = DispatchQueue(label: "FirstEmployeeQueue")
+    let secondEmployeeQueue = DispatchQueue(label: "SecondEmployeeQueue")
+    let thirdEmployeeQueue = DispatchQueue(label: "ThirdEmployeeQueue")
+    
+    let group1 = DispatchGroup()
+    let group2 = DispatchGroup()
+    let group3 = DispatchGroup()
+    
+    let semaphore1 = DispatchSemaphore(value: 1)
+    let semaphore2 = DispatchSemaphore(value: 2)
     
     init(employee: Employee) {
         self.employee = employee
@@ -33,39 +44,105 @@ class BankManager {
 
 extension BankManager {
     private func lineUp() {
+        self.randomNumber = Int.random(in: 10...15)
         for number in 1...randomNumber {
-            let customer = Customer(waitingNumber: number)
+            let bankWork = BankWork.allCases.randomElement()!
+            let customer = Customer(waitingNumber: number, requestedWork: bankWork)
             
-            bank?.waitingLine.enqueue(customer)
+            switch customer.requestedWork {
+            case .deposit:
+                bank?.depositWaitingLine.enqueue(customer)
+            case .loan:
+                bank?.loanWaitingLine.enqueue(customer)
+            }
         }
     }
-
+    
     private func assignWork() {
-        let bankManagerQueue = DispatchQueue(label: "BankManagerQueue")
-        let dispatchGroup = DispatchGroup()
+//        let firstEmployeeQueue = DispatchQueue(label: "FirstEmployeeQueue")
+//        let secondEmployeeQueue = DispatchQueue(label: "SecondEmployeeQueue")
+//        let thirdEmployeeQueue = DispatchQueue(label: "ThirdEmployeeQueue")
+//
+//        let group1 = DispatchGroup()
+//        let group2 = DispatchGroup()
+//        let group3 = DispatchGroup()
+//
+//        let semaphore1 = DispatchSemaphore(value: 1)
+//        let semaphore2 = DispatchSemaphore(value: 2)
         
-        let start = DispatchWorkItem {
-            self.employee.startJob()
+        group1.notify(queue: firstEmployeeQueue) {
+            print("group1 끝")
         }
-        let finish = DispatchWorkItem {
-            self.employee.finishJob()
-            dispatchGroup.leave()
+        group2.notify(queue: secondEmployeeQueue) {
+            print("group2 끝")
+        }
+        group3.notify(queue: thirdEmployeeQueue) {
+            print("group3 끝")
         }
         
-        while self.bank?.waitingLine.isEmpty == false {
-            dispatchGroup.enter()
-            bankManagerQueue.async(execute: start)
-            bankManagerQueue.asyncAfter(deadline: .now() + 0.7, execute: finish)
+        repeat {
+            // First Employee
+            group1.enter()
+            firstEmployeeQueue.asyncAfter(deadline: .now() + 0.7) {
+                self.semaphore1.wait()
+                self.employee.startDepositJob()
+                guard let customer = self.bank?.depositWaitingLine.dequeue() else {
+                    self.group1.leave()
+                    
+                    return
+                }
+                
+                print("직원1 시작")
+                self.semaphore1.signal()
+                
+                self.semaphore1.wait()
+                self.employee.finishDepositJob(customer: customer)
+                print("직원1 끝")
+                self.semaphore1.signal()
+                self.group1.leave()
+            }
             
-            dispatchGroup.wait()
-        }
+            // Second Employee
+            group2.enter()
+            secondEmployeeQueue.asyncAfter(deadline: .now() + 0.7) {
+                self.semaphore1.wait()
+                self.employee.startDepositJob()
+                guard let customer = self.bank?.depositWaitingLine.dequeue() else {
+                    self.group2.leave()
+                    
+                    return
+                }
+                
+                print("직원2 시작")
+                self.semaphore1.signal()
+                
+                self.semaphore1.wait()
+                self.employee.finishDepositJob(customer: customer)
+                print("직원2 끝")
+                self.semaphore1.signal()
+                self.group2.leave()
+                
+            }
+        } while self.bank?.depositWaitingLine.isEmpty == false
+        
+        repeat {
+            // Third Employee
+            group3.enter()
+            thirdEmployeeQueue.asyncAfter(deadline: .now() + 1.1) {
+                self.employee.startLoanJob()
+                self.employee.finishLoanJob()
+                
+                self.group3.leave()
+            }
+        } while self.bank?.loanWaitingLine.isEmpty == false
     }
+    
     
     private func reportResult(from openTime: CFAbsoluteTime, to closeTime: CFAbsoluteTime) {
         guard let calculateResult = calculator.calculate(from: openTime, to: closeTime) else {
             return
         }
         
-        speaker.speakClose(number: randomNumber, time: calculateResult)
+        speaker.speakClose(number: employee.customerCount, time: calculateResult)
     }
 }

--- a/BankManager.swift
+++ b/BankManager.swift
@@ -12,17 +12,9 @@ class BankManager {
     private let speaker = Speaker()
     private let calculator = Calculator()
     private var randomNumber = 0
-    
-    let firstEmployeeQueue = DispatchQueue(label: "FirstEmployeeQueue")
-    let secondEmployeeQueue = DispatchQueue(label: "SecondEmployeeQueue")
-    let thirdEmployeeQueue = DispatchQueue(label: "ThirdEmployeeQueue")
-    
-    let group1 = DispatchGroup()
-    let group2 = DispatchGroup()
-    let group3 = DispatchGroup()
-    
-    let semaphore1 = DispatchSemaphore(value: 1)
-    let semaphore2 = DispatchSemaphore(value: 2)
+    private let employeeGroup = DispatchGroup()
+    private let depositSemaphore = DispatchSemaphore(value: 2)
+    private let loanSemaphore = DispatchSemaphore(value: 1)
     
     init(employee: Employee) {
         self.employee = employee
@@ -34,6 +26,7 @@ class BankManager {
         lineUp()
         assignWork()
         
+        employeeGroup.wait()
         let closeTime = CFAbsoluteTimeGetCurrent()
         
         reportResult(from: openTime, to: closeTime)
@@ -48,93 +41,28 @@ extension BankManager {
         for number in 1...randomNumber {
             let bankWork = BankWork.allCases.randomElement()!
             let customer = Customer(waitingNumber: number, requestedWork: bankWork)
-            
-            switch customer.requestedWork {
-            case .deposit:
-                bank?.depositWaitingLine.enqueue(customer)
-            case .loan:
-                bank?.loanWaitingLine.enqueue(customer)
-            }
+            bank?.waitingLine.enqueue(customer)
         }
     }
     
     private func assignWork() {
-//        let firstEmployeeQueue = DispatchQueue(label: "FirstEmployeeQueue")
-//        let secondEmployeeQueue = DispatchQueue(label: "SecondEmployeeQueue")
-//        let thirdEmployeeQueue = DispatchQueue(label: "ThirdEmployeeQueue")
-//
-//        let group1 = DispatchGroup()
-//        let group2 = DispatchGroup()
-//        let group3 = DispatchGroup()
-//
-//        let semaphore1 = DispatchSemaphore(value: 1)
-//        let semaphore2 = DispatchSemaphore(value: 2)
-        
-        group1.notify(queue: firstEmployeeQueue) {
-            print("group1 끝")
-        }
-        group2.notify(queue: secondEmployeeQueue) {
-            print("group2 끝")
-        }
-        group3.notify(queue: thirdEmployeeQueue) {
-            print("group3 끝")
-        }
-        
-        repeat {
-            // First Employee
-            group1.enter()
-            firstEmployeeQueue.asyncAfter(deadline: .now() + 0.7) {
-                self.semaphore1.wait()
-                self.employee.startDepositJob()
-                guard let customer = self.bank?.depositWaitingLine.dequeue() else {
-                    self.group1.leave()
-                    
-                    return
+        while let customer = bank?.waitingLine.dequeue() {
+            switch customer.requestedWork {
+                
+            case .deposit:
+                DispatchQueue.global().async(group: employeeGroup) {
+                    self.depositSemaphore.wait()
+                    self.employee.work(for: customer)
+                    self.depositSemaphore.signal()
                 }
-                
-                print("직원1 시작")
-                self.semaphore1.signal()
-                
-                self.semaphore1.wait()
-                self.employee.finishDepositJob(customer: customer)
-                print("직원1 끝")
-                self.semaphore1.signal()
-                self.group1.leave()
-            }
-            
-            // Second Employee
-            group2.enter()
-            secondEmployeeQueue.asyncAfter(deadline: .now() + 0.7) {
-                self.semaphore1.wait()
-                self.employee.startDepositJob()
-                guard let customer = self.bank?.depositWaitingLine.dequeue() else {
-                    self.group2.leave()
-                    
-                    return
+            case .loan:
+                DispatchQueue.global().async(group: employeeGroup) {
+                    self.loanSemaphore.wait()
+                    self.employee.work(for: customer)
+                    self.loanSemaphore.signal()
                 }
-                
-                print("직원2 시작")
-                self.semaphore1.signal()
-                
-                self.semaphore1.wait()
-                self.employee.finishDepositJob(customer: customer)
-                print("직원2 끝")
-                self.semaphore1.signal()
-                self.group2.leave()
-                
             }
-        } while self.bank?.depositWaitingLine.isEmpty == false
-        
-        repeat {
-            // Third Employee
-            group3.enter()
-            thirdEmployeeQueue.asyncAfter(deadline: .now() + 1.1) {
-                self.employee.startLoanJob()
-                self.employee.finishLoanJob()
-                
-                self.group3.leave()
-            }
-        } while self.bank?.loanWaitingLine.isEmpty == false
+        }
     }
     
     

--- a/BankManager.swift
+++ b/BankManager.swift
@@ -27,6 +27,7 @@ class BankManager {
         assignWork()
         
         employeeGroup.wait()
+        
         let closeTime = CFAbsoluteTimeGetCurrent()
         
         reportResult(from: openTime, to: closeTime)
@@ -37,10 +38,11 @@ class BankManager {
 
 extension BankManager {
     private func lineUp() {
-        self.randomNumber = Int.random(in: 10...15)
+        self.randomNumber = Int.random(in: 10...30)
         for number in 1...randomNumber {
             let bankWork = BankWork.allCases.randomElement()!
             let customer = Customer(waitingNumber: number, requestedWork: bankWork)
+            
             bank?.waitingLine.enqueue(customer)
         }
     }
@@ -48,7 +50,6 @@ extension BankManager {
     private func assignWork() {
         while let customer = bank?.waitingLine.dequeue() {
             switch customer.requestedWork {
-                
             case .deposit:
                 DispatchQueue.global().async(group: employeeGroup) {
                     self.depositSemaphore.wait()
@@ -64,7 +65,6 @@ extension BankManager {
             }
         }
     }
-    
     
     private func reportResult(from openTime: CFAbsoluteTime, to closeTime: CFAbsoluteTime) {
         guard let calculateResult = calculator.calculate(from: openTime, to: closeTime) else {

--- a/BankManager.swift
+++ b/BankManager.swift
@@ -11,7 +11,6 @@ class BankManager {
     var bank: WaitingLineManageable?
     private let speaker = Speaker()
     private let calculator = Calculator()
-    private var randomNumber = 0
     private let employeeGroup = DispatchGroup()
     private let depositSemaphore = DispatchSemaphore(value: 2)
     private let loanSemaphore = DispatchSemaphore(value: 1)
@@ -38,7 +37,7 @@ class BankManager {
 
 extension BankManager {
     private func lineUp() {
-        self.randomNumber = Int.random(in: 10...30)
+        let randomNumber = Int.random(in: 10...30)
         for number in 1...randomNumber {
             let bankWork = BankWork.allCases.randomElement()!
             let customer = Customer(waitingNumber: number, requestedWork: bankWork)

--- a/BankManager.swift
+++ b/BankManager.swift
@@ -14,7 +14,8 @@ class BankManager {
     private let employeeGroup = DispatchGroup()
     private let depositSemaphore = DispatchSemaphore(value: 2)
     private let loanSemaphore = DispatchSemaphore(value: 1)
-    
+    private var customerCount = 0
+
     init(employee: Employee) {
         self.employee = employee
     }
@@ -53,12 +54,14 @@ extension BankManager {
                 DispatchQueue.global().async(group: employeeGroup) {
                     self.depositSemaphore.wait()
                     self.employee.work(for: customer)
+                    self.customerCount += 1
                     self.depositSemaphore.signal()
                 }
             case .loan:
                 DispatchQueue.global().async(group: employeeGroup) {
                     self.loanSemaphore.wait()
                     self.employee.work(for: customer)
+                    self.customerCount += 1
                     self.loanSemaphore.signal()
                 }
             }
@@ -70,6 +73,6 @@ extension BankManager {
             return
         }
         
-        speaker.speakClose(number: employee.customerCount, time: calculateResult)
+        speaker.speakClose(number: self.customerCount, time: calculateResult)
     }
 }

--- a/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
+++ b/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		0DB9BA142770B4B1003F7B21 /* Queue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DB9BA132770B4B1003F7B21 /* Queue.swift */; };
 		0DB9BA162770BBF2003F7B21 /* QueueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DB9BA152770BBF2003F7B21 /* QueueTests.swift */; };
 		0DB9BA172770BCC0003F7B21 /* Queue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DB9BA132770B4B1003F7B21 /* Queue.swift */; };
+		3B1F20B2277C3F5000E4C2FC /* BankWork.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B1F20B1277C3F5000E4C2FC /* BankWork.swift */; };
 		3B62088C2779BDBF0071E623 /* Calculator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B62088B2779BDBF0071E623 /* Calculator.swift */; };
 		3BE4CC662770707B00178845 /* LinkedList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BE4CC652770707B00178845 /* LinkedList.swift */; };
 		3BE4CC702770902600178845 /* LinkedListTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BE4CC6F2770902600178845 /* LinkedListTests.swift */; };
@@ -47,6 +48,7 @@
 		0D693F1B2779A84000736D4C /* Speaker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Speaker.swift; sourceTree = "<group>"; };
 		0DB9BA132770B4B1003F7B21 /* Queue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Queue.swift; sourceTree = "<group>"; };
 		0DB9BA152770BBF2003F7B21 /* QueueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QueueTests.swift; sourceTree = "<group>"; };
+		3B1F20B1277C3F5000E4C2FC /* BankWork.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BankWork.swift; sourceTree = "<group>"; };
 		3B62088B2779BDBF0071E623 /* Calculator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Calculator.swift; sourceTree = "<group>"; };
 		3BE4CC652770707B00178845 /* LinkedList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkedList.swift; sourceTree = "<group>"; };
 		3BE4CC6D2770902600178845 /* BanckManagerConsoleAppTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = BanckManagerConsoleAppTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -137,6 +139,7 @@
 				C7694E79259C3EC00053667F /* main.swift */,
 				0D4FA8622775550A00577BB1 /* Bank.swift */,
 				C7D65D1A259C8190005510E0 /* BankManager.swift */,
+				3B1F20B1277C3F5000E4C2FC /* BankWork.swift */,
 				0D4FA8642775563A00577BB1 /* Customer.swift */,
 				0D4FA8662775624D00577BB1 /* Employee.swift */,
 				3B62088E2779E73B0071E623 /* Funtional Type */,
@@ -249,6 +252,7 @@
 				0D4FA8672775624D00577BB1 /* Employee.swift in Sources */,
 				C7694E7A259C3EC00053667F /* main.swift in Sources */,
 				3B62088C2779BDBF0071E623 /* Calculator.swift in Sources */,
+				3B1F20B2277C3F5000E4C2FC /* BankWork.swift in Sources */,
 				0D693F1C2779A84000736D4C /* Speaker.swift in Sources */,
 				0D4FA85F2774BAA200577BB1 /* StarterMessage.swift in Sources */,
 				0D4FA85D2774BA6C00577BB1 /* Starter.swift in Sources */,

--- a/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
+++ b/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
@@ -137,10 +137,10 @@
 				3BE4CC642770705700178845 /* Queue */,
 				3B62088D2779E6DE0071E623 /* Starter */,
 				C7694E79259C3EC00053667F /* main.swift */,
-				0D4FA8622775550A00577BB1 /* Bank.swift */,
-				C7D65D1A259C8190005510E0 /* BankManager.swift */,
-				3B1F20B1277C3F5000E4C2FC /* BankWork.swift */,
 				0D4FA8642775563A00577BB1 /* Customer.swift */,
+				0D4FA8622775550A00577BB1 /* Bank.swift */,
+				3B1F20B1277C3F5000E4C2FC /* BankWork.swift */,
+				C7D65D1A259C8190005510E0 /* BankManager.swift */,
 				0D4FA8662775624D00577BB1 /* Employee.swift */,
 				3B62088E2779E73B0071E623 /* Funtional Type */,
 			);

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
@@ -8,13 +8,15 @@
 import Foundation
 
 protocol WaitingLineManageable {
-    var waitingLine: Queue<Customer> { get }
+    var depositWaitingLine: Queue<Customer> { get }
+    var loanWaitingLine: Queue<Customer> { get }
 }
-
+    
 class Bank: WaitingLineManageable  {
     private weak var employee: Employee?
     private weak var bankManager: BankManager?
-    let waitingLine = Queue<Customer>()
+    let depositWaitingLine = Queue<Customer>()
+    let loanWaitingLine = Queue<Customer>()
 
     init(employee: Employee, bankManager: BankManager) {
         self.employee = employee

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
@@ -12,14 +12,11 @@ protocol WaitingLineManageable {
 }
     
 class Bank: WaitingLineManageable  {
-    private weak var employee: Employee?
     private weak var bankManager: BankManager?
     let waitingLine = Queue<Customer>()
 
     init(employee: Employee, bankManager: BankManager) {
-        self.employee = employee
         self.bankManager = bankManager
-        self.employee?.bank = self
         self.bankManager?.bank = self
     }
     

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
@@ -8,15 +8,13 @@
 import Foundation
 
 protocol WaitingLineManageable {
-    var depositWaitingLine: Queue<Customer> { get }
-    var loanWaitingLine: Queue<Customer> { get }
+    var waitingLine: Queue<Customer> { get }
 }
     
 class Bank: WaitingLineManageable  {
     private weak var employee: Employee?
     private weak var bankManager: BankManager?
-    let depositWaitingLine = Queue<Customer>()
-    let loanWaitingLine = Queue<Customer>()
+    let waitingLine = Queue<Customer>()
 
     init(employee: Employee, bankManager: BankManager) {
         self.employee = employee

--- a/BankManagerConsoleApp/BankManagerConsoleApp/BankWork.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/BankWork.swift
@@ -1,0 +1,22 @@
+//
+//  BankWorkType.swift
+//  BankManagerConsoleApp
+//
+//  Created by 권나영 on 2021/12/29.
+//
+
+import Foundation
+
+enum BankWork: CaseIterable {
+    case deposit
+    case loan
+    
+    var koreanDescription: String {
+        switch self {
+        case .deposit:
+            return "예금"
+        case .loan:
+            return "대출"
+        }
+    }
+}

--- a/BankManagerConsoleApp/BankManagerConsoleApp/BankWork.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/BankWork.swift
@@ -19,4 +19,13 @@ enum BankWork: CaseIterable {
             return "대출"
         }
     }
+    
+    var requiredTime: Double {
+        switch self {
+        case .deposit:
+            return 0.7
+        case .loan:
+            return 1.1
+        }
+    }
 }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Customer.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Customer.swift
@@ -9,4 +9,7 @@ import Foundation
 
 struct Customer {
     var waitingNumber: Int
+    var requestedWork: BankWork {
+        BankWork.allCases.randomElement()!
+    }
 }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Customer.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Customer.swift
@@ -9,7 +9,5 @@ import Foundation
 
 struct Customer {
     var waitingNumber: Int
-    var requestedWork: BankWork {
-        BankWork.allCases.randomElement()!
-    }
+    var requestedWork: BankWork
 }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Employee.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Employee.swift
@@ -10,24 +10,37 @@ import Foundation
 class Employee {
     var bank: WaitingLineManageable?
     let speaker = Speaker()
-    private let seconds = 0.7
-    private var customerCount = 0
+    var customerCount = 0
     
-    func startJob() {
-        guard let customer = bank?.waitingLine.first else {
+    func startLoanJob() {
+        guard let customer = bank?.loanWaitingLine.first else {
             return
         }
-        
-        speaker.speakStart(for: customer.waitingNumber)
+                
+        speaker.speakStart(for: customer.waitingNumber, workType: customer.requestedWork)
     }
     
-    func finishJob() {
-        guard let customer = bank?.waitingLine.dequeue() else {
+    func finishLoanJob() {
+        guard let customer = bank?.loanWaitingLine.dequeue() else {
             return
         }
         
         customerCount += 1
-        
-        speaker.speakFinish(for: customer.waitingNumber)
+
+        speaker.speakFinish(for: customer.waitingNumber, workType: customer.requestedWork)
+    }
+    
+    func startDepositJob() {
+        guard let customer = bank?.depositWaitingLine.first else {
+            return
+        }
+                
+        speaker.speakStart(for: customer.waitingNumber, workType: customer.requestedWork)
+    }
+    
+    func finishDepositJob(customer: Customer) {
+        customerCount += 1
+
+        speaker.speakFinish(for: customer.waitingNumber, workType: customer.requestedWork)
     }
 }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Employee.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Employee.swift
@@ -8,39 +8,15 @@
 import Foundation
 
 class Employee {
-    var bank: WaitingLineManageable?
-    let speaker = Speaker()
+    private let speaker = Speaker()
     var customerCount = 0
     
-    func startLoanJob() {
-        guard let customer = bank?.loanWaitingLine.first else {
-            return
+    func work(for customer: Customer) {
+            speaker.speakStart(for: customer.waitingNumber, workType: customer.requestedWork)
+            
+            Thread.sleep(forTimeInterval: customer.requestedWork.requiredTime)
+            customerCount += 1
+            
+            speaker.speakFinish(for: customer.waitingNumber, workType: customer.requestedWork)
         }
-                
-        speaker.speakStart(for: customer.waitingNumber, workType: customer.requestedWork)
-    }
-    
-    func finishLoanJob() {
-        guard let customer = bank?.loanWaitingLine.dequeue() else {
-            return
-        }
-        
-        customerCount += 1
-
-        speaker.speakFinish(for: customer.waitingNumber, workType: customer.requestedWork)
-    }
-    
-    func startDepositJob() {
-        guard let customer = bank?.depositWaitingLine.first else {
-            return
-        }
-                
-        speaker.speakStart(for: customer.waitingNumber, workType: customer.requestedWork)
-    }
-    
-    func finishDepositJob(customer: Customer) {
-        customerCount += 1
-
-        speaker.speakFinish(for: customer.waitingNumber, workType: customer.requestedWork)
-    }
 }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Employee.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Employee.swift
@@ -9,13 +9,11 @@ import Foundation
 
 class Employee {
     private let speaker = Speaker()
-    var customerCount = 0
     
     func work(for customer: Customer) {
             speaker.speakStart(for: customer.waitingNumber, workType: customer.requestedWork)
             
             Thread.sleep(forTimeInterval: customer.requestedWork.requiredTime)
-            customerCount += 1
             
             speaker.speakFinish(for: customer.waitingNumber, workType: customer.requestedWork)
         }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Funtional Type/Speaker.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Funtional Type/Speaker.swift
@@ -8,12 +8,12 @@
 import Foundation
 
 struct Speaker {
-    func speakStart(for number: Int) {
-        print("\(number) 번 고객 업무 시작")
+    func speakStart(for number: Int, workType: BankWork) {
+        print("\(number) 번 고객 \(workType.koreanDescription)업무 시작")
     }
     
-    func speakFinish(for number: Int) {
-        print("\(number) 번 고객 업무 완료")
+    func speakFinish(for number: Int, workType: BankWork) {
+        print("\(number) 번 고객 \(workType.koreanDescription)업무 완료")
     }
     
     func speakClose(number: Int, time: String) {


### PR DESCRIPTION
안녕하세요, 찰리~!! @kcharliek 
Step3의 PR 요쳥드립니다🙏

마지막까지 잘 부탁드립니다!!

## 1. 고민한 점

1-1. BankWorkType.allCases.ramdomElement() 옵셔널 바인딩을 어떻게 해줄 것인가를 고민했습니다. 아래 두 가지 중, BankWork가 빈 열거형이 아니기 때문에 문제가 없다고 판단하여 후자 (강제 언래핑)를 선택했습니다.

```swift
var requestedWork: BankWork {
        guard let work = BankWork.allCases.randomElement() else {
            return BankWork.loan
        }

        return work
}
```

```swift
var requestedWork: BankWork {
        BankWork.allCases.randomElement()!
}
```

1-2. 업무의 시작과 종료를 구분짓기 위해서 async와 asyncAfter로 분리되는 작업을 하나로 변경해주었습니다.

- 이때 시작 단에서 찾은 first와 종료 단에서 찾은 first가 다른 것을 확인하였습니다.
    - 시작단에서 dequeue를 해주면서 반환값을 받고, 받은 값을 종료 메서드의 파라미터에 넣어서 해결하였습니다.

1-3. Step2에서 사용되었던 `asyncAfter`는 `Thread.sleep()`으로 변경하였습니다.

- asyncAfter를 사용하였을 때의 문제
    
![](https://i.imgur.com/0X6goZ5.png)

while문 내부에 위치한 비동기 작업이 멈추는 동안, 계속 조건을 확인하는 while에 의해 group1.enter()가 만 회 가까이 불리게 됩니다. 그러나 그 횟수에 미치지 못하는 group1.leave()로 인해 group1은 기다림에 응답하지 못합니다. (추가 설명은 아래의 추가실험에 작성하였습니다)

1-4. 처음에는 은행원 각각이 큐를 가지고 있어야 한다고 생각했으나, 현재는 디스패치큐를 커스텀하지 않고 global() 큐를 이용하여 비 동기적으로 작업을 수행하도록 구현했습니다.

1-5. 예금과 대출 고객큐를 하나의 큐로 합쳤습니다. 그리고  semaphore의 value 값을 `(예금2, 대출1)` 로 설정하여, 접근할 수 있는 스레드의 개수를 제한했습니다. (추가 설명은 아래의 추가실험에 작성하였습니다)

## 2. 궁금한 점

2-1. semaphore.wait() 의 위치

- 1번과 2번 방식의 차이가 궁금합니다.
- 더 정확히는 처음에 저희는 1번 방식이 맞다고 생각했습니다. 왜냐하면 비동기 작업을 하기 전에, wait()을 해서 접근할 수 있는 스레드의 수를 제한해야 한다고 생각했습니다. 그런데 오히려 1번이 비정상적으로 작동을 하고 있어서(사진 1) 둘이 어떤 차이가 있는지 궁금합니다. 🙋🏻‍♀️

1번. async 전에 `semaphore.wait()` 을 걸기 (비 정상 작동)

```swift
private func assignWork() {
        while let customer = bank?.waitingLine.dequeue() {
            switch customer.requestedWork {
            case .deposit:
                
                self.depositSemaphore.wait() // 이 부분
                DispatchQueue.global().async(group: employeeGroup) {
                    self.employee.work(for: customer)
                    self.depositSemaphore.signal()
                }
                
            case .loan:
                self.loanSemaphore.wait() // 이 부분
                DispatchQueue.global().async(group: employeeGroup) {
                    self.employee.work(for: customer)
                    self.loanSemaphore.signal()
                }
            }
        }
    }
```

2번. async 전에 `semaphore.wait()` 을 걸기 (정상작동)

```swift
private func assignWork() {
        while let customer = bank?.waitingLine.dequeue() {
            switch customer.requestedWork {
            case .deposit:
                DispatchQueue.global().async(group: employeeGroup) {
                    self.depositSemaphore.wait()
                    self.employee.work(for: customer)
                    self.depositSemaphore.signal()
                }
            case .loan:
                DispatchQueue.global().async(group: employeeGroup) {
                    self.loanSemaphore.wait()
                    self.employee.work(for: customer)
                    self.loanSemaphore.signal()
                }
            }
        }
    }
```

⬇️ **사진1**

사진에서 1,2,3 이 대출 / 4,5,6이 예금일 때 원래대로 라면 `1(대출), 4(예금), 5(예금)` 로 시작해야 하는데
대출업무만 시작하는 상황이 발생합니다

<img src="https://i.imgur.com/cQ11lb7.png" width="50%" height="40%">

## 3. 추가 실험: 왜 group.enter()는 만 번이 넘도록 호출될까요?

group.leave()의 횟수는 총 요구되는 고객 수와 일치`(innerCount)`하는 반면, group.enter()는 만 번이 넘도록 호출`(outerCount)`됩니다.
→ group.wait()은 enter 메서드와 leave 메서드가 호출된 횟수를 비교하여 일치할 경우, 응답한 것으로 처리하기 때문에 해당 실험은 조건을 충족하지 못합니다. `(사진 3-1)`

![](https://i.imgur.com/GGzvweV.png)

⬆️ 사진 3-1

이때 두 비동기 작업의 `delay`를 모두 없애게 되면 group.enter()의 호출횟수가 현저히 떨어지게 됩니다.
→ delay 시간 동안 조건을 충족시키기 위해 계속해서 enter()를 호출한다는 것을 추측할 수 있었습니다. `(사진 3-2)`

![](https://i.imgur.com/jKX6TYP.png)

⬆️  사진 3-2

이렇듯이 While문 내부의 asyncAfter가 group으로 지정될 때 문제가 발생된다는 파악이 가능해졌습니다. 해결을 위해 3가지 수정이 이루어졌습니다.

1. waitingLine을 업무 종류과 관계없이 하나의 열로 통일
2. customer가 존재할 때에만 while문에 접근할 수 있도록 조건 변경

위 조건을 토대로 수정된 코드는 아래와 같습니다.

```swift
private func assignWork() {
        while let nextCustomer = bank?.waitingLine.dequeue() {
            
            switch nextCustomer.requestedWork {
            case .deposit:
                self.semaphore1.wait()

                DispatchQueue.global().asyncAfter(deadline: .now() + 0.7) {

                    self.employee?.startJob(customer: nextCustomer)
                    self.employee?.finishJob(customer: nextCustomer)
                    
                    self.semaphore1.signal()
                }
            case .loan:
                self.semaphore2.wait()

                DispatchQueue.global().asyncAfter(deadline: .now() + 1.1) {

                    self.employee?.startJob(customer: nextCustomer)
                    self.employee?.finishJob(customer: nextCustomer)
                    
                    self.semaphore2.signal()
                }
            }
        }
}
```

하지만 여전히... 여전히... 저희가 원하던 그림과는 조금 다른 결과`(사진 3-3)`가 도출되었기 때문에 결과적으로 asyncAfter가 아닌 `Thread.sleep()`을 선택했습니다.

![](https://i.imgur.com/IAgPELc.png)

⬆️  사진 3-3