### PR TITLE
은행 창구 매니저 [STEP1] minsson, derrickkim0109

### DIFF
--- a/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
+++ b/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
@@ -9,6 +9,12 @@
 /* Begin PBXBuildFile section */
 		C7694E7A259C3EC00053667F /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7694E79259C3EC00053667F /* main.swift */; };
 		C7D65D1B259C8190005510E0 /* BankManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7D65D1A259C8190005510E0 /* BankManager.swift */; };
+		FD21DF4728698907006CCF75 /* Node.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD21DF4628698907006CCF75 /* Node.swift */; };
+		FD21DF4928698925006CCF75 /* LinkedList.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD21DF4828698925006CCF75 /* LinkedList.swift */; };
+		FD21DF572869905D006CCF75 /* ClientQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD21DF562869905D006CCF75 /* ClientQueue.swift */; };
+		FD21DF582869905D006CCF75 /* ClientQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD21DF562869905D006CCF75 /* ClientQueue.swift */; };
+		FD21DF5A286990AD006CCF75 /* Queue.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD21DF59286990AD006CCF75 /* Queue.swift */; };
+		FD21DF5B286990AD006CCF75 /* Queue.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD21DF59286990AD006CCF75 /* Queue.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -27,10 +33,22 @@
 		C7694E76259C3EC00053667F /* BankManagerConsoleApp */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = BankManagerConsoleApp; sourceTree = BUILT_PRODUCTS_DIR; };
 		C7694E79259C3EC00053667F /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
 		C7D65D1A259C8190005510E0 /* BankManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = BankManager.swift; path = ../../BankManager.swift; sourceTree = "<group>"; };
+		FD21DF4628698907006CCF75 /* Node.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Node.swift; sourceTree = "<group>"; };
+		FD21DF4828698925006CCF75 /* LinkedList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkedList.swift; sourceTree = "<group>"; };
+		FD21DF4F28698B78006CCF75 /* BankManagerTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = BankManagerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		FD21DF562869905D006CCF75 /* ClientQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClientQueue.swift; sourceTree = "<group>"; };
+		FD21DF59286990AD006CCF75 /* Queue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Queue.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
 		C7694E73259C3EC00053667F /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		FD21DF4C28698B78006CCF75 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -52,6 +70,7 @@
 			isa = PBXGroup;
 			children = (
 				C7694E76259C3EC00053667F /* BankManagerConsoleApp */,
+				FD21DF4F28698B78006CCF75 /* BankManagerTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -61,8 +80,20 @@
 			children = (
 				C7D65D1A259C8190005510E0 /* BankManager.swift */,
 				C7694E79259C3EC00053667F /* main.swift */,
+				FD21DF4A2869892C006CCF75 /* Queue */,
 			);
 			path = BankManagerConsoleApp;
+			sourceTree = "<group>";
+		};
+		FD21DF4A2869892C006CCF75 /* Queue */ = {
+			isa = PBXGroup;
+			children = (
+				FD21DF4628698907006CCF75 /* Node.swift */,
+				FD21DF4828698925006CCF75 /* LinkedList.swift */,
+				FD21DF562869905D006CCF75 /* ClientQueue.swift */,
+				FD21DF59286990AD006CCF75 /* Queue.swift */,
+			);
+			path = Queue;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -85,17 +116,38 @@
 			productReference = C7694E76259C3EC00053667F /* BankManagerConsoleApp */;
 			productType = "com.apple.product-type.tool";
 		};
+		FD21DF4E28698B78006CCF75 /* BankManagerTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = FD21DF5328698B78006CCF75 /* Build configuration list for PBXNativeTarget "BankManagerTests" */;
+			buildPhases = (
+				FD21DF4B28698B78006CCF75 /* Sources */,
+				FD21DF4C28698B78006CCF75 /* Frameworks */,
+				FD21DF4D28698B78006CCF75 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = BankManagerTests;
+			productName = BankManagerTests;
+			productReference = FD21DF4F28698B78006CCF75 /* BankManagerTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
 		C7694E6E259C3EC00053667F /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastSwiftUpdateCheck = 1210;
+				LastSwiftUpdateCheck = 1340;
 				LastUpgradeCheck = 1210;
 				TargetAttributes = {
 					C7694E75259C3EC00053667F = {
 						CreatedOnToolsVersion = 12.1;
+					};
+					FD21DF4E28698B78006CCF75 = {
+						CreatedOnToolsVersion = 13.4.1;
+						LastSwiftMigration = 1340;
 					};
 				};
 			};
@@ -113,17 +165,41 @@
 			projectRoot = "";
 			targets = (
 				C7694E75259C3EC00053667F /* BankManagerConsoleApp */,
+				FD21DF4E28698B78006CCF75 /* BankManagerTests */,
 			);
 		};
 /* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		FD21DF4D28698B78006CCF75 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		C7694E72259C3EC00053667F /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				FD21DF4728698907006CCF75 /* Node.swift in Sources */,
+				FD21DF5A286990AD006CCF75 /* Queue.swift in Sources */,
 				C7694E7A259C3EC00053667F /* main.swift in Sources */,
+				FD21DF572869905D006CCF75 /* ClientQueue.swift in Sources */,
+				FD21DF4928698925006CCF75 /* LinkedList.swift in Sources */,
 				C7D65D1B259C8190005510E0 /* BankManager.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		FD21DF4B28698B78006CCF75 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				FD21DF582869905D006CCF75 /* ClientQueue.swift in Sources */,
+				FD21DF5B286990AD006CCF75 /* Queue.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -263,6 +339,51 @@
 			};
 			name = Release;
 		};
+		FD21DF5428698B78006CCF75 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+					"@loader_path/../Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 12.3;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = io.minsson.BankManagerTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		FD21DF5528698B78006CCF75 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+					"@loader_path/../Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 12.3;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = io.minsson.BankManagerTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -280,6 +401,15 @@
 			buildConfigurations = (
 				C7694E7E259C3EC00053667F /* Debug */,
 				C7694E7F259C3EC00053667F /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		FD21DF5328698B78006CCF75 /* Build configuration list for PBXNativeTarget "BankManagerTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				FD21DF5428698B78006CCF75 /* Debug */,
+				FD21DF5528698B78006CCF75 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Queue/ClientQueue.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Queue/ClientQueue.swift
@@ -1,0 +1,35 @@
+//
+//  ClientQueue.swift
+//  BankManagerConsoleApp
+//
+//  Created by minsson, Derrick on 2022/06/27.
+//
+
+struct ClientQueue<Element> {
+    private let queue = LinkedList<Element>()
+    
+    var peek: Element? {
+        return queue.head?.data ?? nil
+    }
+}
+
+// MARK: - Internal Actions
+
+extension ClientQueue: Queue {
+    mutating func enqueue(_ data: Element) {
+        queue.append(Node(data))
+    }
+    
+    func dequeue() -> Node<Element>? {
+        return queue.isEmpty() == true ? nil : queue.removeFirst()
+    }
+    
+    func isEmpty() -> Bool {
+        return queue.head == nil ? true : false
+    }
+    
+    func clear() {
+        queue.removeAll()
+    }
+}
+

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Queue/LinkedList.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Queue/LinkedList.swift
@@ -1,0 +1,45 @@
+//
+//  LinkedList.swift
+//  BankManagerConsoleApp
+//
+//  Created by minsson, Derrick on 2022/06/27.
+//
+
+final class LinkedList<Element> {
+    private(set) var head: Node<Element>?
+    private var tail: Node<Element>?
+}
+
+// MARK: - Internal Actions
+
+extension LinkedList {
+    func append(_ newNode: Node<Element>) {
+        if head == nil {
+            head = newNode
+            tail = head
+            return
+        }
+        
+        tail?.nextNode = newNode
+        tail = newNode
+    }
+    
+    func isEmpty() -> Bool {
+        return head == nil ? true : false
+    }
+    
+    func removeFirst() -> Node<Element>? {
+        guard let removedNode = head else {
+            return nil
+        }
+        
+        head = removedNode.nextNode
+        
+        return removedNode
+    }
+    
+    func removeAll() {
+        head = nil
+    }
+}
+

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Queue/Node.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Queue/Node.swift
@@ -1,0 +1,15 @@
+//
+//  Node.swift
+//  BankManagerConsoleApp
+//
+//  Created by minsson, Derrick on 2022/06/27.
+//
+
+final class Node<T> {
+    var data: T
+    var nextNode: Node?
+    
+    init(_ data: T) {
+        self.data = data
+    }
+}

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Queue/Queue.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Queue/Queue.swift
@@ -1,0 +1,17 @@
+//
+//  Queue.swift
+//  BankManagerConsoleApp
+//
+//  Created by minsson, Derrick on 2022/06/27.
+//
+
+protocol Queue {
+    associatedtype Element
+    
+    var peek: Element? { get }
+    
+    mutating func enqueue(_ data: Element)
+    mutating func dequeue() -> Node<Element>?
+    func isEmpty() -> Bool
+    func clear()
+}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,78 @@
-## iOS 커리어 스타터 캠프
+## 은행 창구 매니저
 
-### 은행 매니저 프로젝트 저장소
+ 
+<div align="center">
+    <img src="https://img.shields.io/badge/swift-5.7-F05138.svg?style=flat&logo=Swift">
+    <img src="https://img.shields.io/badge/14.0-000000.svg?style=flat&logo=iOS">
+    <img src="https://img.shields.io/badge/Xcode-13.4.1-white.svg?style=flat&logo=XCode">
+    <img src="https://img.shields.io/badge/UIKit-white.svg?style=flat&logo=UIKit">
+</div>
 
-- 이 저장소를 자신의 저장소로 fork하여 프로젝트를 진행합니다
 
+<br>
+
+## 🫂 팀 소개
+|[민쏜](https://github.com/minsson)|[Derrickkim](https://github.com/derrickkim0109)|
+|:--------:|:--------:|
+|<img src="" width=200>|<img src="https://avatars.githubusercontent.com/u/59466342?v=4" width=200>|
+|||
+<br>
+
+## 타임라인
+
+### Week 1
+> 2022.06.27 ~ 2022.07.01
+
+- 2022-06-27(월) 
+    - 프로젝트 요구명세서 파악
+    - 고객 대기열을 표현하는 ClientQueue 구현
+        - "Node" LinkedList 구현을 위한 커스텀 타입 정의
+        - "LinkedList" ClientQueue 구현을 위한 커스텀 타입 정의
+        - "ClientQueue" 은행 고객 대기열을 표현하기 위한 커스텀 타입 정의
+        - ClientQueue가 채택할 Queue 프로토콜 정의
+
+- 2022-06-28(화) - STEP_01 PR 전송 완료
+    - "BankManagerTests" ClientQueue의 메서드 기능 테스트
+
+- 2022-06-29(수)
+    - Step 1 UML 작성
+    - 프로젝트 요구명세서를 바탕으로한 타입 추상화 
+
+- 2022-06-30(목)
+
+- 2022-07-01(금)
+
+
+### Week 2
+> 2022.07.04 ~ 2022.07.08
+
+- 2022-07-04(월)
+ 
+- 2022-07-05(화)
+
+- 2022-07-06(수)
+
+- 2022-07-07(목)
+
+- 2022-07-08(금)
+
+
+## UML
+
+### Step_01
+![](https://i.imgur.com/jE0c2ym.jpg)
+
+
+## 트러블 슈팅
+
+### 1. Command line tool 내 Unit Test 에러
+
+- Unit Test 도중 모듈이 import 되지 않는 에러가 있었습니다.
+- 코드상으로는 `@testable import 모듈` 부분이었습니다.
+- 이에 따라 아래 절차와 같이 해결했습니다.
+`1) Unit test scheme 추가`
+`2) 각 파일별로 target member 체크`
+
+
+## 참고 링크
+[Commandline-tool_UnitTest](https://woongsios.tistory.com/162)


### PR DESCRIPTION
@leejun6694
안녕하세요, 쿠마!🥰 

은행창구매니저 프로젝트 9조 민쏜과 데릭입니다.

Step 1 PR 보냅니다. 

아래와 같이 작업내용과, 저희의 생각의 흐름을 작성해보았습니다.
저희가 생각한 방향에 대해 쿠마는 어떻게 생각하시는지 피드백 부탁 드립니다! 😁


## 작업 내용 

- `ClientQueue` 타입 구현을 위한 단방향 `LinkedList` 타입을 구현했습니다.
    - 단방향 LinkedList이지만 tail 속성을 정의하여 새로운 요소가 추가될 때마다 tail을 업데이트 하고 있습니다.
    - 요소를 추가할 때마다 head에서 tail까지 순회하는 것을 방지하기 위함입니다.
- `ClientQueue` 타입은 다양한 타입의 데이터를 취급할 수 있도록 스위프트의 Generics 기능을 활용했습니다.
- `ClientQueue` 타입의 정상 동작 여부를 Unit Test를 통해 검증했습니다.

### enqueue
```swift 
   mutating func enqueue(_ data: Element) {
        queue.append(Node(data))
    }
```

### dequeue
```swift 
    func dequeue() -> Node<Element>? {
        return queue.isEmpty() == true ? nil : queue.removeFirst()
    }

```

### clear
```swift 
    func clear() {
        queue.removeAll()
    }
```

### peek
```swift 
    var peek: Element? {
        return queue.head?.data ?? nil
    }
```

### isEmpty
```swift 
    func isEmpty() -> Bool {
        return queue.head == nil ? true : false
    }
```

## 테스트 방법
1. BankManagerTests에 구현되어 있는 Test 코드들을 실행 시킵니다.

## 리뷰 노트
1. 양방향 리스트가 필요할지 단방향 리스트가 필요할지 고민해보았습니다.
    - 고객 대기열에서 먼저 온 고객이 먼저 처리되기 때문에(FIFO), 현재로서는 Queue의 tail부터 요소에 접근할 일이 없다고 가정했습니다.
    - 따라서 단방향 리스트를 사용해보았습니다.

2. `LinkedList`에서 removeAll()메서드를 구현할 때 head와 tail 모두를 nil로 처리해서 연결리스트를 끊어 주어야 할지 head만 끊어주면 될지 고민해보았습니다.
```swift
    func removeAll() {
        head = nil
    }
```

> 단방향 리스트는 각 노드가 `data` 속성과 `nextNode` 속성을 갖고 있다
> `class` 로 선언하므로, 참조타입이며, 참조 타입의 인스턴스는 힙 영역에 생성된다
	<br> 힙 영역의 인스턴스들은 그 인스턴스를 참조하는 다른 객체가 없다면, 즉, 총 해당 인스턴스의 참조가 0이라면 사라진다<br>
		 따라서, `head = nil`을 쓰면 `head.nextNode`에 들어있던 두 번째 노드를 가리키는 객체가 없어지므로, 두 번째 노드는 사라지게 된다(메모리에서 해제된다고 말한다). 두 번째 노드가 사라지므로 세 번째 노드를 가리키는 객체가 없고, 그래서 세 번째 노드도 사라진다. 이게 연쇄적으로 작용하여 결국 모든 노드는 사라진다.
- [ ] ARC에 대해 공부하고 다시 한번 생각해볼 것

3. 해당 부분은 guard let으로 head의 값을 할당하면 값 타입이 아닌 참조타입이 되는지 확인했습니다.

# LinkedList 

### 처음에 작성해 본 코드
```swift
 func removeFirstNode() -> Node<Element>? {
        if !isEmpty() {
            let removedNode = head ?? nil
            head = head?.nextNode
            return removedNode ?? nil
        }
        
        return nil
}
```
- 불필요한 `nil-Coalescing`를 반복사용하였고 `nil` 반환을 3번 하고 있습니다.
- 불필요한 `isEmpty()`를 사용하고 있습니다. 사실 `head`가 없으면 비어 있으므로 굳이 쓸 필요 없다고 생각했습니다.
- `head`가 옵셔널이므로 `removedNode`로 `unwrapping`했지만, 정작 바로 아래에서는 그 값을 쓰지 않고 `head?.nextNode`라고 `optional chaining`을 사용했습니다.

### 리팩토링한 코드
```swift
    func removeFirst() -> Node<Element>? {
        guard let removedNode = head else {
            return nil
        }
        
        head = removedNode.nextNode
        
        return removedNode
    }
```

### 참조타입 검증

처음에 `head = removedNode.nextNode`가 아니라 `head = head?.nextNode`라고 작성했던 이유는 `removedNode`와 `head`가 같은 메모리 주소를 참조하는지 확신할 수 없었기 때문입니다.
따라서 아래와 같은 메서드를 통해서 두 개의 인스턴스가 참조하는 주소값이 같은지를 확인하였습니다.

```swift
print("heap 영역 1 : ", Unmanaged.passUnretained(head).toOpaque())
print("heap 영역 2 : ", Unmanaged.passUnretained(removedNode).toOpaque())
```
 
4. 커밋메시지를 `feat: "타입이름" 구현한 내용`과 같은 양식으로 작성해보았습니다.
    - feat, refactor 등 어떤 성격의 작업을, 어떤 타입과 관련해, 어떤 내용을 구현했는지 표기하고자 했습니다.
    - 처음에는 `feat: [타입이름] 구현한 내용`과 같이 `대괄호`를 사용했지만, 마크다운 에디터 등 여러 환경에서 대괄호가 특정 기능을 수행하는 경우가 많아 보여 `쌍따옴표`로 변경했습니다.

## 스텝 핵심 경험
- [x] Linked-list 자료구조의 이해 및 구현
- [x] Queue 자료구조의 이해 및 구현
- [x] Generics 개념이해 및 적용