### PR TITLE
은행 창구 매니저 [STEP2] 파프리, 마이노

### DIFF
--- a/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
+++ b/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		A1E557C12819113E008870CC /* Client.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1E557C02819113E008870CC /* Client.swift */; };
 		A1E557C3281916BC008870CC /* BankClerk.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1E557C2281916BC008870CC /* BankClerk.swift */; };
 		A1E557CB28196578008870CC /* Presentable.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1E557CA28196578008870CC /* Presentable.swift */; };
+		A1E557CD281A2CD3008870CC /* BankManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1E557CC281A2CD3008870CC /* BankManager.swift */; };
 		ACFC801545EAB83ED5A03CC3 /* Pods_BankManagerConsoleApp.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E73E324EDE079A1E4E9B7760 /* Pods_BankManagerConsoleApp.framework */; };
 		C7694E7A259C3EC00053667F /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7694E79259C3EC00053667F /* main.swift */; };
 /* End PBXBuildFile section */
@@ -50,6 +51,7 @@
 		A1E557C02819113E008870CC /* Client.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Client.swift; sourceTree = "<group>"; };
 		A1E557C2281916BC008870CC /* BankClerk.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BankClerk.swift; sourceTree = "<group>"; };
 		A1E557CA28196578008870CC /* Presentable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Presentable.swift; sourceTree = "<group>"; };
+		A1E557CC281A2CD3008870CC /* BankManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BankManager.swift; sourceTree = "<group>"; };
 		C7694E76259C3EC00053667F /* BankManagerConsoleApp */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = BankManagerConsoleApp; sourceTree = BUILT_PRODUCTS_DIR; };
 		C7694E79259C3EC00053667F /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
 		E73E324EDE079A1E4E9B7760 /* Pods_BankManagerConsoleApp.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_BankManagerConsoleApp.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -100,6 +102,7 @@
 				A1E557C02819113E008870CC /* Client.swift */,
 				67251F1D281912B700069BBA /* Bank.swift */,
 				A1E557C2281916BC008870CC /* BankClerk.swift */,
+				A1E557CC281A2CD3008870CC /* BankManager.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -305,6 +308,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				67251F23281960D100069BBA /* BankError.swift in Sources */,
+				A1E557CD281A2CD3008870CC /* BankManager.swift in Sources */,
 				A11246A32816CDFD00292332 /* LinkedList.swift in Sources */,
 				A1E557C3281916BC008870CC /* BankClerk.swift in Sources */,
 				C7694E7A259C3EC00053667F /* main.swift in Sources */,

--- a/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
+++ b/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
@@ -13,9 +13,9 @@
 		A11246C42816DEF400292332 /* Queue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 674062242816D35E0032A2AE /* Queue.swift */; };
 		A11246C52816DEF600292332 /* LinkedList.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11246A22816CDFD00292332 /* LinkedList.swift */; };
 		A13BFFD928178CCD00B3A6C0 /* .swiftlint.yml in Resources */ = {isa = PBXBuildFile; fileRef = A13BFFD828178CCD00B3A6C0 /* .swiftlint.yml */; };
+		A1E557C12819113E008870CC /* Client.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1E557C02819113E008870CC /* Client.swift */; };
 		ACFC801545EAB83ED5A03CC3 /* Pods_BankManagerConsoleApp.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E73E324EDE079A1E4E9B7760 /* Pods_BankManagerConsoleApp.framework */; };
 		C7694E7A259C3EC00053667F /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7694E79259C3EC00053667F /* main.swift */; };
-		C7D65D1B259C8190005510E0 /* BankManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7D65D1A259C8190005510E0 /* BankManager.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -39,9 +39,9 @@
 		A11246B82816DBB300292332 /* BankManagerConsoleAppTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = BankManagerConsoleAppTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		A11246BA2816DBB300292332 /* QueueTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QueueTest.swift; sourceTree = "<group>"; };
 		A13BFFD828178CCD00B3A6C0 /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
+		A1E557C02819113E008870CC /* Client.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Client.swift; sourceTree = "<group>"; };
 		C7694E76259C3EC00053667F /* BankManagerConsoleApp */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = BankManagerConsoleApp; sourceTree = BUILT_PRODUCTS_DIR; };
 		C7694E79259C3EC00053667F /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
-		C7D65D1A259C8190005510E0 /* BankManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BankManager.swift; sourceTree = "<group>"; };
 		E73E324EDE079A1E4E9B7760 /* Pods_BankManagerConsoleApp.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_BankManagerConsoleApp.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
@@ -76,9 +76,9 @@
 		A11246A12816CDEF00292332 /* Model */ = {
 			isa = PBXGroup;
 			children = (
-				C7D65D1A259C8190005510E0 /* BankManager.swift */,
 				A11246A22816CDFD00292332 /* LinkedList.swift */,
 				674062242816D35E0032A2AE /* Queue.swift */,
+				A1E557C02819113E008870CC /* Client.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -275,7 +275,7 @@
 			files = (
 				A11246A32816CDFD00292332 /* LinkedList.swift in Sources */,
 				C7694E7A259C3EC00053667F /* main.swift in Sources */,
-				C7D65D1B259C8190005510E0 /* BankManager.swift in Sources */,
+				A1E557C12819113E008870CC /* Client.swift in Sources */,
 				674062252816D35E0032A2AE /* Queue.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
+++ b/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		67251F1E281912B700069BBA /* Bank.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67251F1D281912B700069BBA /* Bank.swift */; };
 		674062252816D35E0032A2AE /* Queue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 674062242816D35E0032A2AE /* Queue.swift */; };
 		A11246A32816CDFD00292332 /* LinkedList.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11246A22816CDFD00292332 /* LinkedList.swift */; };
 		A11246BB2816DBB300292332 /* QueueTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11246BA2816DBB300292332 /* QueueTest.swift */; };
@@ -32,6 +33,7 @@
 
 /* Begin PBXFileReference section */
 		0205DF7F705BF47F057A0DEB /* Pods-BankManagerConsoleApp.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BankManagerConsoleApp.debug.xcconfig"; path = "Target Support Files/Pods-BankManagerConsoleApp/Pods-BankManagerConsoleApp.debug.xcconfig"; sourceTree = "<group>"; };
+		67251F1D281912B700069BBA /* Bank.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Bank.swift; sourceTree = "<group>"; };
 		674062242816D35E0032A2AE /* Queue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Queue.swift; sourceTree = "<group>"; };
 		9E7AA34411D40488271CC611 /* Pods-BankManagerConsoleApp.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BankManagerConsoleApp.release.xcconfig"; path = "Target Support Files/Pods-BankManagerConsoleApp/Pods-BankManagerConsoleApp.release.xcconfig"; sourceTree = "<group>"; };
 		A11246A22816CDFD00292332 /* LinkedList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkedList.swift; sourceTree = "<group>"; };
@@ -79,6 +81,7 @@
 				A11246A22816CDFD00292332 /* LinkedList.swift */,
 				674062242816D35E0032A2AE /* Queue.swift */,
 				A1E557C02819113E008870CC /* Client.swift */,
+				67251F1D281912B700069BBA /* Bank.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -275,6 +278,7 @@
 			files = (
 				A11246A32816CDFD00292332 /* LinkedList.swift in Sources */,
 				C7694E7A259C3EC00053667F /* main.swift in Sources */,
+				67251F1E281912B700069BBA /* Bank.swift in Sources */,
 				A1E557C12819113E008870CC /* Client.swift in Sources */,
 				674062252816D35E0032A2AE /* Queue.swift in Sources */,
 			);

--- a/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
+++ b/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		A13BFFD928178CCD00B3A6C0 /* .swiftlint.yml in Resources */ = {isa = PBXBuildFile; fileRef = A13BFFD828178CCD00B3A6C0 /* .swiftlint.yml */; };
 		A1E557C12819113E008870CC /* Client.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1E557C02819113E008870CC /* Client.swift */; };
 		A1E557C3281916BC008870CC /* BankClerk.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1E557C2281916BC008870CC /* BankClerk.swift */; };
+		A1E557CB28196578008870CC /* Presentable.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1E557CA28196578008870CC /* Presentable.swift */; };
 		ACFC801545EAB83ED5A03CC3 /* Pods_BankManagerConsoleApp.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E73E324EDE079A1E4E9B7760 /* Pods_BankManagerConsoleApp.framework */; };
 		C7694E7A259C3EC00053667F /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7694E79259C3EC00053667F /* main.swift */; };
 /* End PBXBuildFile section */
@@ -48,6 +49,7 @@
 		A13BFFD828178CCD00B3A6C0 /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
 		A1E557C02819113E008870CC /* Client.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Client.swift; sourceTree = "<group>"; };
 		A1E557C2281916BC008870CC /* BankClerk.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BankClerk.swift; sourceTree = "<group>"; };
+		A1E557CA28196578008870CC /* Presentable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Presentable.swift; sourceTree = "<group>"; };
 		C7694E76259C3EC00053667F /* BankManagerConsoleApp */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = BankManagerConsoleApp; sourceTree = BUILT_PRODUCTS_DIR; };
 		C7694E79259C3EC00053667F /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
 		E73E324EDE079A1E4E9B7760 /* Pods_BankManagerConsoleApp.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_BankManagerConsoleApp.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -111,6 +113,14 @@
 			path = BankManagerConsoleAppTests;
 			sourceTree = "<group>";
 		};
+		A1E557C92819654D008870CC /* Protocol */ = {
+			isa = PBXGroup;
+			children = (
+				A1E557CA28196578008870CC /* Presentable.swift */,
+			);
+			path = Protocol;
+			sourceTree = "<group>";
+		};
 		B50A4892713E0517202336BA /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
@@ -142,6 +152,7 @@
 		C7694E78259C3EC00053667F /* BankManagerConsoleApp */ = {
 			isa = PBXGroup;
 			children = (
+				A1E557C92819654D008870CC /* Protocol */,
 				67251F1F28195A9500069BBA /* Util */,
 				A11246A12816CDEF00292332 /* Model */,
 				C7694E79259C3EC00053667F /* main.swift */,
@@ -301,6 +312,7 @@
 				67251F2128195AAE00069BBA /* Constants.swift in Sources */,
 				A1E557C12819113E008870CC /* Client.swift in Sources */,
 				674062252816D35E0032A2AE /* Queue.swift in Sources */,
+				A1E557CB28196578008870CC /* Presentable.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
+++ b/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		67251F1E281912B700069BBA /* Bank.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67251F1D281912B700069BBA /* Bank.swift */; };
+		67251F2128195AAE00069BBA /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67251F2028195AAE00069BBA /* Constants.swift */; };
 		674062252816D35E0032A2AE /* Queue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 674062242816D35E0032A2AE /* Queue.swift */; };
 		A11246A32816CDFD00292332 /* LinkedList.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11246A22816CDFD00292332 /* LinkedList.swift */; };
 		A11246BB2816DBB300292332 /* QueueTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11246BA2816DBB300292332 /* QueueTest.swift */; };
@@ -35,6 +36,7 @@
 /* Begin PBXFileReference section */
 		0205DF7F705BF47F057A0DEB /* Pods-BankManagerConsoleApp.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BankManagerConsoleApp.debug.xcconfig"; path = "Target Support Files/Pods-BankManagerConsoleApp/Pods-BankManagerConsoleApp.debug.xcconfig"; sourceTree = "<group>"; };
 		67251F1D281912B700069BBA /* Bank.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Bank.swift; sourceTree = "<group>"; };
+		67251F2028195AAE00069BBA /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		674062242816D35E0032A2AE /* Queue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Queue.swift; sourceTree = "<group>"; };
 		9E7AA34411D40488271CC611 /* Pods-BankManagerConsoleApp.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BankManagerConsoleApp.release.xcconfig"; path = "Target Support Files/Pods-BankManagerConsoleApp/Pods-BankManagerConsoleApp.release.xcconfig"; sourceTree = "<group>"; };
 		A11246A22816CDFD00292332 /* LinkedList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkedList.swift; sourceTree = "<group>"; };
@@ -75,6 +77,14 @@
 				9E7AA34411D40488271CC611 /* Pods-BankManagerConsoleApp.release.xcconfig */,
 			);
 			path = Pods;
+			sourceTree = "<group>";
+		};
+		67251F1F28195A9500069BBA /* Util */ = {
+			isa = PBXGroup;
+			children = (
+				67251F2028195AAE00069BBA /* Constants.swift */,
+			);
+			path = Util;
 			sourceTree = "<group>";
 		};
 		A11246A12816CDEF00292332 /* Model */ = {
@@ -129,6 +139,7 @@
 		C7694E78259C3EC00053667F /* BankManagerConsoleApp */ = {
 			isa = PBXGroup;
 			children = (
+				67251F1F28195A9500069BBA /* Util */,
 				A11246A12816CDEF00292332 /* Model */,
 				C7694E79259C3EC00053667F /* main.swift */,
 				A11246A42816D15600292332 /* .swiftlint.yml */,
@@ -283,6 +294,7 @@
 				A1E557C3281916BC008870CC /* BankClerk.swift in Sources */,
 				C7694E7A259C3EC00053667F /* main.swift in Sources */,
 				67251F1E281912B700069BBA /* Bank.swift in Sources */,
+				67251F2128195AAE00069BBA /* Constants.swift in Sources */,
 				A1E557C12819113E008870CC /* Client.swift in Sources */,
 				674062252816D35E0032A2AE /* Queue.swift in Sources */,
 			);

--- a/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
+++ b/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		67251F1E281912B700069BBA /* Bank.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67251F1D281912B700069BBA /* Bank.swift */; };
 		67251F2128195AAE00069BBA /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67251F2028195AAE00069BBA /* Constants.swift */; };
+		67251F23281960D100069BBA /* BankError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67251F22281960D100069BBA /* BankError.swift */; };
 		674062252816D35E0032A2AE /* Queue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 674062242816D35E0032A2AE /* Queue.swift */; };
 		A11246A32816CDFD00292332 /* LinkedList.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11246A22816CDFD00292332 /* LinkedList.swift */; };
 		A11246BB2816DBB300292332 /* QueueTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11246BA2816DBB300292332 /* QueueTest.swift */; };
@@ -37,6 +38,7 @@
 		0205DF7F705BF47F057A0DEB /* Pods-BankManagerConsoleApp.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BankManagerConsoleApp.debug.xcconfig"; path = "Target Support Files/Pods-BankManagerConsoleApp/Pods-BankManagerConsoleApp.debug.xcconfig"; sourceTree = "<group>"; };
 		67251F1D281912B700069BBA /* Bank.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Bank.swift; sourceTree = "<group>"; };
 		67251F2028195AAE00069BBA /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
+		67251F22281960D100069BBA /* BankError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BankError.swift; sourceTree = "<group>"; };
 		674062242816D35E0032A2AE /* Queue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Queue.swift; sourceTree = "<group>"; };
 		9E7AA34411D40488271CC611 /* Pods-BankManagerConsoleApp.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BankManagerConsoleApp.release.xcconfig"; path = "Target Support Files/Pods-BankManagerConsoleApp/Pods-BankManagerConsoleApp.release.xcconfig"; sourceTree = "<group>"; };
 		A11246A22816CDFD00292332 /* LinkedList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkedList.swift; sourceTree = "<group>"; };
@@ -83,6 +85,7 @@
 			isa = PBXGroup;
 			children = (
 				67251F2028195AAE00069BBA /* Constants.swift */,
+				67251F22281960D100069BBA /* BankError.swift */,
 			);
 			path = Util;
 			sourceTree = "<group>";
@@ -290,6 +293,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				67251F23281960D100069BBA /* BankError.swift in Sources */,
 				A11246A32816CDFD00292332 /* LinkedList.swift in Sources */,
 				A1E557C3281916BC008870CC /* BankClerk.swift in Sources */,
 				C7694E7A259C3EC00053667F /* main.swift in Sources */,

--- a/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
+++ b/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		A11246C52816DEF600292332 /* LinkedList.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11246A22816CDFD00292332 /* LinkedList.swift */; };
 		A13BFFD928178CCD00B3A6C0 /* .swiftlint.yml in Resources */ = {isa = PBXBuildFile; fileRef = A13BFFD828178CCD00B3A6C0 /* .swiftlint.yml */; };
 		A1E557C12819113E008870CC /* Client.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1E557C02819113E008870CC /* Client.swift */; };
+		A1E557C3281916BC008870CC /* BankClerk.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1E557C2281916BC008870CC /* BankClerk.swift */; };
 		ACFC801545EAB83ED5A03CC3 /* Pods_BankManagerConsoleApp.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E73E324EDE079A1E4E9B7760 /* Pods_BankManagerConsoleApp.framework */; };
 		C7694E7A259C3EC00053667F /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7694E79259C3EC00053667F /* main.swift */; };
 /* End PBXBuildFile section */
@@ -42,6 +43,7 @@
 		A11246BA2816DBB300292332 /* QueueTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QueueTest.swift; sourceTree = "<group>"; };
 		A13BFFD828178CCD00B3A6C0 /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
 		A1E557C02819113E008870CC /* Client.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Client.swift; sourceTree = "<group>"; };
+		A1E557C2281916BC008870CC /* BankClerk.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BankClerk.swift; sourceTree = "<group>"; };
 		C7694E76259C3EC00053667F /* BankManagerConsoleApp */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = BankManagerConsoleApp; sourceTree = BUILT_PRODUCTS_DIR; };
 		C7694E79259C3EC00053667F /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
 		E73E324EDE079A1E4E9B7760 /* Pods_BankManagerConsoleApp.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_BankManagerConsoleApp.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -82,6 +84,7 @@
 				674062242816D35E0032A2AE /* Queue.swift */,
 				A1E557C02819113E008870CC /* Client.swift */,
 				67251F1D281912B700069BBA /* Bank.swift */,
+				A1E557C2281916BC008870CC /* BankClerk.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -277,6 +280,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				A11246A32816CDFD00292332 /* LinkedList.swift in Sources */,
+				A1E557C3281916BC008870CC /* BankClerk.swift in Sources */,
 				C7694E7A259C3EC00053667F /* main.swift in Sources */,
 				67251F1E281912B700069BBA /* Bank.swift in Sources */,
 				A1E557C12819113E008870CC /* Client.swift in Sources */,

--- a/BankManagerConsoleApp/BankManagerConsoleApp/.swiftlint.yml
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/.swiftlint.yml
@@ -1,4 +1,5 @@
 disabled_rules:
     - trailing_whitespace
+    - private_over_fileprivate
 excluded:
     - Pods

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Model/Bank.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Model/Bank.swift
@@ -5,11 +5,13 @@
 //  Created by 허윤영 on 27/04/2022.
 //
 
-protocol BankDelegate: AnyObject {
-    func close(totalWorkTime: String)
+import Foundation
+
+fileprivate extension Constants {
+    static let decimalPlace = "%.2f"
 }
 
-final class Bank: BankDelegate, Presentable {
+final class Bank: Presentable {
     private let clientQueue = Queue<Client>()
     private let bankClerk: BankClerk
     private let clientCount: Int
@@ -17,12 +19,16 @@ final class Bank: BankDelegate, Presentable {
     init(bankClerk: BankClerk, clientCount: Int) {
         self.bankClerk = bankClerk
         self.clientCount = clientCount
-        bankClerk.setDelegate(delegate: self)
     }
     
     func open() {
         receiveClients()
-        bankClerk.work(clientQueue)
+        
+        let totalWorkTime = measureTotalWorkTime {
+            bankClerk.work(clientQueue)
+        }
+        
+        close(totalWorkTime: totalWorkTime)
     }
     
     private func receiveClients() {
@@ -31,7 +37,22 @@ final class Bank: BankDelegate, Presentable {
         }
     }
     
-    func close(totalWorkTime: String) {
+    private func measureTotalWorkTime(_ task: () -> Void) -> String {
+        let startTime = CFAbsoluteTimeGetCurrent()
+        task()
+        let finishTime = CFAbsoluteTimeGetCurrent()
+        let totalTime = finishTime - startTime
+        
+        return totalTime.formatted
+    }
+    
+    private func close(totalWorkTime: String) {
         printClosingMessage(clientCount: clientCount, totalWorkTime: totalWorkTime)
+    }
+}
+
+fileprivate extension CFAbsoluteTime {
+    var formatted: String {
+        String(format: Constants.decimalPlace, self)
     }
 }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Model/Bank.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Model/Bank.swift
@@ -5,10 +5,13 @@
 //  Created by 허윤영 on 27/04/2022.
 //
 
-import Foundation
-
 final class Bank {
     private let clientQueue = Queue<Client>()
+    private let bankClerk: BankClerk
+    
+    init(bankClerk: BankClerk) {
+        self.bankClerk = bankClerk
+    }
     
     private func receiveClients() {
         let clientCount = Int.random(in: 10 ... 30)
@@ -16,5 +19,10 @@ final class Bank {
         for order in 1 ... clientCount {
             clientQueue.enqueue(Client(waitingNumber: order))
         }
+    }
+    
+    func open() {
+        receiveClients()
+        bankClerk.work(clientQueue)
     }
 }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Model/Bank.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Model/Bank.swift
@@ -6,7 +6,7 @@
 //
 
 protocol BankDelegate: AnyObject {
-    func close()
+    func close(totalWorkTime: String)
 }
 
 final class Bank: BankDelegate {
@@ -30,7 +30,7 @@ final class Bank: BankDelegate {
         bankClerk.work(clientQueue)
     }
     
-    func close() {
-        print("업무가 마감되었습니다.")
+    func close(totalWorkTime: String) {
+        print("업무가 마감되었습니다. 오늘 업무를 처리한 고객은 총 \(clientCount)명이며, 총 업무시간은 \(totalWorkTime)초입니다.")
     }
 }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Model/Bank.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Model/Bank.swift
@@ -20,15 +20,15 @@ final class Bank: BankDelegate, Presentable {
         bankClerk.setDelegate(delegate: self)
     }
     
+    func open() {
+        receiveClients()
+        bankClerk.work(clientQueue)
+    }
+    
     private func receiveClients() {
         for order in 1 ... clientCount {
             clientQueue.enqueue(Client(waitingNumber: order))
         }
-    }
-    
-    func open() {
-        receiveClients()
-        bankClerk.work(clientQueue)
     }
     
     func close(totalWorkTime: String) {

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Model/Bank.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Model/Bank.swift
@@ -1,0 +1,20 @@
+//
+//  Bank.swift
+//  BankManagerConsoleApp
+//
+//  Created by 허윤영 on 27/04/2022.
+//
+
+import Foundation
+
+final class Bank {
+    private let clientQueue = Queue<Client>()
+    
+    private func receiveClients() {
+        let clientCount = Int.random(in: 10 ... 30)
+        
+        for order in 1 ... clientCount {
+            clientQueue.enqueue(Client(waitingNumber: order))
+        }
+    }
+}

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Model/Bank.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Model/Bank.swift
@@ -5,17 +5,21 @@
 //  Created by 허윤영 on 27/04/2022.
 //
 
-final class Bank {
+protocol BankDelegate: AnyObject {
+    func close()
+}
+
+final class Bank: BankDelegate {
     private let clientQueue = Queue<Client>()
     private let bankClerk: BankClerk
+    private let clientCount = Int.random(in: 10 ... 30)
     
     init(bankClerk: BankClerk) {
         self.bankClerk = bankClerk
+        bankClerk.setDelegate(delegate: self)
     }
     
     private func receiveClients() {
-        let clientCount = Int.random(in: 10 ... 30)
-        
         for order in 1 ... clientCount {
             clientQueue.enqueue(Client(waitingNumber: order))
         }
@@ -24,5 +28,9 @@ final class Bank {
     func open() {
         receiveClients()
         bankClerk.work(clientQueue)
+    }
+    
+    func close() {
+        print("업무가 마감되었습니다.")
     }
 }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Model/Bank.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Model/Bank.swift
@@ -12,10 +12,11 @@ protocol BankDelegate: AnyObject {
 final class Bank: BankDelegate {
     private let clientQueue = Queue<Client>()
     private let bankClerk: BankClerk
-    private let clientCount = Int.random(in: 10 ... 30)
+    private let clientCount: Int
     
-    init(bankClerk: BankClerk) {
+    init(bankClerk: BankClerk, clientCount: Int) {
         self.bankClerk = bankClerk
+        self.clientCount = clientCount
         bankClerk.setDelegate(delegate: self)
     }
     

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Model/Bank.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Model/Bank.swift
@@ -9,7 +9,7 @@ protocol BankDelegate: AnyObject {
     func close(totalWorkTime: String)
 }
 
-final class Bank: BankDelegate {
+final class Bank: BankDelegate, Presentable {
     private let clientQueue = Queue<Client>()
     private let bankClerk: BankClerk
     private let clientCount: Int
@@ -32,6 +32,6 @@ final class Bank: BankDelegate {
     }
     
     func close(totalWorkTime: String) {
-        print("업무가 마감되었습니다. 오늘 업무를 처리한 고객은 총 \(clientCount)명이며, 총 업무시간은 \(totalWorkTime)초입니다.")
+        printClosingMessage(clientCount: clientCount, totalWorkTime: totalWorkTime)
     }
 }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Model/BankClerk.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Model/BankClerk.swift
@@ -41,7 +41,7 @@ final class BankClerk: Presentable {
         }
                 
         while queue.isEmpty == false {
-            workQueue.async(execute: workItem)
+            workQueue.sync(execute: workItem)
         }
         
         let finishTime = CFAbsoluteTimeGetCurrent()

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Model/BankClerk.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Model/BankClerk.swift
@@ -7,12 +7,16 @@
 
 import Foundation
 
-final class BankClerk {
+fileprivate extension Constants {
+    static let decimalPlace = "%.2f"
+}
+
+final class BankClerk: Presentable {
     private let name: String
-    private let workSpeed: Double
+    private let workSpeed: UInt32
     private weak var delegate: BankDelegate?
     
-    init(name: String, workSpeed: Double) {
+    init(name: String, workSpeed: UInt32) {
         self.name = name
         self.workSpeed = workSpeed
     }
@@ -28,9 +32,10 @@ final class BankClerk {
             guard let client = queue.peek else {
                 return
             }
-            print("\(client.waitingNumber)번 고객 업무 시작")
-            usleep(UInt32(self.workSpeed))
-            print("\(client.waitingNumber)번 고객 업무 완료")
+            
+            self.printStartTaskMessage(waitingNumber: client.waitingNumber)
+            usleep(self.workSpeed)
+            self.printFinishTaskMessage(waitingNumber: client.waitingNumber)
             
             queue.dequeue()
         }
@@ -38,8 +43,16 @@ final class BankClerk {
         while queue.isEmpty == false {
             workQueue.async(execute: workItem)
         }
+        
         let finishTime = CFAbsoluteTimeGetCurrent()
         let totalTime = finishTime - startTime
-        delegate?.close(totalWorkTime: String(format: "%.2f", totalTime))
+        
+        delegate?.close(totalWorkTime: totalTime.formatted)
+    }
+}
+
+fileprivate extension CFAbsoluteTime {
+    var formatted: String {
+        String(format: Constants.decimalPlace, self)
     }
 }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Model/BankClerk.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Model/BankClerk.swift
@@ -1,0 +1,37 @@
+//
+//  BankClerk.swift
+//  BankManagerConsoleApp
+//
+//  Created by 조민호 on 2022/04/27.
+//
+
+import Foundation
+
+final class BankClerk {
+    private let workSpeed: Double = 0.7
+    private let name: String
+    
+    init(name: String) {
+        self.name = name
+    }
+    
+    func work(_ queue: Queue<Client>) {
+        let workGroup = DispatchGroup()
+        let workQueue = DispatchQueue(label: name)
+        
+        let workItem = DispatchWorkItem {
+            guard let client = queue.peek else {
+                return
+            }
+            print("\(client.waitingNumber)번 고객 업무 시작")
+            sleep(UInt32(self.workSpeed))
+            print("\(client.waitingNumber)번 고객 업무 완료")
+            
+            queue.dequeue()
+        }
+                
+        while queue.isEmpty == false {
+            workQueue.async(group: workGroup, execute: workItem)
+        }
+    }
+}

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Model/BankClerk.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Model/BankClerk.swift
@@ -8,9 +8,9 @@
 import Foundation
 
 final class BankClerk {
-    private let workSpeed: Double = 0.7
+    private let workSpeed: Double = 700000
     private let name: String
-    weak var delegate: BankDelegate?
+    private weak var delegate: BankDelegate?
     
     init(name: String) {
         self.name = name
@@ -22,13 +22,13 @@ final class BankClerk {
     
     func work(_ queue: Queue<Client>) {
         let workQueue = DispatchQueue(label: name)
-        
+        let startTime = CFAbsoluteTimeGetCurrent()
         let workItem = DispatchWorkItem {
             guard let client = queue.peek else {
                 return
             }
             print("\(client.waitingNumber)번 고객 업무 시작")
-            sleep(UInt32(self.workSpeed))
+            usleep(UInt32(self.workSpeed))
             print("\(client.waitingNumber)번 고객 업무 완료")
             
             queue.dequeue()
@@ -37,11 +37,8 @@ final class BankClerk {
         while queue.isEmpty == false {
             workQueue.async(execute: workItem)
         }
-        
-        endWork()
-    }
-    
-    func endWork() {
-        delegate?.close()
+        let finishTime = CFAbsoluteTimeGetCurrent()
+        let totalTime = finishTime - startTime
+        delegate?.close(totalWorkTime: String(format: "%.2f", totalTime))
     }
 }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Model/BankClerk.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Model/BankClerk.swift
@@ -8,12 +8,13 @@
 import Foundation
 
 final class BankClerk {
-    private let workSpeed: Double = 700000
     private let name: String
+    private let workSpeed: Double
     private weak var delegate: BankDelegate?
     
-    init(name: String) {
+    init(name: String, workSpeed: Double) {
         self.name = name
+        self.workSpeed = workSpeed
     }
     
     func setDelegate(delegate: BankDelegate) {

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Model/BankClerk.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Model/BankClerk.swift
@@ -7,28 +7,26 @@
 
 import Foundation
 
-fileprivate extension Constants {
-    static let decimalPlace = "%.2f"
-}
-
 final class BankClerk: Presentable {
     private let name: String
     private let workSpeed: Double
-    private weak var delegate: BankDelegate?
     
     init(name: String, workSpeed: Double) {
         self.name = name
         self.workSpeed = workSpeed
     }
     
-    func setDelegate(delegate: BankDelegate) {
-        self.delegate = delegate
-    }
-    
     func work(_ queue: Queue<Client>) {
         let workQueue = DispatchQueue(label: name)
-        let startTime = CFAbsoluteTimeGetCurrent()
-        let workItem = DispatchWorkItem {
+        let workItem = createWorkItem(queue)
+        
+        while queue.isEmpty == false {
+            workQueue.sync(execute: workItem)
+        }
+    }
+    
+    private func createWorkItem(_ queue: Queue<Client>) -> DispatchWorkItem {
+        DispatchWorkItem {
             guard let client = queue.peek else {
                 return
             }
@@ -39,20 +37,5 @@ final class BankClerk: Presentable {
             
             queue.dequeue()
         }
-                
-        while queue.isEmpty == false {
-            workQueue.sync(execute: workItem)
-        }
-        
-        let finishTime = CFAbsoluteTimeGetCurrent()
-        let totalTime = finishTime - startTime
-        
-        delegate?.close(totalWorkTime: totalTime.formatted)
-    }
-}
-
-fileprivate extension CFAbsoluteTime {
-    var formatted: String {
-        String(format: Constants.decimalPlace, self)
     }
 }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Model/BankClerk.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Model/BankClerk.swift
@@ -13,10 +13,10 @@ fileprivate extension Constants {
 
 final class BankClerk: Presentable {
     private let name: String
-    private let workSpeed: UInt32
+    private let workSpeed: Double
     private weak var delegate: BankDelegate?
     
-    init(name: String, workSpeed: UInt32) {
+    init(name: String, workSpeed: Double) {
         self.name = name
         self.workSpeed = workSpeed
     }
@@ -34,7 +34,7 @@ final class BankClerk: Presentable {
             }
             
             self.printStartTaskMessage(waitingNumber: client.waitingNumber)
-            usleep(self.workSpeed)
+            Thread.sleep(forTimeInterval: self.workSpeed)
             self.printFinishTaskMessage(waitingNumber: client.waitingNumber)
             
             queue.dequeue()

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Model/BankClerk.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Model/BankClerk.swift
@@ -10,13 +10,17 @@ import Foundation
 final class BankClerk {
     private let workSpeed: Double = 0.7
     private let name: String
+    weak var delegate: BankDelegate?
     
     init(name: String) {
         self.name = name
     }
     
+    func setDelegate(delegate: BankDelegate) {
+        self.delegate = delegate
+    }
+    
     func work(_ queue: Queue<Client>) {
-        let workGroup = DispatchGroup()
         let workQueue = DispatchQueue(label: name)
         
         let workItem = DispatchWorkItem {
@@ -31,7 +35,13 @@ final class BankClerk {
         }
                 
         while queue.isEmpty == false {
-            workQueue.async(group: workGroup, execute: workItem)
+            workQueue.async(execute: workItem)
         }
+        
+        endWork()
+    }
+    
+    func endWork() {
+        delegate?.close()
     }
 }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Model/BankManager.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Model/BankManager.swift
@@ -1,0 +1,56 @@
+//
+//  BankManager.swift
+//  BankManagerConsoleApp
+//
+//  Created by 조민호 on 2022/04/28.
+//
+
+fileprivate extension Constants {
+    static let bankOpen = "1"
+    static let exit = "2"
+    static let menu = """
+    1 : 은행개점
+    2 : 종료
+    입력 :
+    """
+    static let whiteSpace = " "
+}
+
+struct BankManager {
+    private let bankClerk: BankClerk
+    private let bank: Bank
+    
+    init(bankClerk: BankClerk, bank: Bank) {
+        self.bankClerk = bankClerk
+        self.bank = bank
+    }
+    
+    func startProgram(bank: Bank, bankClerk: BankClerk) throws {
+        while true {
+            printMenu()
+            let userInput = try receivedUserInput()
+            
+            switch userInput {
+            case Constants.bankOpen:
+                bank.open()
+            case Constants.exit:
+                return
+            default:
+                continue
+            }
+        }
+    }
+
+    private func printMenu() {
+        let menu = Constants.menu
+        print(menu, terminator: Constants.whiteSpace)
+    }
+
+    private func receivedUserInput() throws -> String {
+        guard let userInput = readLine() else {
+            throw BankError.wrongInput
+        }
+        
+        return userInput
+    }
+}

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Model/BankManager.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Model/BankManager.swift
@@ -1,5 +1,0 @@
-//
-//  BankManager.swift
-//  Created by yagom.
-//  Copyright © yagom academy. All rights reserved.
-//

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Model/Client.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Model/Client.swift
@@ -1,0 +1,10 @@
+//
+//  Client.swift
+//  BankManagerConsoleApp
+//
+//  Created by 조민호 on 2022/04/27.
+//
+
+struct Client {
+    let waitingNumber: Int
+}

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Protocol/Presentable.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Protocol/Presentable.swift
@@ -1,0 +1,24 @@
+//
+//  Presentable.swift
+//  BankManagerConsoleApp
+//
+//  Created by 조민호 on 2022/04/27.
+//
+
+protocol Presentable {}
+
+extension Presentable where Self: Bank {
+    func printClosingMessage(clientCount: Int, totalWorkTime: String) {
+        print("업무가 마감되었습니다. 오늘 업무를 처리한 고객은 총 \(clientCount)명이며, 총 업무시간은 \(totalWorkTime)초입니다.")
+    }
+}
+
+extension Presentable where Self: BankClerk {
+    func printStartTaskMessage(waitingNumber: Int) {
+        print("\(waitingNumber)번 고객 업무 시작")
+    }
+    
+    func printFinishTaskMessage(waitingNumber: Int) {
+        print("\(waitingNumber)번 고객 업무 완료")
+    }
+}

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Util/BankError.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Util/BankError.swift
@@ -1,0 +1,20 @@
+//
+//  BankError.swift
+//  BankManagerConsoleApp
+//
+//  Created by 허윤영 on 27/04/2022.
+//
+import Foundation
+
+enum BankError: LocalizedError {
+    case wrongInput
+}
+
+extension BankError {
+    var errorDescription: String? {
+        switch self {
+        case .wrongInput:
+            return "잘못된 입력입니다"
+        }
+    }
+}

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Util/Constants.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Util/Constants.swift
@@ -5,7 +5,4 @@
 //  Created by 허윤영 on 27/04/2022.
 //
 
-
-enum Constants {
-    
-}
+enum Constants {}

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Util/Constants.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Util/Constants.swift
@@ -1,0 +1,11 @@
+//
+//  Constants.swift
+//  BankManagerConsoleApp
+//
+//  Created by 허윤영 on 27/04/2022.
+//
+
+
+enum Constants {
+    
+}

--- a/BankManagerConsoleApp/BankManagerConsoleApp/main.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/main.swift
@@ -4,6 +4,22 @@
 //  Copyright © yagom academy. All rights reserved.
 //
 
+func startProgram() {
+    while true {
+        printMenu()
+        let userInput = receivedUserInput()
+        
+        switch userInput {
+        case "1":
+            print("은행 개점")
+        case "2":
+            return
+        default:
+            continue
+        }
+    }
+}
+
 fileprivate func printMenu() {
     let menu = """
     1 : 은행개점
@@ -12,3 +28,13 @@ fileprivate func printMenu() {
     """
     print(menu, terminator: " ")
 }
+
+fileprivate func receivedUserInput() -> String {
+    guard let userInput = readLine() else {
+        return ""
+    }
+    
+    return userInput
+}
+
+startProgram()

--- a/BankManagerConsoleApp/BankManagerConsoleApp/main.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/main.swift
@@ -17,13 +17,18 @@ fileprivate extension Constants {
     static let whiteSpace = " "
 }
 
-let bankClerk = BankClerk(name: "임시", workSpeed: Constants.workSpeed)
-let bank = Bank(bankClerk: bankClerk, clientCount: Int.random(in: Constants.range))
+do {
+    let bankClerk = BankClerk(name: "임시", workSpeed: Constants.workSpeed)
+    let bank = Bank(bankClerk: bankClerk, clientCount: Int.random(in: Constants.range))
+    try startProgram(bank: bank, bankClerk: bankClerk)
+} catch {
+    print(error.localizedDescription)
+}
 
-func startProgram(bank: Bank, bankClerk: BankClerk) {
+func startProgram(bank: Bank, bankClerk: BankClerk) throws {
     while true {
         printMenu()
-        let userInput = receivedUserInput()
+        let userInput = try receivedUserInput()
         
         switch userInput {
         case Constants.bankOpen:
@@ -41,12 +46,10 @@ fileprivate func printMenu() {
     print(menu, terminator: Constants.whiteSpace)
 }
 
-fileprivate func receivedUserInput() -> String {
+fileprivate func receivedUserInput() throws -> String {
     guard let userInput = readLine() else {
-        return ""
+        throw BankError.wrongInput
     }
     
     return userInput
 }
-
-startProgram(bank: bank, bankClerk: bankClerk)

--- a/BankManagerConsoleApp/BankManagerConsoleApp/main.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/main.swift
@@ -10,17 +10,17 @@ fileprivate extension Constants {
     static let temporaryName = "임시이름"
 }
 
-let bankClerk = BankClerk(
+private let bankClerk = BankClerk(
     name: Constants.temporaryName,
     workSpeed: Constants.workSpeed
 )
 
-let bank = Bank(
+private let bank = Bank(
     bankClerk: bankClerk,
     clientCount: Int.random(in: Constants.clientCountRange)
 )
 
-let bankManager = BankManager(
+private let bankManager = BankManager(
     bankClerk: bankClerk,
     bank: bank
 )

--- a/BankManagerConsoleApp/BankManagerConsoleApp/main.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/main.swift
@@ -5,6 +5,8 @@
 //
 
 fileprivate extension Constants {
+    static let range: ClosedRange<Int> = 10 ... 30
+    static let workSpeed: Double = 700000
     static let bankOpen = "1"
     static let exit = "2"
     static let menu = """
@@ -15,11 +17,10 @@ fileprivate extension Constants {
     static let whiteSpace = " "
 }
 
-func startProgram() {
-    // TODO: 매직넘버, 매직스트링 커버, 은행 생성, 에러처리
-    let bankClerk = BankClerk(name: "임시")
-    let bank = Bank(bankClerk: bankClerk)
-    
+let bankClerk = BankClerk(name: "임시", workSpeed: Constants.workSpeed)
+let bank = Bank(bankClerk: bankClerk, clientCount: Int.random(in: Constants.range))
+
+func startProgram(bank: Bank, bankClerk: BankClerk) {
     while true {
         printMenu()
         let userInput = receivedUserInput()
@@ -48,4 +49,4 @@ fileprivate func receivedUserInput() -> String {
     return userInput
 }
 
-startProgram()
+startProgram(bank: bank, bankClerk: bankClerk)

--- a/BankManagerConsoleApp/BankManagerConsoleApp/main.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/main.swift
@@ -5,52 +5,28 @@
 //
 
 fileprivate extension Constants {
-    static let range: ClosedRange<Int> = 10 ... 30
-    static let workSpeed: UInt32 = 700000
-    static let bankOpen = "1"
-    static let exit = "2"
-    static let menu = """
-    1 : 은행개점
-    2 : 종료
-    입력 :
-    """
-    static let whiteSpace = " "
+    static let clientCountRange: ClosedRange<Int> = 10 ... 30
+    static let workSpeed: Double = 0.7
     static let temporaryName = "임시이름"
 }
 
+let bankClerk = BankClerk(
+    name: Constants.temporaryName,
+    workSpeed: Constants.workSpeed
+)
+
+let bank = Bank(
+    bankClerk: bankClerk,
+    clientCount: Int.random(in: Constants.clientCountRange)
+)
+
+let bankManager = BankManager(
+    bankClerk: bankClerk,
+    bank: bank
+)
+
 do {
-    let bankClerk = BankClerk(name: Constants.temporaryName, workSpeed: Constants.workSpeed)
-    let bank = Bank(bankClerk: bankClerk, clientCount: Int.random(in: Constants.range))
-    try startProgram(bank: bank, bankClerk: bankClerk)
+    try bankManager.startProgram(bank: bank, bankClerk: bankClerk)
 } catch {
     print(error.localizedDescription)
-}
-
-func startProgram(bank: Bank, bankClerk: BankClerk) throws {
-    while true {
-        printMenu()
-        let userInput = try receivedUserInput()
-        
-        switch userInput {
-        case Constants.bankOpen:
-            bank.open()
-        case Constants.exit:
-            return
-        default:
-            continue
-        }
-    }
-}
-
-fileprivate func printMenu() {
-    let menu = Constants.menu
-    print(menu, terminator: Constants.whiteSpace)
-}
-
-fileprivate func receivedUserInput() throws -> String {
-    guard let userInput = readLine() else {
-        throw BankError.wrongInput
-    }
-    
-    return userInput
 }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/main.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/main.swift
@@ -6,13 +6,16 @@
 
 func startProgram() {
     // TODO: 매직넘버, 매직스트링 커버, 은행 생성, 에러처리
+    let bankClerk = BankClerk(name: "은행원1")
+    let bank = Bank(bankClerk: bankClerk)
+    
     while true {
         printMenu()
         let userInput = receivedUserInput()
         
         switch userInput {
         case "1":
-            print("은행 개점")
+            bank.open()
         case "2":
             return
         default:

--- a/BankManagerConsoleApp/BankManagerConsoleApp/main.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/main.swift
@@ -4,9 +4,20 @@
 //  Copyright © yagom academy. All rights reserved.
 //
 
+fileprivate extension Constants {
+    static let bankOpen = "1"
+    static let exit = "2"
+    static let menu = """
+    1 : 은행개점
+    2 : 종료
+    입력 :
+    """
+    static let whiteSpace = " "
+}
+
 func startProgram() {
     // TODO: 매직넘버, 매직스트링 커버, 은행 생성, 에러처리
-    let bankClerk = BankClerk(name: "은행원1")
+    let bankClerk = BankClerk(name: "임시")
     let bank = Bank(bankClerk: bankClerk)
     
     while true {
@@ -14,9 +25,9 @@ func startProgram() {
         let userInput = receivedUserInput()
         
         switch userInput {
-        case "1":
+        case Constants.bankOpen:
             bank.open()
-        case "2":
+        case Constants.exit:
             return
         default:
             continue
@@ -25,12 +36,8 @@ func startProgram() {
 }
 
 fileprivate func printMenu() {
-    let menu = """
-    1 : 은행개점
-    2 : 종료
-    입력 :
-    """
-    print(menu, terminator: " ")
+    let menu = Constants.menu
+    print(menu, terminator: Constants.whiteSpace)
 }
 
 fileprivate func receivedUserInput() -> String {

--- a/BankManagerConsoleApp/BankManagerConsoleApp/main.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/main.swift
@@ -5,6 +5,7 @@
 //
 
 func startProgram() {
+    // TODO: 매직넘버, 매직스트링 커버, 은행 생성, 에러처리
     while true {
         printMenu()
         let userInput = receivedUserInput()

--- a/BankManagerConsoleApp/BankManagerConsoleApp/main.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/main.swift
@@ -6,7 +6,7 @@
 
 fileprivate extension Constants {
     static let range: ClosedRange<Int> = 10 ... 30
-    static let workSpeed: Double = 700000
+    static let workSpeed: UInt32 = 700000
     static let bankOpen = "1"
     static let exit = "2"
     static let menu = """
@@ -15,10 +15,11 @@ fileprivate extension Constants {
     입력 :
     """
     static let whiteSpace = " "
+    static let temporaryName = "임시이름"
 }
 
 do {
-    let bankClerk = BankClerk(name: "임시", workSpeed: Constants.workSpeed)
+    let bankClerk = BankClerk(name: Constants.temporaryName, workSpeed: Constants.workSpeed)
     let bank = Bank(bankClerk: bankClerk, clientCount: Int.random(in: Constants.range))
     try startProgram(bank: bank, bankClerk: bankClerk)
 } catch {

--- a/BankManagerConsoleApp/BankManagerConsoleApp/main.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/main.swift
@@ -2,4 +2,13 @@
 //  BankManagerConsoleApp - main.swift
 //  Created by yagom. 
 //  Copyright © yagom academy. All rights reserved.
-// 
+//
+
+fileprivate func printMenu() {
+    let menu = """
+    1 : 은행개점
+    2 : 종료
+    입력 :
+    """
+    print(menu, terminator: " ")
+}


### PR DESCRIPTION
# 은행 창구 매니저 [STEP2]
@Monsteel 
안녕하세요 토니!!!
STEP2 구현 완료하여 PR 보내드립니다!!
잘 부탁드립니다🙇‍♂️

---

## 구현내용
- Client 타입 구현
- Bank 타입 구현
- BankClerk 타입 구현
- BankManager 타입 구현

---

## UML
<img src = https://user-images.githubusercontent.com/54234176/165666739-3917117f-89d5-4c73-9949-9ee110f4ae84.png width=700 height=700>

---

## 실행화면
![은행STEP2실행화면](https://user-images.githubusercontent.com/54234176/165666745-2fd123d3-29ae-4852-8ada-05213a7ceadf.gif)

---

## 고민한 점 및 질문

### 1. UML 작성
- 범용적으로 사용되는 constants가 존재할 수 있다는 것을 고려하여 네임스페이스로서 활용할 Constants 타입을 생성하였습니다.
- BankClerk.swift와 BankManager.swift에서 발생하는 매직넘버와 매직스트링을 Constant extension을 통해 각각의 파일에서 바로 확인 가능하도록 가독성을 높여주었습니다.
- 이런 경우에 Constants는 UML에서 어떻게 표현해야하는지 궁금합니다. 토니는 어떤식으로 표현하시나요?!

### 2. Delegate Pattern 적용
- BankClerk이 작업을 완료하면, Bank는 마감메시지를 출력해야합니다.
- BankClerk이 작업을 완료하면 Bank의 close()메소드가 실행되도록 하는데, 결합도를 낮추기 위해 delegate pattern을 적용해보았습니다.

### 3. BankClerk의 work 메서드
- GCD를 학습하고, 사용을 해보고자 현재로서는 불필요한 코드들이 들어가면서 코드가 많이 지저분 해진 것 같습니다😭
- 해당 부분에서 workItem의 코드블럭, 메서드의 수행 시간 측정하는 부분들을 메서드로 분리해볼 수 있을 것 같다 라고까지만 생각을 해본 것 같습니다.
- 이 부분은 토니에게 피드백을 받고 수정하는게 좋을 것 같아 우선 남겨두었습니다!

### 4. sleep
- 현재 은행원이 작업시간이 0.7초가 걸리는 요구사항이 있습니다.
- 해당 요구사항을 반영하기 위해 `Thread.sleep(forTimeInterval:)` 메서드를 사용했는데 이보다 더 나은 방향이 있을까요?!

### 5. Constants
- Constants를 사용할 때 하나의 네임스페이스에 모두 몰아넣고 사용하는 경우 해당 상수를 확인하고 싶을 때 매번 코드점핑이 된다고 생각했습니다.
- 그래서 2개 이상 파일에서 사용하지 않고 하나의 파일에서만 사용되는 상수들의 경우 `fileprivate extension Constants {}` 처럼 해당 파일에 Extension하여 사용했습니다.
- 해당 부분에 대해서 토니는 어떻게 생각하실까요?!

