### PR TITLE
은행 창구 매니저 [STEP3] 파프리, 마이노

### DIFF
--- a/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
+++ b/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		67251F2128195AAE00069BBA /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67251F2028195AAE00069BBA /* Constants.swift */; };
 		67251F23281960D100069BBA /* BankError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67251F22281960D100069BBA /* BankError.swift */; };
 		674062252816D35E0032A2AE /* Queue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 674062242816D35E0032A2AE /* Queue.swift */; };
+		67831DBF281F7CCC0062C7C8 /* BankService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67831DBE281F7CCC0062C7C8 /* BankService.swift */; };
 		A11246A32816CDFD00292332 /* LinkedList.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11246A22816CDFD00292332 /* LinkedList.swift */; };
 		A11246BB2816DBB300292332 /* QueueTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11246BA2816DBB300292332 /* QueueTest.swift */; };
 		A11246C42816DEF400292332 /* Queue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 674062242816D35E0032A2AE /* Queue.swift */; };
@@ -42,6 +43,7 @@
 		67251F2028195AAE00069BBA /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		67251F22281960D100069BBA /* BankError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BankError.swift; sourceTree = "<group>"; };
 		674062242816D35E0032A2AE /* Queue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Queue.swift; sourceTree = "<group>"; };
+		67831DBE281F7CCC0062C7C8 /* BankService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BankService.swift; sourceTree = "<group>"; };
 		9E7AA34411D40488271CC611 /* Pods-BankManagerConsoleApp.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BankManagerConsoleApp.release.xcconfig"; path = "Target Support Files/Pods-BankManagerConsoleApp/Pods-BankManagerConsoleApp.release.xcconfig"; sourceTree = "<group>"; };
 		A11246A22816CDFD00292332 /* LinkedList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkedList.swift; sourceTree = "<group>"; };
 		A11246A42816D15600292332 /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
@@ -103,6 +105,7 @@
 				67251F1D281912B700069BBA /* Bank.swift */,
 				A1E557C2281916BC008870CC /* BankClerk.swift */,
 				A1E557CC281A2CD3008870CC /* BankManager.swift */,
+				67831DBE281F7CCC0062C7C8 /* BankService.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -313,6 +316,7 @@
 				A1E557C3281916BC008870CC /* BankClerk.swift in Sources */,
 				C7694E7A259C3EC00053667F /* main.swift in Sources */,
 				67251F1E281912B700069BBA /* Bank.swift in Sources */,
+				67831DBF281F7CCC0062C7C8 /* BankService.swift in Sources */,
 				67251F2128195AAE00069BBA /* Constants.swift in Sources */,
 				A1E557C12819113E008870CC /* Client.swift in Sources */,
 				674062252816D35E0032A2AE /* Queue.swift in Sources */,

--- a/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
+++ b/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
@@ -11,7 +11,7 @@
 		67251F2128195AAE00069BBA /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67251F2028195AAE00069BBA /* Constants.swift */; };
 		67251F23281960D100069BBA /* BankError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67251F22281960D100069BBA /* BankError.swift */; };
 		674062252816D35E0032A2AE /* Queue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 674062242816D35E0032A2AE /* Queue.swift */; };
-		67831DBF281F7CCC0062C7C8 /* BankService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67831DBE281F7CCC0062C7C8 /* BankService.swift */; };
+		67831DBF281F7CCC0062C7C8 /* BankServiceType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67831DBE281F7CCC0062C7C8 /* BankServiceType.swift */; };
 		A11246A32816CDFD00292332 /* LinkedList.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11246A22816CDFD00292332 /* LinkedList.swift */; };
 		A11246BB2816DBB300292332 /* QueueTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11246BA2816DBB300292332 /* QueueTest.swift */; };
 		A11246C42816DEF400292332 /* Queue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 674062242816D35E0032A2AE /* Queue.swift */; };
@@ -43,7 +43,7 @@
 		67251F2028195AAE00069BBA /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		67251F22281960D100069BBA /* BankError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BankError.swift; sourceTree = "<group>"; };
 		674062242816D35E0032A2AE /* Queue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Queue.swift; sourceTree = "<group>"; };
-		67831DBE281F7CCC0062C7C8 /* BankService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BankService.swift; sourceTree = "<group>"; };
+		67831DBE281F7CCC0062C7C8 /* BankServiceType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BankServiceType.swift; sourceTree = "<group>"; };
 		9E7AA34411D40488271CC611 /* Pods-BankManagerConsoleApp.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BankManagerConsoleApp.release.xcconfig"; path = "Target Support Files/Pods-BankManagerConsoleApp/Pods-BankManagerConsoleApp.release.xcconfig"; sourceTree = "<group>"; };
 		A11246A22816CDFD00292332 /* LinkedList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkedList.swift; sourceTree = "<group>"; };
 		A11246A42816D15600292332 /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
@@ -105,7 +105,7 @@
 				67251F1D281912B700069BBA /* Bank.swift */,
 				A1E557C2281916BC008870CC /* BankClerk.swift */,
 				A1E557CC281A2CD3008870CC /* BankManager.swift */,
-				67831DBE281F7CCC0062C7C8 /* BankService.swift */,
+				67831DBE281F7CCC0062C7C8 /* BankServiceType.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -316,7 +316,7 @@
 				A1E557C3281916BC008870CC /* BankClerk.swift in Sources */,
 				C7694E7A259C3EC00053667F /* main.swift in Sources */,
 				67251F1E281912B700069BBA /* Bank.swift in Sources */,
-				67831DBF281F7CCC0062C7C8 /* BankService.swift in Sources */,
+				67831DBF281F7CCC0062C7C8 /* BankServiceType.swift in Sources */,
 				67251F2128195AAE00069BBA /* Constants.swift in Sources */,
 				A1E557C12819113E008870CC /* Client.swift in Sources */,
 				674062252816D35E0032A2AE /* Queue.swift in Sources */,

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Model/Bank.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Model/Bank.swift
@@ -50,7 +50,7 @@ final class Bank: Presentable {
     private func assignClientToBankClerk() {
         let group = DispatchGroup()
         
-        bankClerks.filter { $0.service == .deposit }.forEach { bankClerk in
+        bankClerks.filter { $0.bankService == .deposit }.forEach { bankClerk in
             assignWorkToBankClerk(
                 group: group,
                 queue: self.depositClientQueue,
@@ -58,7 +58,7 @@ final class Bank: Presentable {
             )
         }
         
-        bankClerks.filter { $0.service == .loan }.forEach { bankClerk in
+        bankClerks.filter { $0.bankService == .loan }.forEach { bankClerk in
             assignWorkToBankClerk(
                 group: group,
                 queue: self.loanClientQueue,

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Model/Bank.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Model/Bank.swift
@@ -14,12 +14,15 @@ fileprivate extension Constants {
 final class Bank: Presentable {
     private let bankClerks: [BankClerk]
     private let clientCount: Int
-    private let depositClientQueue = Queue<Client>()
-    private let loanClientQueue = Queue<Client>()
+    private let queueDictionary: [String: Queue<Client>]
     
-    init(bankClerks: [BankClerk], clientCount: Int) {
+    init(bankClerks: [BankClerk],
+         clientCount: Int,
+         queueDictionary: [String: Queue<Client>]
+    ) {
         self.bankClerks = bankClerks
         self.clientCount = clientCount
+        self.queueDictionary = queueDictionary
     }
     
     func open() {
@@ -53,7 +56,7 @@ final class Bank: Presentable {
         bankClerks.filter { $0.bankService == .deposit }.forEach { bankClerk in
             assignWorkToBankClerk(
                 group: group,
-                queue: self.depositClientQueue,
+                queue: queueDictionary["예금"] ?? Queue<Client>(),
                 bankClerk: bankClerk
             )
         }
@@ -61,7 +64,7 @@ final class Bank: Presentable {
         bankClerks.filter { $0.bankService == .loan }.forEach { bankClerk in
             assignWorkToBankClerk(
                 group: group,
-                queue: self.loanClientQueue,
+                queue: queueDictionary["대출"] ?? Queue<Client>(),
                 bankClerk: bankClerk
             )
         }
@@ -85,9 +88,9 @@ final class Bank: Presentable {
         let client = Client(waitingNumber: waitingNumber, bankService: .randomBankService)
         switch client.bankService {
         case .deposit:
-            depositClientQueue.enqueue(client)
+            queueDictionary["예금"]?.enqueue(client)
         case .loan:
-            loanClientQueue.enqueue(client)
+            queueDictionary["대출"]?.enqueue(client)
         }
     }
     

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Model/Bank.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Model/Bank.swift
@@ -49,15 +49,12 @@ final class Bank: Presentable {
     
     private func assignClientToBankClerk() {
         let group = DispatchGroup()
-        let depositSemaphore = DispatchSemaphore(value: Constants.numberOfDepositBankClerks)
-        let loanSemaphore = DispatchSemaphore(value: Constants.numberOfLoanBankClerks)
         
         bankClerks.filter { $0.service == .deposit }.forEach { bankClerk in
             assignWorkToBankClerk(
                 group: group,
                 queue: self.depositClientQueue,
-                bankClerk: bankClerk,
-                semaphore: depositSemaphore
+                bankClerk: bankClerk
             )
         }
         
@@ -65,8 +62,7 @@ final class Bank: Presentable {
             assignWorkToBankClerk(
                 group: group,
                 queue: self.loanClientQueue,
-                bankClerk: bankClerk,
-                semaphore: loanSemaphore
+                bankClerk: bankClerk
             )
         }
         
@@ -76,15 +72,12 @@ final class Bank: Presentable {
     private func assignWorkToBankClerk(
         group: DispatchGroup,
         queue: Queue<Client>,
-        bankClerk: BankClerk,
-        semaphore: DispatchSemaphore
+        bankClerk: BankClerk
     ) {
         DispatchQueue.global().async(group: group) {
-            semaphore.wait()
             while let client = queue.dequeue() {
                 bankClerk.work(client: client)
             }
-            semaphore.signal()
         }
     }
     

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Model/Bank.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Model/Bank.swift
@@ -41,6 +41,16 @@ final class Bank: Presentable {
         }
     }
     
+    private func classifyClients(waitingNumber: Int) {
+        let client = Client(waitingNumber: waitingNumber, bankService: .randomBankService)
+        switch client.bankService {
+        case .deposit:
+            queueDictionary[BankServiceType.deposit.description]?.enqueue(client)
+        case .loan:
+            queueDictionary[BankServiceType.loan.description]?.enqueue(client)
+        }
+    }
+    
     private func measureTotalWorkTime(_ task: () -> Void) -> String {
         let startTime = CFAbsoluteTimeGetCurrent()
         task()
@@ -56,7 +66,7 @@ final class Bank: Presentable {
         bankClerks.filter { $0.bankService == .deposit }.forEach { bankClerk in
             assignWorkToBankClerk(
                 group: group,
-                queue: queueDictionary["예금"] ?? Queue<Client>(),
+                queue: queueDictionary[BankServiceType.deposit.description] ?? Queue<Client>(),
                 bankClerk: bankClerk
             )
         }
@@ -64,7 +74,7 @@ final class Bank: Presentable {
         bankClerks.filter { $0.bankService == .loan }.forEach { bankClerk in
             assignWorkToBankClerk(
                 group: group,
-                queue: queueDictionary["대출"] ?? Queue<Client>(),
+                queue: queueDictionary[BankServiceType.loan.description] ?? Queue<Client>(),
                 bankClerk: bankClerk
             )
         }
@@ -81,16 +91,6 @@ final class Bank: Presentable {
             while let client = queue.dequeue() {
                 bankClerk.work(client: client)
             }
-        }
-    }
-    
-    private func classifyClients(waitingNumber: Int) {
-        let client = Client(waitingNumber: waitingNumber, bankService: .randomBankService)
-        switch client.bankService {
-        case .deposit:
-            queueDictionary["예금"]?.enqueue(client)
-        case .loan:
-            queueDictionary["대출"]?.enqueue(client)
         }
     }
     

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Model/Bank.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Model/Bank.swift
@@ -33,26 +33,29 @@ final class Bank: Presentable {
     }
     
     private func assignClientToBankClerk() {
-        
-        let dispatchGroup = DispatchGroup()
+        let group = DispatchGroup()
         
         bankClerks.filter { $0.service == .deposit }.forEach { bankClerk in
-            DispatchQueue.global().async(group: dispatchGroup) {
-                while let client = self.depositClientQueue.dequeue() {
-                    bankClerk.work(client: client)
-                }
-            }
+            assignWorkToBankClerk(group: group, queue: self.depositClientQueue, bankClerk: bankClerk)
         }
         
         bankClerks.filter { $0.service == .loan }.forEach { bankClerk in
-            DispatchQueue.global().async(group: dispatchGroup) {
-                while let client = self.loanClientQueue.dequeue() {
-                    bankClerk.work(client: client)
-                }
-            }
+            assignWorkToBankClerk(group: group, queue: self.loanClientQueue, bankClerk: bankClerk)
         }
         
-        dispatchGroup.wait()
+        group.wait()
+    }
+    
+    private func assignWorkToBankClerk(
+        group: DispatchGroup,
+        queue: Queue<Client>,
+        bankClerk: BankClerk
+    ) {
+        DispatchQueue.global().async(group: group) {
+            while let client = queue.dequeue() {
+                bankClerk.work(client: client)
+            }
+        }
     }
     
     private func receiveClients() {

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Model/Bank.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Model/Bank.swift
@@ -13,11 +13,11 @@ fileprivate extension Constants {
 
 final class Bank: Presentable {
     private let clientQueue = Queue<Client>()
-    private let bankClerk: BankClerk
+    private let bankClerks: [BankClerk]
     private let clientCount: Int
     
-    init(bankClerk: BankClerk, clientCount: Int) {
-        self.bankClerk = bankClerk
+    init(bankClerks: [BankClerk], clientCount: Int) {
+        self.bankClerks = bankClerks
         self.clientCount = clientCount
     }
     
@@ -25,7 +25,7 @@ final class Bank: Presentable {
         receiveClients()
         
         let totalWorkTime = measureTotalWorkTime {
-            bankClerk.work(clientQueue)
+
         }
         
         close(totalWorkTime: totalWorkTime)
@@ -33,7 +33,7 @@ final class Bank: Presentable {
     
     private func receiveClients() {
         for order in 1 ... clientCount {
-            clientQueue.enqueue(Client(waitingNumber: order))
+            clientQueue.enqueue(Client(waitingNumber: order, bankService: .randomBankService))
         }
     }
     

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Model/BankClerk.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Model/BankClerk.swift
@@ -9,33 +9,16 @@ import Foundation
 
 final class BankClerk: Presentable {
     private let name: String
-    private let service: BankService
+    private(set) var service: BankService
     
     init(name: String, service: BankService) {
         self.name = name
         self.service = service
     }
     
-    func work(_ queue: Queue<Client>) {
-        let workQueue = DispatchQueue(label: name)
-        let workItem = createWorkItem(queue)
-        
-        while queue.isEmpty == false {
-            workQueue.sync(execute: workItem)
-        }
-    }
-    
-    private func createWorkItem(_ queue: Queue<Client>) -> DispatchWorkItem {
-        DispatchWorkItem {
-            guard let client = queue.peek else {
-                return
-            }
-            
-            self.printStartTaskMessage(waitingNumber: client.waitingNumber)
-            Thread.sleep(forTimeInterval: self.service.requiredTime)
-            self.printFinishTaskMessage(waitingNumber: client.waitingNumber)
-            
-            queue.dequeue()
-        }
+    func work(client: Client) {
+        self.printStartTaskMessage(client: client)
+        Thread.sleep(forTimeInterval: self.service.requiredTime)
+        self.printFinishTaskMessage(client: client)
     }
 }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Model/BankClerk.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Model/BankClerk.swift
@@ -9,16 +9,16 @@ import Foundation
 
 final class BankClerk: Presentable {
     private let name: String
-    private(set) var service: BankService
+    private(set) var bankService: BankServiceType
     
-    init(name: String, service: BankService) {
+    init(name: String, service: BankServiceType) {
         self.name = name
-        self.service = service
+        self.bankService = service
     }
     
     func work(client: Client) {
         self.printStartTaskMessage(client: client)
-        Thread.sleep(forTimeInterval: self.service.requiredTime)
+        Thread.sleep(forTimeInterval: self.bankService.requiredTime)
         self.printFinishTaskMessage(client: client)
     }
 }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Model/BankClerk.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Model/BankClerk.swift
@@ -11,9 +11,9 @@ final class BankClerk: Presentable {
     private let name: String
     private(set) var bankService: BankServiceType
     
-    init(name: String, service: BankServiceType) {
+    init(name: String, bankService: BankServiceType) {
         self.name = name
-        self.bankService = service
+        self.bankService = bankService
     }
     
     func work(client: Client) {

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Model/BankClerk.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Model/BankClerk.swift
@@ -9,11 +9,11 @@ import Foundation
 
 final class BankClerk: Presentable {
     private let name: String
-    private let workSpeed: Double
+    private let service: BankService
     
-    init(name: String, workSpeed: Double) {
+    init(name: String, service: BankService) {
         self.name = name
-        self.workSpeed = workSpeed
+        self.service = service
     }
     
     func work(_ queue: Queue<Client>) {
@@ -32,7 +32,7 @@ final class BankClerk: Presentable {
             }
             
             self.printStartTaskMessage(waitingNumber: client.waitingNumber)
-            Thread.sleep(forTimeInterval: self.workSpeed)
+            Thread.sleep(forTimeInterval: self.service.requiredTime)
             self.printFinishTaskMessage(waitingNumber: client.waitingNumber)
             
             queue.dequeue()

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Model/BankManager.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Model/BankManager.swift
@@ -17,15 +17,13 @@ fileprivate extension Constants {
 }
 
 struct BankManager {
-    private let bankClerk: BankClerk
     private let bank: Bank
     
-    init(bankClerk: BankClerk, bank: Bank) {
-        self.bankClerk = bankClerk
+    init(bank: Bank) {
         self.bank = bank
     }
     
-    func startProgram(bank: Bank, bankClerk: BankClerk) throws {
+    func startProgram() throws {
         while true {
             printMenu()
             let userInput = try receivedUserInput()

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Model/BankService.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Model/BankService.swift
@@ -33,7 +33,7 @@ extension BankService {
 }
 
 extension BankService {
-    static var generateRandomBankService: BankService {
+    static var randomBankService: BankService {
         guard let bankService = self.allCases.randomElement() else {
             return .deposit
         }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Model/BankService.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Model/BankService.swift
@@ -1,0 +1,42 @@
+//
+//  BankService.swift
+//  BankManagerConsoleApp
+//
+//  Created by 허윤영 on 02/05/2022.
+//
+
+import Foundation
+
+enum BankService: CaseIterable {
+    case deposit
+    case loan
+}
+
+extension BankService {
+    var description: String {
+        switch self {
+        case .deposit:
+            return "예금"
+        case .loan:
+            return "대출"
+        }
+    }
+    
+    var requiredTime: Double {
+        switch self {
+        case .deposit:
+            return 0.7
+        case .loan:
+            return 1.1
+        }
+    }
+}
+
+extension BankService {
+    static var generateRandomBankService: BankService {
+        guard let bankService = self.allCases.randomElement() else {
+            return .deposit
+        }
+        return bankService
+    }
+}

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Model/BankService.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Model/BankService.swift
@@ -12,7 +12,7 @@ enum BankService: CaseIterable {
     case loan
 }
 
-extension BankService {
+extension BankService: CustomStringConvertible {
     var description: String {
         switch self {
         case .deposit:

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Model/BankServiceType.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Model/BankServiceType.swift
@@ -7,12 +7,12 @@
 
 import Foundation
 
-enum BankService: CaseIterable {
+enum BankServiceType: CaseIterable {
     case deposit
     case loan
 }
 
-extension BankService: CustomStringConvertible {
+extension BankServiceType: CustomStringConvertible {
     var description: String {
         switch self {
         case .deposit:
@@ -32,8 +32,8 @@ extension BankService: CustomStringConvertible {
     }
 }
 
-extension BankService {
-    static var randomBankService: BankService {
+extension BankServiceType {
+    static var randomBankService: BankServiceType {
         guard let bankService = self.allCases.randomElement() else {
             return .deposit
         }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Model/Client.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Model/Client.swift
@@ -7,4 +7,5 @@
 
 struct Client {
     let waitingNumber: Int
+    let bankService: BankService
 }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Model/Client.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Model/Client.swift
@@ -7,5 +7,5 @@
 
 struct Client {
     let waitingNumber: Int
-    let bankService: BankService
+    let bankService: BankServiceType
 }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Model/LinkedList.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Model/LinkedList.swift
@@ -5,6 +5,8 @@
 //  Created by 조민호 on 2022/04/25.
 //
 
+import Foundation
+
 final public class LinkedList<Element> {
     final private class Node {
         var element: Element
@@ -17,6 +19,7 @@ final public class LinkedList<Element> {
     
     private var head: Node?
     private var tail: Node?
+    private let lockQueue = DispatchQueue(label: "lockQueue")
     
     var isEmpty: Bool {
         return head == nil
@@ -39,13 +42,17 @@ final public class LinkedList<Element> {
     }
     
     func removeFirst() -> Element? {
-        guard isEmpty == false else {
-            return nil
+        var element: Element?
+        
+        lockQueue.sync {
+            guard let removedNode = head else {
+                return
+            }
+            head = removedNode.next
+            element = removedNode.element
         }
         
-        let removedNode = head
-        head = removedNode?.next
-        return removedNode?.element
+        return element
     }
     
     func removeAll() {

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Protocol/Presentable.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Protocol/Presentable.swift
@@ -14,11 +14,11 @@ extension Presentable where Self: Bank {
 }
 
 extension Presentable where Self: BankClerk {
-    func printStartTaskMessage(waitingNumber: Int) {
-        print("\(waitingNumber)번 고객 업무 시작")
+    func printStartTaskMessage(client: Client) {
+        print("\(client.waitingNumber)번 고객 \(client.bankService)업무 시작")
     }
     
-    func printFinishTaskMessage(waitingNumber: Int) {
-        print("\(waitingNumber)번 고객 업무 완료")
+    func printFinishTaskMessage(client: Client) {
+        print("\(client.waitingNumber)번 고객 \(client.bankService)업무 완료")
     }
 }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Util/Constants.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Util/Constants.swift
@@ -5,4 +5,7 @@
 //  Created by 허윤영 on 27/04/2022.
 //
 
-enum Constants {}
+enum Constants {
+    static let numberOfDepositBankClerks: Int = 2
+    static let numberOfLoanBankClerks: Int = 1
+}

--- a/BankManagerConsoleApp/BankManagerConsoleApp/main.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/main.swift
@@ -11,6 +11,16 @@ fileprivate extension Constants {
     
 }
 
+private let bank = Bank(
+    bankClerks: createBankClerk(
+        Constants.numberOfDepositBankClerks,
+        Constants.numberOfLoanBankClerks
+    ),
+    clientCount: Int.random(in: Constants.clientCountRange)
+)
+
+private let bankManager = BankManager(bank: bank)
+
 private func createBankClerk(
     _ numberOfDepositBankClerks: Int,
     _ numberOfLoanBankClerks: Int
@@ -37,18 +47,6 @@ private func createBankClerk(
     
     return bankClerks
 }
-
-private let bank = Bank(
-    bankClerks: createBankClerk(
-        Constants.numberOfDepositBankClerks,
-        Constants.numberOfLoanBankClerks
-    ),
-    clientCount: Int.random(in: Constants.clientCountRange)
-)
-
-private let bankManager = BankManager(
-    bank: bank
-)
 
 do {
     try bankManager.startProgram()

--- a/BankManagerConsoleApp/BankManagerConsoleApp/main.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/main.swift
@@ -6,27 +6,52 @@
 
 fileprivate extension Constants {
     static let clientCountRange: ClosedRange<Int> = 10 ... 30
-    static let workSpeed: Double = 0.7
-    static let temporaryName = "임시이름"
+    static let numberOfDepositBankClerks: Int = 2
+    static let numberOfLoanBankClerks: Int = 1
+    
 }
 
-private let bankClerk = BankClerk(
-    name: Constants.temporaryName,
-    workSpeed: Constants.workSpeed
-)
+private func createBankClerk(
+    _ numberOfDepositBankClerks: Int,
+    _ numberOfLoanBankClerks: Int
+) -> [BankClerk] {
+    var bankClerks: [BankClerk] = []
+    
+    for order in 1 ... numberOfDepositBankClerks {
+        bankClerks.append(
+            BankClerk(
+                name: "\(BankService.deposit)\(order)",
+                service: .deposit
+            )
+        )
+    }
+    
+    for order in 1 ... numberOfLoanBankClerks {
+        bankClerks.append(
+            BankClerk(
+                name: "\(BankService.loan)\(order)",
+                service: .loan
+            )
+        )
+    }
+    
+    return bankClerks
+}
 
 private let bank = Bank(
-    bankClerk: bankClerk,
+    bankClerks: createBankClerk(
+        Constants.numberOfDepositBankClerks,
+        Constants.numberOfLoanBankClerks
+    ),
     clientCount: Int.random(in: Constants.clientCountRange)
 )
 
 private let bankManager = BankManager(
-    bankClerk: bankClerk,
     bank: bank
 )
 
 do {
-    try bankManager.startProgram(bank: bank, bankClerk: bankClerk)
+    try bankManager.startProgram()
 } catch {
     print(error.localizedDescription)
 }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/main.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/main.swift
@@ -8,15 +8,28 @@ fileprivate extension Constants {
     static let clientCountRange: ClosedRange<Int> = 10 ... 30
 }
 
+typealias QueueDictionary = [String: Queue<Client>]
+
 private let bank = Bank(
     bankClerks: createBankClerk(
         Constants.numberOfDepositBankClerks,
         Constants.numberOfLoanBankClerks
     ),
-    clientCount: Int.random(in: Constants.clientCountRange)
+    clientCount: Int.random(in: Constants.clientCountRange),
+    queueDictionary: createQueueDictionary()
 )
 
 private let bankManager = BankManager(bank: bank)
+
+private func createQueueDictionary() -> QueueDictionary {
+    var queueDictionary: QueueDictionary = [:]
+    
+    BankServiceType.allCases.forEach { bankService in
+        queueDictionary.updateValue(Queue<Client>(), forKey: bankService.description)
+    }
+    
+    return queueDictionary
+}
 
 private func createBankClerk(
     _ numberOfDepositBankClerks: Int,

--- a/BankManagerConsoleApp/BankManagerConsoleApp/main.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/main.swift
@@ -6,9 +6,6 @@
 
 fileprivate extension Constants {
     static let clientCountRange: ClosedRange<Int> = 10 ... 30
-    static let numberOfDepositBankClerks: Int = 2
-    static let numberOfLoanBankClerks: Int = 1
-    
 }
 
 private let bank = Bank(

--- a/BankManagerConsoleApp/BankManagerConsoleApp/main.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/main.swift
@@ -27,7 +27,7 @@ private func createBankClerk(
     for order in 1 ... numberOfDepositBankClerks {
         bankClerks.append(
             BankClerk(
-                name: "\(BankService.deposit)\(order)",
+                name: "\(BankServiceType.deposit)\(order)",
                 service: .deposit
             )
         )
@@ -36,7 +36,7 @@ private func createBankClerk(
     for order in 1 ... numberOfLoanBankClerks {
         bankClerks.append(
             BankClerk(
-                name: "\(BankService.loan)\(order)",
+                name: "\(BankServiceType.loan)\(order)",
                 service: .loan
             )
         )

--- a/BankManagerConsoleApp/BankManagerConsoleApp/main.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/main.swift
@@ -28,7 +28,7 @@ private func createBankClerk(
         bankClerks.append(
             BankClerk(
                 name: "\(BankServiceType.deposit)\(order)",
-                service: .deposit
+                bankService: .deposit
             )
         )
     }
@@ -37,7 +37,7 @@ private func createBankClerk(
         bankClerks.append(
             BankClerk(
                 name: "\(BankServiceType.loan)\(order)",
-                service: .loan
+                bankService: .loan
             )
         )
     }


### PR DESCRIPTION
# 은행 창구 매니저 [STEP3]
@Monsteel 
안녕하세요 토니!!!!
STEP3 구현 완료하여 PR 요청 드립니다!!!
잘 부탁드립니다!!!🙇‍♂️

---

## 구현내용
- BankService: 은행 업무와 관련된 Enum
- 업무에 따른 고객 큐 분리
- 업무에 따른 은행원 업무 할당
- 비동기 처리

---

## UML
![](https://i.imgur.com/omd7L1K.png)

---

## 실행화면
![](https://i.imgur.com/CGOX2dN.gif)

---

## 고민한 점 및 질문

### 1. UML
- 이전 스텝에서 조언해주신걸 토대로 Constants를 재구성 해보았습니다. 토니가 말씀해주신 부분이 맞을까요?!

### 2. 확장성
이번 프로젝트에서는
고객(`Client`)의 은행업무(`BankService`)에 따라
해당 업무를 담당하는 은행원(`BankClerk`)이 해당 고객의 업무를 처리 할 수 있어야 했습니다.
이를 위해`Bank` 의 프로퍼티로
`private let depositClientQueue = Queue<Client>()`
`private let loanClientQueue = Queue<Client>()`
를 두었습니다.

추후에 은행업무가 다양해지거나, 은행원이 담당할 수 있는 업무가 하나 이상이 되는 경우 새롭게 Bank에 해당 업무를 보기위한 고객들의 큐를 프로퍼티로 두어야하고, 코드 안에서 수정해야하는 부분이 많음을 느꼈습니다.
좀 더 확장이 유연하게 될 수 있도록 수정하고 싶은데, 이를 위해 공부할만한 키워드를 던져주실 수 있으실까요?!


### 3. Data Race
* Xcode의 기본 기능인 Thread Sanitizer을 통해 Data Race가 발생하는지 확인하였습니다.
![](https://i.imgur.com/RsHWKYQ.png)

위의 이미지와 같은 Threading Issue를 확인 할 수 있었습니다.
- 해당 부분을 해결하기 위해 linkedList의 removeFirst() 메서드에서 Serial Queue와 flags 파라미터의 값을 barrier로 시도를 해보았지만 해결하지 못하였습니다😭

### 4. 은행원 수 == Thread의 수
- 은행원 수 만큼만의 Thread를 생성하기 위해 은행원 배열만큼을 for문을 돌려 해당 횟수 만큼만 global().async를 통해 thread를 생성하도록 하였습니다.

감사합니다!!!