### PR TITLE
은행 창구 매니저 [STEP3] mmim, malrang

### DIFF
--- a/BankManager.swift
+++ b/BankManager.swift
@@ -21,7 +21,10 @@ final class BankManager {
         self.bank = bank
     }
     
+    func taskStart() {
+        bank.assignByWork(bank.loanClerksCount, bank.depositClerksCount)
         showMenuMessage()
+        
         guard let selectedOption = SelectOptionType(rawValue: inputNumber()) else {
             return taskStart()
         }

--- a/BankManager.swift
+++ b/BankManager.swift
@@ -21,17 +21,6 @@ final class BankManager {
         self.bank = bank
     }
     
-    mutating func hireClerks(loanClerk: Int, depositClerk: Int) {
-        for _ in 0..<loanClerk {
-            bank.assignClerk(by: .loan)
-        }
-        
-        for _ in 0..<depositClerk {
-            bank.assignClerk(by: .deposit)
-        }
-    }
-    
-    mutating func taskStart() {
         showMenuMessage()
         guard let selectedOption = SelectOptionType(rawValue: inputNumber()) else {
             return taskStart()

--- a/BankManager.swift
+++ b/BankManager.swift
@@ -21,6 +21,16 @@ struct BankManager {
         self.bank = bank
     }
     
+    mutating func hireClerks(loanClerk: Int, depositClerk: Int) {
+        for _ in 0..<loanClerk {
+            bank.assignClerk(by: .loan)
+        }
+        
+        for _ in 0..<depositClerk {
+            bank.assignClerk(by: .deposit)
+        }
+    }
+    
     mutating func taskStart() {
         showMenuMessage()
         guard let selectedOption = SelectOptionType(rawValue: inputNumber()) else {

--- a/BankManager.swift
+++ b/BankManager.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct BankManager {
+final class BankManager {
     private enum Text {
         static let open = "1 : 은행개점"
         static let close = "2 : 종료"

--- a/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
+++ b/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		030645682816CD7600A70C0E /* Node.swift in Sources */ = {isa = PBXBuildFile; fileRef = 030645672816CD7600A70C0E /* Node.swift */; };
 		038CC73E28184EB9008CE5C6 /* Queue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 038CC73D28184EB9008CE5C6 /* Queue.swift */; };
+		03AA3A992820BE3E00A5E2F5 /* WorkType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03AA3A982820BE3E00A5E2F5 /* WorkType.swift */; };
 		03B6257B2819A9AE00403C66 /* LinkedList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3064A8672816DFB900317449 /* LinkedList.swift */; };
 		03B6257C2819A9B500403C66 /* Node.swift in Sources */ = {isa = PBXBuildFile; fileRef = 030645672816CD7600A70C0E /* Node.swift */; };
 		03DAA7DF281AD2EF009BEF7A /* Bank.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03DAA7DE281AD2EF009BEF7A /* Bank.swift */; };
@@ -45,6 +46,7 @@
 /* Begin PBXFileReference section */
 		030645672816CD7600A70C0E /* Node.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Node.swift; sourceTree = "<group>"; };
 		038CC73D28184EB9008CE5C6 /* Queue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Queue.swift; sourceTree = "<group>"; };
+		03AA3A982820BE3E00A5E2F5 /* WorkType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkType.swift; sourceTree = "<group>"; };
 		03B625732819A97E00403C66 /* LinkedListTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = LinkedListTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		03B625752819A97E00403C66 /* LinkedListTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkedListTests.swift; sourceTree = "<group>"; };
 		03DAA7DE281AD2EF009BEF7A /* Bank.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Bank.swift; sourceTree = "<group>"; };
@@ -158,6 +160,7 @@
 				03DAA7DE281AD2EF009BEF7A /* Bank.swift */,
 				03DAA7E2281B1B8D009BEF7A /* Workable.swift */,
 				03DAA7E4281B1BCF009BEF7A /* BankClerk.swift */,
+				03AA3A982820BE3E00A5E2F5 /* WorkType.swift */,
 				03DAA7E0281AD33E009BEF7A /* Client.swift */,
 				30EB2350281AEAD1003840BC /* SelectOption.swift */,
 				03DAA7E6281B1CA2009BEF7A /* DataStructure */,
@@ -350,6 +353,7 @@
 			files = (
 				038CC73E28184EB9008CE5C6 /* Queue.swift in Sources */,
 				305C6F6B281A9E82000A2621 /* Listable.swift in Sources */,
+				03AA3A992820BE3E00A5E2F5 /* WorkType.swift in Sources */,
 				03DAA7E3281B1B8D009BEF7A /* Workable.swift in Sources */,
 				030645682816CD7600A70C0E /* Node.swift in Sources */,
 				C7694E7A259C3EC00053667F /* main.swift in Sources */,

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
@@ -24,10 +24,11 @@ struct Bank {
         print(resultMessage)
     }
     
-    @discardableResult
-    private mutating func receiveClients() -> Int {
+    private mutating func receiveClients() {
         for order in 1...Int.random(in: 10...30) {
-            clientQueue.enqueue(Client(order))
+            arrangeByWorkType(Client(order))
+        }
+    }
     
     private mutating func arrangeByWorkType(_ client: Client) {
         switch client.requirementType {

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
@@ -41,6 +41,13 @@ struct Bank {
         return clientQueue.count
     }
     
+    private func measureWorkTime(_ block: () -> Void) -> Double {
+        let start = CFAbsoluteTimeGetCurrent()
+        block()
+        let interval = CFAbsoluteTimeGetCurrent() - start
+        return interval
+    }
+    
     private mutating func serveClients() {
         while let client = clientQueue.dequeue() {
             excuteWork(of: client)

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
@@ -12,6 +12,8 @@ final class Bank {
     private var loanClientQueue = Queue(list: LinkedList<Client>())
     private var depositClientQueue = Queue(list: LinkedList<Client>())
     private let operationQueue = OperationQueue()
+    private(set) var loanClerksCount: Int
+    private(set) var depositClerksCount: Int
     
     mutating func assignClerk(by workType: WorkType) {
         switch workType {

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
@@ -11,19 +11,20 @@ struct Bank {
     private let loanClerk: Workable
     private let depositClerk: Workable
     private var clientQueue = Queue(list: LinkedList<Client>())
+    private var semaphore: DispatchSemaphore
+    private let clerks = DispatchGroup()
     
     init(loanClerkCount: Int, depositClerkCount: Int) {
         self.loanClerk = BankClerk(workType: .loan, clerkCount: loanClerkCount)
         self.depositClerk = BankClerk(workType: .deposit, clerkCount: depositClerkCount)
+        self.semaphore = DispatchSemaphore(value: loanClerkCount + depositClerkCount)
     }
     
     mutating func executeBankWork() {
         let start = CFAbsoluteTimeGetCurrent()
         let numberOfClients = receiveClients()
         
-        DispatchQueue.global().sync {
-            serveClients()
-        }
+        serveClients()
         
         let interval = CFAbsoluteTimeGetCurrent() - start
         let resultDescription = "업무가 마감되었습니다. 오늘 업무를 처리한 고객은 총 %d명이며, 총 업무시간은 %.2f입니다."

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
@@ -15,14 +15,6 @@ final class Bank {
     private(set) var loanClerksCount: Int
     private(set) var depositClerksCount: Int
     
-    mutating func assignClerk(by workType: WorkType) {
-        switch workType {
-        case .loan:
-            let newClerk = BankClerk(workType: .loan, queue: loanClientQueue)
-            clerks.append(newClerk)
-        case .deposit:
-            let newClerk = BankClerk(workType: .deposit, queue: depositClientQueue)
-            clerks.append(newClerk)
         }
     }
     

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
@@ -43,13 +43,22 @@ struct Bank {
     
     private mutating func serveClients() {
         while let client = clientQueue.dequeue() {
-            self.semaphore.wait()
-            
-            DispatchQueue.global().async(group: clerks) { [self] in
-                client.wantedWork == .loan ? self.loanClerk.deal(with: client) : self.depositClerk.deal(with: client)
-                self.semaphore.signal()
-            }
+            excuteWork(of: client)
         }
         clerks.wait()
+    }
+    
+    private mutating func excuteWork(of client: Client) {
+        self.semaphore.wait()
+        
+        DispatchQueue.global().async(group: clerks) { [self] in
+            if client.wantedWork == .loan {
+                self.loanClerk.deal(with: client)
+            } else if client.wantedWork == .deposit {
+                self.depositClerk.deal(with: client)
+            }
+            
+            self.semaphore.signal()
+        }
     }
 }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
@@ -39,13 +39,6 @@ struct Bank {
         return interval
     }
     
-    private mutating func serveClients() {
-        while let client = clientQueue.dequeue() {
-            executeWork(of: client)
-        }
-        clerks.wait()
-    }
-    
     private mutating func executeWork(of client: Client) {
         self.clerksCount.wait()
         

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
@@ -14,12 +14,13 @@ struct Bank {
     private let operationQueue = OperationQueue()
     
     mutating func executeBankWork() {
-        let numberOfClients = receiveClients()
+        receiveClients()
+        let totalClientsCount = loanClientQueue.count + depositClientQueue.count
         let totalWorkTime = measureWorkTime {
-            serveClients()
+            executeWork()
         }
         let resultDescription = "업무가 마감되었습니다. 오늘 업무를 처리한 고객은 총 %d명이며, 총 업무시간은 %.2f입니다."
-        let resultMessage = String(format: resultDescription, numberOfClients, totalWorkTime)
+        let resultMessage = String(format: resultDescription, totalClientsCount, totalWorkTime)
         
         print(resultMessage)
     }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
@@ -28,8 +28,14 @@ struct Bank {
     private mutating func receiveClients() -> Int {
         for order in 1...Int.random(in: 10...30) {
             clientQueue.enqueue(Client(order))
+    
+    private mutating func arrangeByWorkType(_ client: Client) {
+        switch client.requirementType {
+        case .loan:
+            loanClientQueue.enqueue(client)
+        case .deposit:
+            depositClientQueue.enqueue(client)
         }
-        return clientQueue.count
     }
     
     private func measureWorkTime(_ block: () -> Void) -> Double {

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
@@ -21,12 +21,11 @@ struct Bank {
     }
     
     mutating func executeBankWork() {
-        let start = CFAbsoluteTimeGetCurrent()
         let numberOfClients = receiveClients()
+        let totalWorkTime = measureWorkTime {
+            serveClients()
+        }
         
-        serveClients()
-        
-        let interval = CFAbsoluteTimeGetCurrent() - start
         let resultDescription = "업무가 마감되었습니다. 오늘 업무를 처리한 고객은 총 %d명이며, 총 업무시간은 %.2f입니다."
         let resultMessage = String(format: resultDescription, numberOfClients, interval)
         

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
@@ -57,9 +57,9 @@ struct Bank {
         self.clerksCount.wait()
         
         DispatchQueue.global().async(group: clerks) { [self] in
-            if client.wantedWork == .loan {
+            if client.requirementType == .loan {
                 self.loanClerk.deal(with: client)
-            } else if client.wantedWork == .deposit {
+            } else if client.requirementType == .deposit {
                 self.depositClerk.deal(with: client)
             }
             

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
@@ -15,6 +15,10 @@ final class Bank {
     private(set) var loanClerksCount: Int
     private(set) var depositClerksCount: Int
     
+    init(loanClerksCount: Int, depositClerksCount: Int) {
+        self.loanClerksCount = loanClerksCount
+        self.depositClerksCount = depositClerksCount
+    }
         }
     }
     

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
@@ -8,17 +8,10 @@
 import Foundation
 
 struct Bank {
-    private let loanClerk: Workable
-    private let depositClerk: Workable
-    private var clientQueue = Queue(list: LinkedList<Client>())
-    private var clerksCount: DispatchSemaphore
-    private let clerks = DispatchGroup()
-    
-    init(loanClerkCount: Int, depositClerkCount: Int) {
-        self.loanClerk = BankClerk(workType: .loan, clerkCount: loanClerkCount)
-        self.depositClerk = BankClerk(workType: .deposit, clerkCount: depositClerkCount)
-        self.clerksCount = DispatchSemaphore(value: loanClerkCount + depositClerkCount)
-    }
+    private var clerks: [Workable] = []
+    private var loanClientQueue = Queue(list: LinkedList<Client>())
+    private var depositClientQueue = Queue(list: LinkedList<Client>())
+    private let operationQueue = OperationQueue()
     
     mutating func executeBankWork() {
         let numberOfClients = receiveClients()

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
@@ -13,6 +13,17 @@ struct Bank {
     private var depositClientQueue = Queue(list: LinkedList<Client>())
     private let operationQueue = OperationQueue()
     
+    mutating func assignClerk(by workType: WorkType) {
+        switch workType {
+        case .loan:
+            let newClerk = BankClerk(workType: .loan, queue: loanClientQueue)
+            clerks.append(newClerk)
+        case .deposit:
+            let newClerk = BankClerk(workType: .deposit, queue: depositClientQueue)
+            clerks.append(newClerk)
+        }
+    }
+    
     mutating func executeBankWork() {
         receiveClients()
         let totalClientsCount = loanClientQueue.count + depositClientQueue.count

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
@@ -39,17 +39,8 @@ struct Bank {
         return interval
     }
     
-    private mutating func executeWork(of client: Client) {
-        self.clerksCount.wait()
-        
-        DispatchQueue.global().async(group: clerks) { [self] in
-            if client.requirementType == .loan {
-                self.loanClerk.deal(with: client)
-            } else if client.requirementType == .deposit {
-                self.depositClerk.deal(with: client)
-            }
-            
-            self.clerksCount.signal()
-        }
+    private func executeWork() {
+        operationQueue.maxConcurrentOperationCount = clerks.count
+        operationQueue.addOperations(clerks, waitUntilFinished: true)
     }
 }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct Bank {
+final class Bank {
     private var clerks: [Workable] = []
     private var loanClientQueue = Queue(list: LinkedList<Client>())
     private var depositClientQueue = Queue(list: LinkedList<Client>())

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
@@ -42,6 +42,7 @@ final class Bank {
         let resultMessage = String(format: resultDescription, totalClientsCount, totalWorkTime)
         
         print(resultMessage)
+        clerks.removeAll()
     }
     
     private mutating func receiveClients() {

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
@@ -25,7 +25,6 @@ struct Bank {
         let totalWorkTime = measureWorkTime {
             serveClients()
         }
-        
         let resultDescription = "업무가 마감되었습니다. 오늘 업무를 처리한 고객은 총 %d명이며, 총 업무시간은 %.2f입니다."
         let resultMessage = String(format: resultDescription, numberOfClients, totalWorkTime)
         

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
@@ -32,7 +32,7 @@ final class Bank {
         }
     }
     
-    mutating func executeBankWork() {
+    func executeBankWork() {
         receiveClients()
         let totalClientsCount = loanClientQueue.count + depositClientQueue.count
         let totalWorkTime = measureWorkTime {

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
@@ -8,11 +8,13 @@
 import Foundation
 
 struct Bank {
-    private let clerk: Workable
+    private let loanClerk: Workable
+    private let depositClerk: Workable
     private var clientQueue = Queue(list: LinkedList<Client>())
     
-    init(with clerk: Workable) {
-        self.clerk = clerk
+    init(loanClerkCount: Int, depositClerkCount: Int) {
+        self.loanClerk = BankClerk(workType: .loan, clerkCount: loanClerkCount)
+        self.depositClerk = BankClerk(workType: .deposit, clerkCount: depositClerkCount)
     }
     
     mutating func executeBankWork() {

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
@@ -19,6 +19,16 @@ final class Bank {
         self.loanClerksCount = loanClerksCount
         self.depositClerksCount = depositClerksCount
     }
+    
+    func assignByWork(_ loanClerksCount: Int, _ depositClerksCount: Int) {
+        for _ in 0..<loanClerksCount {
+            let loanClerk = BankClerk(workType: .loan, queue: loanClientQueue)
+            clerks.append(loanClerk)
+        }
+        
+        for _ in 0..<depositClerksCount {
+            let depositClerk = BankClerk(workType: .deposit, queue: depositClientQueue)
+            clerks.append(depositClerk)
         }
     }
     

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
@@ -45,13 +45,13 @@ final class Bank {
         clerks.removeAll()
     }
     
-    private mutating func receiveClients() {
+    private func receiveClients() {
         for order in 1...Int.random(in: 10...30) {
             arrangeByWorkType(Client(order))
         }
     }
     
-    private mutating func arrangeByWorkType(_ client: Client) {
+    private func arrangeByWorkType(_ client: Client) {
         switch client.requirementType {
         case .loan:
             loanClientQueue.enqueue(client)

--- a/BankManagerConsoleApp/BankManagerConsoleApp/BankClerk.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/BankClerk.swift
@@ -12,11 +12,6 @@ struct BankClerk: Workable {
         static let start = "%d번 고객 %@업무 시작"
         static let end = "%d번 고객 %@업무 종료"
     }
-
-    private enum Constant {
-        static let loanWorkTime = 1.1
-        static let depositWorkTime = 0.7
-    }
     
     private(set) var workType: WorkType
     private(set) var clerksCountByWork: DispatchSemaphore
@@ -33,7 +28,6 @@ struct BankClerk: Workable {
             return
         }
         
-        let workTime = workType == .loan ? Constant.loanWorkTime : Constant.depositWorkTime
         let workStartingMessage = String(format: Message.start,
                                          client.orderNumber,
                                          workType.description)
@@ -42,7 +36,7 @@ struct BankClerk: Workable {
                                        workType.description)
         
         print(workStartingMessage)
-        Thread.sleep(forTimeInterval: workTime)
+        Thread.sleep(forTimeInterval: workType.delayTime)
         print(workEndingMessage)
         
         self.clerksCountByWork.signal()

--- a/BankManagerConsoleApp/BankManagerConsoleApp/BankClerk.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/BankClerk.swift
@@ -13,12 +13,12 @@ final class BankClerk: Operation, Workable {
         static let end = "%d번 고객 %@업무 종료"
     }
     
+    private(set) var clientQueue: Queue<LinkedList<Client>>
     private(set) var workType: WorkType
-    private(set) var clerksCountByWork: DispatchSemaphore
     
-    init(workType: WorkType, clerkCount: Int) {
+    init(workType: WorkType, queue: Queue<LinkedList<Client>>) {
         self.workType = workType
-        self.clerksCountByWork = DispatchSemaphore(value: clerkCount)
+        self.clientQueue = queue
     }
     
     func deal(with client: Client?) {

--- a/BankManagerConsoleApp/BankManagerConsoleApp/BankClerk.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/BankClerk.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct BankClerk: Workable {
+final class BankClerk: Operation, Workable {
     private enum Message {
         static let start = "%d번 고객 %@업무 시작"
         static let end = "%d번 고객 %@업무 종료"

--- a/BankManagerConsoleApp/BankManagerConsoleApp/BankClerk.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/BankClerk.swift
@@ -9,8 +9,8 @@ import Foundation
 
 struct BankClerk: Workable {
     private enum Message {
-        static let start = "%d번 고객 %s업무 시작"
-        static let end = "%d번 고객 %s업무 종료"
+        static let start = "%d번 고객 %@업무 시작"
+        static let end = "%d번 고객 %@업무 종료"
     }
 
     private enum Constant {

--- a/BankManagerConsoleApp/BankManagerConsoleApp/BankClerk.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/BankClerk.swift
@@ -21,11 +21,6 @@ final class BankClerk: Operation, Workable {
         self.clientQueue = queue
     }
     
-    func deal(with client: Client?) {
-        self.clerksCountByWork.wait()
-        
-        guard let client = client else {
-            return
     override func main() {
         serveClient()
     }
@@ -34,6 +29,9 @@ final class BankClerk: Operation, Workable {
         while let client = clientQueue.dequeue() {
             deal(with: client)
         }
+    }
+    
+    private func deal(with client: Client) {
         let workStartingMessage = String(format: Message.start,
                                          client.orderNumber,
                                          workType.description)
@@ -44,7 +42,5 @@ final class BankClerk: Operation, Workable {
         print(workStartingMessage)
         Thread.sleep(forTimeInterval: workType.takenTime)
         print(workEndingMessage)
-        
-        self.clerksCountByWork.signal()
     }
 }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/BankClerk.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/BankClerk.swift
@@ -36,7 +36,7 @@ struct BankClerk: Workable {
                                        workType.description)
         
         print(workStartingMessage)
-        Thread.sleep(forTimeInterval: workType.delayTime)
+        Thread.sleep(forTimeInterval: workType.takenTime)
         print(workEndingMessage)
         
         self.clerksCountByWork.signal()

--- a/BankManagerConsoleApp/BankManagerConsoleApp/BankClerk.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/BankClerk.swift
@@ -26,8 +26,14 @@ final class BankClerk: Operation, Workable {
         
         guard let client = client else {
             return
+    override func main() {
+        serveClient()
+    }
+    
+    private func serveClient() {
+        while let client = clientQueue.dequeue() {
+            deal(with: client)
         }
-        
         let workStartingMessage = String(format: Message.start,
                                          client.orderNumber,
                                          workType.description)

--- a/BankManagerConsoleApp/BankManagerConsoleApp/BankClerk.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/BankClerk.swift
@@ -19,7 +19,6 @@ struct BankClerk: Workable {
     }
     
     private(set) var workType: WorkType
-    
     private(set) var clerksCountByWork: DispatchSemaphore
     
     init(workType: WorkType, clerkCount: Int) {

--- a/BankManagerConsoleApp/BankManagerConsoleApp/BankClerk.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/BankClerk.swift
@@ -28,17 +28,20 @@ struct BankClerk: Workable {
     }
     
     func deal(with client: Client?) {
+        self.semaphore.wait()
+        
         guard let client = client else {
             return
         }
         
         let workTime = workType == .loan ? Constant.loanWorkTime : Constant.depositWorkTime
-        
         let workStartingMessage = String(format: Message.start, client.orderNumber, workType.description)
         let workEndingMessage = String(format: Message.end, client.orderNumber, workType.description)
         
         print(workStartingMessage)
         Thread.sleep(forTimeInterval: workTime)
         print(workEndingMessage)
+        
+        self.semaphore.signal()
     }
 }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/BankClerk.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/BankClerk.swift
@@ -9,28 +9,36 @@ import Foundation
 
 struct BankClerk: Workable {
     private enum Message {
-        static let start = "번 고객 업무 시작"
-        static let end = "번 고객 업무 종료"
+        static let start = "%d번 고객 %s업무 시작"
+        static let end = "%d번 고객 %s업무 종료"
     }
 
     private enum Constant {
-        static let workTime = 0.7
+        static let loanWorkTime = 1.1
+        static let depositWorkTime = 0.7
     }
     
     private(set) var workType: WorkType
     
     private(set) var semaphore: DispatchSemaphore
     
+    init(workType: WorkType, clerkCount: Int) {
+        self.workType = workType
+        self.semaphore = DispatchSemaphore(value: clerkCount)
+    }
+    
     func deal(with client: Client?) {
         guard let client = client else {
             return
         }
         
-        let workStartingMessage = String(format: "%d\(Message.start)", client.orderNumber)
-        let workEndingMessage = String(format: "%d\(Message.start)", client.orderNumber)
+        let workTime = workType == .loan ? Constant.loanWorkTime : Constant.depositWorkTime
+        
+        let workStartingMessage = String(format: Message.start, client.orderNumber, workType.description)
+        let workEndingMessage = String(format: Message.end, client.orderNumber, workType.description)
         
         print(workStartingMessage)
-        Thread.sleep(forTimeInterval: Constant.workTime)
+        Thread.sleep(forTimeInterval: workTime)
         print(workEndingMessage)
     }
 }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/BankClerk.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/BankClerk.swift
@@ -20,28 +20,32 @@ struct BankClerk: Workable {
     
     private(set) var workType: WorkType
     
-    private(set) var semaphore: DispatchSemaphore
+    private(set) var clerksCountByWork: DispatchSemaphore
     
     init(workType: WorkType, clerkCount: Int) {
         self.workType = workType
-        self.semaphore = DispatchSemaphore(value: clerkCount)
+        self.clerksCountByWork = DispatchSemaphore(value: clerkCount)
     }
     
     func deal(with client: Client?) {
-        self.semaphore.wait()
+        self.clerksCountByWork.wait()
         
         guard let client = client else {
             return
         }
         
         let workTime = workType == .loan ? Constant.loanWorkTime : Constant.depositWorkTime
-        let workStartingMessage = String(format: Message.start, client.orderNumber, workType.description)
-        let workEndingMessage = String(format: Message.end, client.orderNumber, workType.description)
+        let workStartingMessage = String(format: Message.start,
+                                         client.orderNumber,
+                                         workType.description)
+        let workEndingMessage = String(format: Message.end,
+                                       client.orderNumber,
+                                       workType.description)
         
         print(workStartingMessage)
         Thread.sleep(forTimeInterval: workTime)
         print(workEndingMessage)
         
-        self.semaphore.signal()
+        self.clerksCountByWork.signal()
     }
 }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/BankClerk.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/BankClerk.swift
@@ -17,6 +17,10 @@ struct BankClerk: Workable {
         static let workTime = 0.7
     }
     
+    private(set) var workType: WorkType
+    
+    private(set) var semaphore: DispatchSemaphore
+    
     func deal(with client: Client?) {
         guard let client = client else {
             return

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Client.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Client.swift
@@ -9,10 +9,10 @@ import Foundation
 
 struct Client {
     private(set) var orderNumber: Int
-    private(set) var requirementType: WorkType?
+    private(set) var requirementType: WorkType
     
     init(_ orderNumber: Int) {
         self.orderNumber = orderNumber
-        self.requirementType = WorkType.allCases.randomElement()
+        self.requirementType = WorkType.allCases.randomElement() ?? .deposit
     }
 }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Client.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Client.swift
@@ -9,10 +9,10 @@ import Foundation
 
 struct Client {
     private(set) var orderNumber: Int
-    private(set) var wantedWork: WorkType?
+    private(set) var requirementType: WorkType?
     
     init(_ orderNumber: Int) {
         self.orderNumber = orderNumber
-        self.wantedWork = WorkType.allCases.randomElement()
+        self.requirementType = WorkType.allCases.randomElement()
     }
 }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Client.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Client.swift
@@ -9,8 +9,10 @@ import Foundation
 
 struct Client {
     private(set) var orderNumber: Int
+    private(set) var wantedWork: WorkType?
     
     init(_ orderNumber: Int) {
         self.orderNumber = orderNumber
+        self.wantedWork = WorkType.allCases.randomElement()
     }
 }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/DataStructure/Queue.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/DataStructure/Queue.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct Queue<List: Listable> {
+class Queue<List: Listable> {
     private var list: List
     
     init(list: List) {
@@ -26,15 +26,15 @@ struct Queue<List: Listable> {
         return list.first
     }
     
-    mutating func enqueue(_ value: List.Element) {
+    func enqueue(_ value: List.Element) {
         list.append(value: value)
     }
     
-    mutating func dequeue() -> List.Element? {
+    func dequeue() -> List.Element? {
         return list.removeFirst()
     }
     
-    mutating func clear() {
+    func clear() {
         list.removeAll()
     }
 }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/WorkType.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/WorkType.swift
@@ -1,0 +1,13 @@
+//
+//  WorkType.swift
+//  BankManagerConsoleApp
+//
+//  Created by mmim, malrang.
+//
+
+import Foundation
+
+enum WorkType: CaseIterable {
+    case deposit
+    case loan
+}

--- a/BankManagerConsoleApp/BankManagerConsoleApp/WorkType.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/WorkType.swift
@@ -11,6 +11,15 @@ enum WorkType: String, CaseIterable {
     case loan = "대출"
     case deposit = "예금"
     
+    var delayTime: Double {
+        switch self {
+        case .loan:
+            return 1.1
+        case .deposit:
+            return 0.7
+        }
+    }
+    
     var description: String {
         return self.rawValue
     }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/WorkType.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/WorkType.swift
@@ -7,7 +7,11 @@
 
 import Foundation
 
-enum WorkType: CaseIterable {
-    case deposit
-    case loan
+enum WorkType: String, CaseIterable {
+    case loan = "대출"
+    case deposit = "예금"
+    
+    var description: String {
+        return self.rawValue
+    }
 }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/WorkType.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/WorkType.swift
@@ -11,7 +11,7 @@ enum WorkType: String, CaseIterable {
     case loan = "대출"
     case deposit = "예금"
     
-    var delayTime: Double {
+    var takenTime: Double {
         switch self {
         case .loan:
             return 1.1

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Workable.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Workable.swift
@@ -7,9 +7,6 @@
 
 import Foundation
 
-protocol Workable {
+protocol Workable: Operation {
     var workType: WorkType { get }
-    var clerksCountByWork: DispatchSemaphore { get }
-    
-    func deal(with client: Client?)
 }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Workable.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Workable.swift
@@ -8,5 +8,8 @@
 import Foundation
 
 protocol Workable {
+    var workType: WorkType { get }
+    var semaphore: DispatchSemaphore { get }
+    
     func deal(with client: Client?)
 }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Workable.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Workable.swift
@@ -8,5 +8,6 @@
 import Foundation
 
 protocol Workable: Operation {
+    var clientQueue: Queue<LinkedList<Client>> { get }
     var workType: WorkType { get }
 }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Workable.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Workable.swift
@@ -9,7 +9,7 @@ import Foundation
 
 protocol Workable {
     var workType: WorkType { get }
-    var semaphore: DispatchSemaphore { get }
+    var clerksCountByWork: DispatchSemaphore { get }
     
     func deal(with client: Client?)
 }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/main.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/main.swift
@@ -6,3 +6,8 @@
 //
 
 import Foundation
+
+let someBank = Bank()
+var m = BankManager(of: someBank)
+m.hireClerks(loanClerk: 1, depositClerk: 2)
+m.taskStart()

--- a/BankManagerConsoleApp/BankManagerConsoleApp/main.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/main.swift
@@ -7,7 +7,6 @@
 
 import Foundation
 
-let someBank = Bank()
+let someBank = Bank(loanClerksCount: 1, depositClerksCount: 2)
 var m = BankManager(of: someBank)
-m.hireClerks(loanClerk: 1, depositClerk: 2)
 m.taskStart()

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
 ---
 
 ## UML
-<img width="700" src="https://i.imgur.com/Qy0VbSv.jpg"/>
+<img width="700" src="https://i.imgur.com/RWguZju.jpg"/>
 
 ---
 
@@ -223,6 +223,198 @@ print("\(Constant.a)\(Constant.b)\(numberOfClients)\(Constant.c)\(Constant.d)\(t
 - GCD
 - protocol, POP
 - Queue
+
+### PR 후 개선사항
+1️⃣ `String(format:)` 적용
+
+>**변경전**
+>네임스페이스를 활용해 매직리터럴 문자를 개선하였으나 변경전 코드는 `print` 구문 내부에서 어떤 값을 의미하는지 의미를 한번에 이해하기 어려웠다.
+
+```swift
+private enum Message {
+        static let start = "번 고객 업무 시작"
+        static let end = "번 고객 업무 종료"
+    }
+
+    print("\(client.orderNumber)\(Message.start)")
+    Thread.sleep(forTimeInterval: Constant.workTime)
+    print("\(client.orderNumber)\(Message.end)")
+```
+
+
+>**변경후**
+>네임스페이스 와 `String(format: )`을 활용해 좀더 이해하기 쉽도록 수정해주었다.
+```swift
+private enum Message {
+        static let start = "%d번 고객 %@업무 시작"
+        static let end = "%d번 고객 %@업무 종료"
+    }
+
+    let workStartingMessage = String(format: Message.start, client.orderNumber, workType.description)
+    let workEndingMessage = String(format: Message.end, client.orderNumber, workType.description)
+        
+    print(workStartingMessage)
+    Thread.sleep(forTimeInterval: workTime)
+    print(workEndingMessage)
+```
+
+---
+
+## STEP 3 기능 구현
+- `enum WorkType: String, CaseIterable`
+    - `case loan = 대출`: 은행원, 손님 의 업무 케이스
+    - `case deposit = 예금`: 은행원, 손님 의 업무 케이스
+- `struct Bank`
+    - `measureWorkTime(_ block: () -> Void) -> Double`: 파라미터로 받은 클로저의 실행 시간을 측정하는 메서드
+    - `executeWork(of client: Client)`: `Client` 인스턴스의 업무값에따라 담당 은행원에게 인계해준뒤 은행원이 비동기적으로 일하게 하는 메서드
+- `BankClerk: Workable`
+    - `private(set) var workType`: 은행원의 담당 업무값을 갖는 프로퍼티
+    - `private(set) var clerksCountByWork`: 은행원이 몇명인지(스레드를 최대 몇개 사용할수있는지)를 갖는 `DispatchSemaphore`
+
+### 고민한 점(트러블 슈팅)
+1️⃣ 재활용성과 확장성에 대한 고민
+- 이번 프로젝트에선 업무가 2개(예금, 대출)이지만, 후에 업무가 추가되고 그에 따라서 직원이 새로 배치된다고 가정했다. 
+- 이때, 코드의 수정을 최소화하고, 확장에 용이하도록 구현하는 것이 목표였다.
+- 첫번째 시도
+    1) 직무 별로 직급을 두고 직급별로 객체를 구현하는 것을 시도했다.  
+    2) 만약 이럴 경우 타입이 늘어날수록 중복코드가 늘어난다는 문제가 생긴다. 
+    3) 이를 해결하기 위해 class를 통한 상속을 이용해야한다. 
+    4) superClass로 `Worker`를 두고 중복되는 코드를 구현한다. 
+    5) 그리고 업무별 직원 class에 `Worker`를 상속시킨다.
+    6) 장점: 직무가 늘어나도 class만 추가만 해주면 되기 때문에 확장성이 매우 용이하, 직무별 달라지는 업무 내용은 `override`를 통해 수정할 수 있다. 
+    7) 단점: class로 구현하게 되어 RC 증가로 인해 많은 비용이 든다.
+- 두번째 시도
+    1) `BankClerk` 구조체를 유지하고, class를 사용하지 않는 방법으로 시도했다.
+    2) 문제는 `client.wantedWork`(고객 업무)에 따라 `Clerk`의 업무 내용도 달라져야 한다는 점이었다.
+    3) 이 문제를 해결하기 위해서 `WorkType` enum을 만들어줬다.
+    4) 직무가 늘어난다면 enum에 csae를 추가하는 것만으로 `BankClerk` 객체에 업무라는 특성을 쥐어줄 수 있다.
+    5) `BankClerk`에 `workType: WorkType` 프로퍼티를 만들어주어서 초기화되는 `BankClerk` 인스턴스 별로 식별할 수 있는 직무 특성을 부여했다.
+    6) `Bank` 구조체에 직무별 `BankClerk` 인스턴스를 생성하고, dequeue 과정에서 client의 wanedWork가 무엇이냐에 따라 각각의 인스턴스의 `deal(with:)` 메서드를 호출하게 구현했다.
+    7) 장점: class를 사용하지 않아 비용이 비교적 적게 든다. / `WorkType` enum에 case 추가와 `Bank` 구조체에 `BankClerk` 인스턴스를 추가하는 것만으로 확장이 가능하다.
+    8) 단점: 확장을 하려면 이전에 구현된 약간의 로직을 수정해야한다. / OOP 관점에서 직관적이지 않다.(객체가 나뉘어 있지 않고 하나의 타입이 여러 인스턴스로 생성할 때 나뉘기 때문에)
+
+> apple은 가능하면 많은 비용이 드는 class를 피하라 추천한다. 따라서 다른 방법이 있다면 굳이 class는 피하자는 생각을 했다.
+> 따라서, 두번째 방법을 채택했다. 이로인해 OOP 관점에서 멀어진 것은 아닐까 고민을 했다.
+> 하지만 관점에 따라서 OOP를 잘 따랐다고도 말할 수 있다.
+> 오히려 class를 이용한 상속으로 인해 SOLID 원칙(LSP)을 어기는 상황 또한 고려해봐야 한다고 판단했다.
+
+2️⃣ 재귀함수 말고 다른 방법에 대한 고민 
+- 기존 재귀함수로 되어있던 taskStart() 구조를 바꾸어보려고 고민했다.
+- 재귀함수는 호출할때마다 이전 함수의 메모리가 해제되지 않아, 메소드 위에 메소드가 올라가는 식으로 메모리에 스택이 쌓이게된다.(반복문 공간복잡도 O(1), 재귀함수 공간복잡도 O(n))
+- 이러한 문제를 해결하기위해 재귀함수 말고 다른방법으로 고민후 반복문을 사용해 구현해보았다.
+
+**재귀함수 사용 코드**
+```swift
+enum SelectOptionType: String {
+    case open = "1"
+    case close = "2"
+}
+
+mutating func taskStart() {
+        showMenuMessage()
+        guard let selectedOption = SelectOptionType(rawValue: inputNumber()) else {
+            return taskStart()
+        }
+        
+        switch selectedOption {
+        case .open:
+            bank.executeBankWork()
+            return taskStart()
+        case .close:
+            return
+        }
+```
+
+**while 반복문 사용 코드**
+![](https://i.imgur.com/0qg0WCf.png)
+
+3️⃣ Concurrency 
+>**이번 프로젝트에선 스레드를 3개만 사용해야한다.**
+**따라서 우리가 고려해야할 상황은 race condition과 최대 3개의 스레드였다.**
+
+- **`DispatchQueue.global().async {}` 내부에 `serialMyQueue.sync {}`를 사용한 방법**
+    1) 이 방식을 선택한다면 두 문제 상황을 해결할 수 있다.
+    2) 하지만 필요로 하는 스레드만큼 `serialMyQueue.sync {}`를 사용해야한다.
+    3) 만약 직원이 10명이라고 한다면 10개의 스레드가 필요하기 때문에 10번의 `serialMyQueue.sync {}`를 사용해야한다.
+    4) 뿐만 아니라 내부 로직도 반복되기 때문에 좋지 않은 코드가 된다.
+    5) 다른 문제는 직무별 최대 스레드를 통제할 수가 없는 점이다. 
+    6) 만약 예금 직무가 2개라고 가정한다면, `serialMyQueue.sync {}`를 두번 사용하거나, 다시 한번 비동기를 사용한 반복문을 사용하고 그 안에서 `serialMyQueue.sync {}` 해야한다.
+    7) 또한, 직무가 늘어날 때마다 `serialMyQueue.sync {}` 구문이 증가해야한다. 
+    8) 때문에 이번 프로젝트에는 합리적인 방법이 아니다.
+- **위 방식의 문제를 해결하기 위해 client Queue를 2개 사용**
+    1) 만약 예금 고객과 대출 고객의 `Queue`를 각각 `enqueue` 받는다면, 각각의 고객 `Queue` 별로  `DispatchQueue.global().async {}`를 사용하여 `dequeue`해주고 `semaphore`를 통해 스레드 최대수를 통제할 수 있다.
+    2) 처음에는 좋은 방법이라고 생각했지만, 확장성 면에서 큰 단점을 발견했다.
+    3) 만약 직무가 10개라고 하면, `client`의 `queue`가 10개 존재하게 된다.
+    4) 또한 각 직무별 `semaphore` 또한 10개 존재한다.
+    5) 때문에 확장성을 고려했을 때 큰 단점이라고 생각되어 선택하지 않았다.
+- **semaphore와 직무별 분기를 이용한 방법**
+    1) 최대 스레드는 직원의 수만큼 이어야한다. 또한 직무별 최대 스레드는 직무별 직원이 수만큼 이어야한다.
+    2) 이 두점을 해결하고자 전체 직원 수만큼의 `semaphore`를 설정하고, 다시 `BankClerk`타입 내부에서 직무별 `semaphore`를 설정하여 문제를 해결하고자 했다.
+    3) `DispatchQueue.global().async` 이전에 `전체 semaphore.wait()`을 통해 스레드를 제한했다.
+    4) 다음 분기를 통해 선택된 직무별 직원 `deal(with: )` 메서드 내부의 `부분 semaphore.wait() / .signal()`을 통해 직무별 스레드도 제한해줄 수 있었다.
+    5) 다만 이 부분에서 문제됐던 점은 `전체 semaphore.wait()`의 시점이었다.
+    6) `DispatchQueue.global().async` 이후, 즉 내부에서 `전체 semaphore.wait()`을 사용하면 이미 `semaphore count`가 감소하기 전에 스레드로 던져지기 때문에`semaphore count`과 무관하게 스레드가 이미 생성되버리는 현상이 생겼다.
+    7) 이 문제는 `DispatchQueue.global().async` 이전에 해줌으로써 해결할 수 있었다.
+
+```swift
+// 수정 전
+DispatchQueue.global().async(group: clerks) { [self] in
+    self.clerksCount.wait() // `semaphore count`가 1감소 했지만 이미 스레드는 생성
+    // some code
+    self.clerksCount.signal()
+}
+// 수정 후
+
+self.clerksCount.wait() // 스레드가 생겨나기 이전에 `semaphore count`가 1감소하여 스레드 제한
+DispatchQueue.global().async(group: clerks) { [self] in      
+    // some code
+    self.clerksCount.signal()
+        }
+```
+
+### 질문사항
+1️⃣ `DispatchSemaphore` 의 네이밍은 어떻게 지어야 할까요? 🤔
+- 저희 코드에서 DispatchSemaphore 는 총직원수를 의미합니다
+- 그렇기 때문에 총직원수 라는 의미를 갖도록 `clerksCount` 라는 네이밍을 사용했는데요
+- DispatchSemaphore 를 사용할때 주로 사용되는 네이밍이 따로 있는지 궁금합니다!!
+```swift
+private var clerksCount: DispatchSemaphore
+```
+
+2️⃣ 재귀함수 말고 다른 좋은 방법!?
+- 반복문으로 구현하게되면 `SelectOptionType` 에 추가 case 가 필요하게되어 반복문 을 활용한 코드로 변경하지 않았습니다! 
+- 재귀함수, 꼬리재귀 말고 다른 방법으로 아래의 코드를 구현할수있는 좋은방법이있을까요? 🤔
+
+**재귀함수 사용 코드**
+```swift
+enum SelectOptionType: String {
+    case open = "1"
+    case close = "2"
+}
+
+mutating func taskStart() {
+        showMenuMessage()
+        guard let selectedOption = SelectOptionType(rawValue: inputNumber()) else {
+            return taskStart()
+        }
+        
+        switch selectedOption {
+        case .open:
+            bank.executeBankWork()
+            return taskStart()
+        case .close:
+            return
+        }
+```
+**while 반복문 사용 코드**
+![](https://i.imgur.com/0qg0WCf.png)
+
+### 배운 개념
+`@discardableResult`  
+`DispatchQueue`  
+`DispatchGroup`  
+`DispatchWorkitem`  
+`DispatchSemaphore, wait(), signal()`  
 
 ### PR 후 개선사항
 


### PR DESCRIPTION
@hyunable  안녕하세요 혀나!! 
이번 STEP도 잘부탁드리겠습니다! 🥳

---  

<img width="700" src="https://i.imgur.com/RWguZju.jpg"/>

---  

### 고민한 점(트러블 슈팅)
1️⃣ 재활용성과 확장성에 대한 고민
- 이번 프로젝트에선 업무가 2개(예금, 대출)이지만, 후에 업무가 추가되고 그에 따라서 직원이 새로 배치된다고 가정했다. 
- 이때, 코드의 수정을 최소화하고, 확장에 용이하도록 구현하는 것이 목표였다.
- 첫번째 시도
    1) 직무 별로 직급을 두고 직급별로 객체를 구현하는 것을 시도했다.  
    2) 만약 이럴 경우 타입이 늘어날수록 중복코드가 늘어난다는 문제가 생긴다. 
    3) 이를 해결하기 위해 class를 통한 상속을 이용해야한다. 
    4) superClass로 `Worker`를 두고 중복되는 코드를 구현한다. 
    5) 그리고 업무별 직원 class에 `Worker`를 상속시킨다.
    6) 장점: 직무가 늘어나도 class만 추가만 해주면 되기 때문에 확장성이 매우 용이하, 직무별 달라지는 업무 내용은 `override`를 통해 수정할 수 있다. 
    7) 단점: class로 구현하게 되어 RC 증가로 인해 많은 비용이 든다.
- 두번째 시도
    1) `BankClerk` 구조체를 유지하고, class를 사용하지 않는 방법으로 시도했다.
    2) 문제는 `client.wantedWork`(고객 업무)에 따라 `Clerk`의 업무 내용도 달라져야 한다는 점이었다.
    3) 이 문제를 해결하기 위해서 `WorkType` enum을 만들어줬다.
    4) 직무가 늘어난다면 enum에 csae를 추가하는 것만으로 `BankClerk` 객체에 업무라는 특성을 쥐어줄 수 있다.
    5) `BankClerk`에 `workType: WorkType` 프로퍼티를 만들어주어서 초기화되는 `BankClerk` 인스턴스 별로 식별할 수 있는 직무 특성을 부여했다.
    6) `Bank` 구조체에 직무별 `BankClerk` 인스턴스를 생성하고, dequeue 과정에서 client의 wanedWork가 무엇이냐에 따라 각각의 인스턴스의 `deal(with:)` 메서드를 호출하게 구현했다.
    7) 장점: class를 사용하지 않아 비용이 비교적 적게 든다. / `WorkType` enum에 case 추가와 `Bank` 구조체에 `BankClerk` 인스턴스를 추가하는 것만으로 확장이 가능하다.
    8) 단점: 확장을 하려면 이전에 구현된 약간의 로직을 수정해야한다. / OOP 관점에서 직관적이지 않다.(객체가 나뉘어 있지 않고 하나의 타입이 여러 인스턴스로 생성할 때 나뉘기 때문에)

> apple은 가능하면 많은 비용이 드는 class를 피하라 추천한다. 따라서 다른 방법이 있다면 굳이 class는 피하자는 생각을 했다.
> 따라서, 두번째 방법을 채택했다. 이로인해 OOP 관점에서 멀어진 것은 아닐까 고민을 했다.
> 하지만 관점에 따라서 OOP를 잘 따랐다고도 말할 수 있다.
> 오히려 class를 이용한 상속으로 인해 SOLID 원칙(LSP)을 어기는 상황 또한 고려해봐야 한다고 판단했다.

2️⃣ 재귀함수 말고 다른 방법에 대한 고민 
- 기존 재귀함수로 되어있던 taskStart() 구조를 바꾸어보려고 고민했다.
- 재귀함수는 호출할때마다 이전 함수의 메모리가 해제되지 않아, 메소드 위에 메소드가 올라가는 식으로 메모리에 스택이 쌓이게된다.(반복문 공간복잡도 O(1), 재귀함수 공간복잡도 O(n))
- 이러한 문제를 해결하기위해 재귀함수 말고 다른방법으로 고민후 반복문을 사용해 구현해보았다.

**재귀함수 사용 코드**
```swift
enum SelectOptionType: String {
    case open = "1"
    case close = "2"
}

mutating func taskStart() {
        showMenuMessage()
        guard let selectedOption = SelectOptionType(rawValue: inputNumber()) else {
            return taskStart()
        }
        
        switch selectedOption {
        case .open:
            bank.executeBankWork()
            return taskStart()
        case .close:
            return
        }
```

**while 반복문 사용 코드**
![](https://i.imgur.com/0qg0WCf.png)

3️⃣ Concurrency 
>**이번 프로젝트에선 스레드를 3개만 사용해야한다.**
**따라서 우리가 고려해야할 상황은 race condition과 최대 3개의 스레드였다.**

- **`DispatchQueue.global().async {}` 내부에 `serialMyQueue.sync {}`를 사용한 방법**
    1) 이 방식을 선택한다면 두 문제 상황을 해결할 수 있다.
    2) 하지만 필요로 하는 스레드만큼 `serialMyQueue.sync {}`를 사용해야한다.
    3) 만약 직원이 10명이라고 한다면 10개의 스레드가 필요하기 때문에 10번의 `serialMyQueue.sync {}`를 사용해야한다.
    4) 뿐만 아니라 내부 로직도 반복되기 때문에 좋지 않은 코드가 된다.
    5) 다른 문제는 직무별 최대 스레드를 통제할 수가 없는 점이다. 
    6) 만약 예금 직무가 2개라고 가정한다면, `serialMyQueue.sync {}`를 두번 사용하거나, 다시 한번 비동기를 사용한 반복문을 사용하고 그 안에서 `serialMyQueue.sync {}` 해야한다.
    7) 또한, 직무가 늘어날 때마다 `serialMyQueue.sync {}` 구문이 증가해야한다. 
    8) 때문에 이번 프로젝트에는 합리적인 방법이 아니다.
- **위 방식의 문제를 해결하기 위해 client Queue를 2개 사용**
    1) 만약 예금 고객과 대출 고객의 `Queue`를 각각 `enqueue` 받는다면, 각각의 고객 `Queue` 별로  `DispatchQueue.global().async {}`를 사용하여 `dequeue`해주고 `semaphore`를 통해 스레드 최대수를 통제할 수 있다.
    2) 처음에는 좋은 방법이라고 생각했지만, 확장성 면에서 큰 단점을 발견했다.
    3) 만약 직무가 10개라고 하면, `client`의 `queue`가 10개 존재하게 된다.
    4) 또한 각 직무별 `semaphore` 또한 10개 존재한다.
    5) 때문에 확장성을 고려했을 때 큰 단점이라고 생각되어 선택하지 않았다.
- **semaphore와 직무별 분기를 이용한 방법**
    1) 최대 스레드는 직원의 수만큼 이어야한다. 또한 직무별 최대 스레드는 직무별 직원이 수만큼 이어야한다.
    2) 이 두점을 해결하고자 전체 직원 수만큼의 `semaphore`를 설정하고, 다시 `BankClerk`타입 내부에서 직무별 `semaphore`를 설정하여 문제를 해결하고자 했다.
    3) `DispatchQueue.global().async` 이전에 `전체 semaphore.wait()`을 통해 스레드를 제한했다.
    4) 다음 분기를 통해 선택된 직무별 직원 `deal(with: )` 메서드 내부의 `부분 semaphore.wait() / .signal()`을 통해 직무별 스레드도 제한해줄 수 있었다.
    5) 다만 이 부분에서 문제됐던 점은 `전체 semaphore.wait()`의 시점이었다.
    6) `DispatchQueue.global().async` 이후, 즉 내부에서 `전체 semaphore.wait()`을 사용하면 이미 `semaphore count`가 감소하기 전에 스레드로 던져지기 때문에`semaphore count`과 무관하게 스레드가 이미 생성되버리는 현상이 생겼다.
    7) 이 문제는 `DispatchQueue.global().async` 이전에 해줌으로써 해결할 수 있었다.

```swift
// 수정 전
DispatchQueue.global().async(group: clerks) { [self] in
    self.clerksCount.wait() // `semaphore count`가 1감소 했지만 이미 스레드는 생성
    // some code
    self.clerksCount.signal()
}
// 수정 후

self.clerksCount.wait() // 스레드가 생겨나기 이전에 `semaphore count`가 1감소하여 스레드 제한
DispatchQueue.global().async(group: clerks) { [self] in      
    // some code
    self.clerksCount.signal()
        }
```

### 질문사항
1️⃣ `DispatchSemaphore` 의 네이밍은 어떻게 지어야 할까요? 🤔
- 저희 코드에서 DispatchSemaphore 는 총직원수를 의미합니다
- 그렇기 때문에 총직원수 라는 의미를 갖도록 `clerksCount` 라는 네이밍을 사용했는데요
- DispatchSemaphore 를 사용할때 주로 사용되는 네이밍이 따로 있는지 궁금합니다!!
```swift
private var clerksCount: DispatchSemaphore
```

2️⃣ 재귀함수 말고 다른 좋은 방법!?
- 반복문으로 구현하게되면 `SelectOptionType` 에 추가 case 가 필요하게되어 반복문 을 활용한 코드로 변경하지 않았습니다! 
- 재귀함수, 꼬리재귀 말고 다른 방법으로 아래의 코드를 구현할수있는 좋은방법이있을까요? 🤔

**재귀함수 사용 코드**
```swift
enum SelectOptionType: String {
    case open = "1"
    case close = "2"
}

mutating func taskStart() {
        showMenuMessage()
        guard let selectedOption = SelectOptionType(rawValue: inputNumber()) else {
            return taskStart()
        }
        
        switch selectedOption {
        case .open:
            bank.executeBankWork()
            return taskStart()
        case .close:
            return
        }
```
**while 반복문 사용 코드**
![](https://i.imgur.com/0qg0WCf.png)
