### PR TITLE
은행 창구 매니저 [STEP1] Bard, Finnn

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -144,3 +144,32 @@ bh_unicode_properties.cache
 # Sublime-github package stores a github token in this file
 # https://packagecontrol.io/packages/sublime-github
 GitHub.sublime-settings
+
+# Created by https://www.toptal.com/developers/gitignore/api/cocoapods,carthage,swiftpackagemanager
+# Edit at https://www.toptal.com/developers/gitignore?templates=cocoapods,carthage,swiftpackagemanager
+
+### Carthage ###
+# Carthage
+#
+# Add this line if you want to avoid checking in source code from Carthage dependencies.
+# Carthage/Checkouts
+
+Carthage/Build
+
+### CocoaPods ###
+## CocoaPods GitIgnore Template
+
+# CocoaPods - Only use to conserve bandwidth / Save time on Pushing
+#           - Also handy if you have a large number of dependant pods
+#           - AS PER https://guides.cocoapods.org/using/using-cocoapods.html NEVER IGNORE THE LOCK FILE
+Pods/
+
+### SwiftPackageManager ###
+Packages
+.build/
+xcuserdata
+DerivedData/
+*.xcodeproj
+
+
+# End of https://www.toptal.com/developers/gitignore/api/cocoapods,carthage,swiftpackagemanager

--- a/BankManager.swift
+++ b/BankManager.swift
@@ -1,7 +1,5 @@
 //
 //  BankManager.swift
-//  Created by yagom.
+//  Created by finnn, bard.
 //  Copyright © yagom academy. All rights reserved.
 //
-
-import Foundation

--- a/BankManagerConsoleApp/.swiftlint.yml
+++ b/BankManagerConsoleApp/.swiftlint.yml
@@ -1,0 +1,31 @@
+disabled_rules:
+ - trailing_whitespace
+ 
+opt_in_rules:
+  - empty_count
+  - empty_string
+  - colon
+  - comma
+  
+included:
+  - BankManagerConsoleApp
+  - Source
+  
+excluded:
+  - Carthage
+  - Pods
+  - Source/ExcludedFolder
+  - Source/ExcludedFile.swift
+  - Source/*/ExcludedFile.swift
+  
+analyzer_rules:
+  - explicit_self
+
+force_cast: warning
+force_try:
+  severity: warning
+
+line_length: 100
+
+
+

--- a/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
+++ b/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
@@ -57,6 +57,7 @@
 		D762D05D2869B13600E8235F /* Node.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Node.swift; sourceTree = "<group>"; };
 		D7BE3A66286A9D9000CED030 /* LinkedList+extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "LinkedList+extension.swift"; sourceTree = "<group>"; };
 		D7BE3A68286A9D9B00CED030 /* Queue+extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Queue+extension.swift"; sourceTree = "<group>"; };
+		D7BE3A6D286AEB7D00CED030 /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -104,6 +105,7 @@
 		C7694E6D259C3EC00053667F = {
 			isa = PBXGroup;
 			children = (
+				D7BE3A6D286AEB7D00CED030 /* .swiftlint.yml */,
 				C7694E78259C3EC00053667F /* BankManagerConsoleApp */,
 				B47641CD2869A6CE00EE924C /* LinkedListTest */,
 				B49E5518286A97700001E4B4 /* QueueTest */,
@@ -291,7 +293,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "# Type a script or drag a script file from your workspace to insert its path.\n#\"${PODS_ROOT}/SwiftLint/swiftlint\"\n";
+			shellScript = "# Type a script or drag a script file from your workspace to insert its path.\n\"${PODS_ROOT}/SwiftLint/swiftlint\"\n";
 		};
 		E5589D14F0B1120AFD5882B5 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
+++ b/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
@@ -7,8 +7,25 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		B47038152869E3C800DB790C /* Queue.swift in Sources */ = {isa = PBXBuildFile; fileRef = B47038142869E3C800DB790C /* Queue.swift */; };
+		B47038162869E3C800DB790C /* Queue.swift in Sources */ = {isa = PBXBuildFile; fileRef = B47038142869E3C800DB790C /* Queue.swift */; };
+		B47641C72869A6BC00EE924C /* LinkedList.swift in Sources */ = {isa = PBXBuildFile; fileRef = B47641C62869A6BC00EE924C /* LinkedList.swift */; };
+		B47641D32869A6D700EE924C /* LinkedList.swift in Sources */ = {isa = PBXBuildFile; fileRef = B47641C62869A6BC00EE924C /* LinkedList.swift */; };
+		B49AECE62869B83000E22E19 /* LinkedListTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = B47641CE2869A6CE00EE924C /* LinkedListTest.swift */; };
+		B49E551A286A97700001E4B4 /* QueueTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = B49E5519286A97700001E4B4 /* QueueTest.swift */; };
+		B49E551E286A97820001E4B4 /* Queue.swift in Sources */ = {isa = PBXBuildFile; fileRef = B47038142869E3C800DB790C /* Queue.swift */; };
+		B49E551F286A97840001E4B4 /* LinkedList.swift in Sources */ = {isa = PBXBuildFile; fileRef = B47641C62869A6BC00EE924C /* LinkedList.swift */; };
+		B49E5520286A97860001E4B4 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7694E79259C3EC00053667F /* main.swift */; };
+		B49E5521286A97890001E4B4 /* Node.swift in Sources */ = {isa = PBXBuildFile; fileRef = D762D05D2869B13600E8235F /* Node.swift */; };
+		B49E5522286A978C0001E4B4 /* BankManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7D65D1A259C8190005510E0 /* BankManager.swift */; };
 		C7694E7A259C3EC00053667F /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7694E79259C3EC00053667F /* main.swift */; };
 		C7D65D1B259C8190005510E0 /* BankManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7D65D1A259C8190005510E0 /* BankManager.swift */; };
+		D762D05B2869B12E00E8235F /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7694E79259C3EC00053667F /* main.swift */; };
+		D762D05C2869B13100E8235F /* BankManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7D65D1A259C8190005510E0 /* BankManager.swift */; };
+		D762D05E2869B13600E8235F /* Node.swift in Sources */ = {isa = PBXBuildFile; fileRef = D762D05D2869B13600E8235F /* Node.swift */; };
+		D762D0602869B22C00E8235F /* Node.swift in Sources */ = {isa = PBXBuildFile; fileRef = D762D05D2869B13600E8235F /* Node.swift */; };
+		D7BE3A67286A9D9000CED030 /* LinkedList+extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7BE3A66286A9D9000CED030 /* LinkedList+extension.swift */; };
+		D7BE3A69286A9D9B00CED030 /* Queue+extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7BE3A68286A9D9B00CED030 /* Queue+extension.swift */; };
 		DF3483F13516D01F69048FC1 /* Pods_BankManagerConsoleApp.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 304C19EEE45F7DC65C6D643A /* Pods_BankManagerConsoleApp.framework */; };
 /* End PBXBuildFile section */
 
@@ -27,13 +44,36 @@
 /* Begin PBXFileReference section */
 		304C19EEE45F7DC65C6D643A /* Pods_BankManagerConsoleApp.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_BankManagerConsoleApp.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		81FCEB3562D7DEEE97ED0217 /* Pods-BankManagerConsoleApp.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BankManagerConsoleApp.release.xcconfig"; path = "Target Support Files/Pods-BankManagerConsoleApp/Pods-BankManagerConsoleApp.release.xcconfig"; sourceTree = "<group>"; };
+		B47038142869E3C800DB790C /* Queue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Queue.swift; sourceTree = "<group>"; };
+		B47641C62869A6BC00EE924C /* LinkedList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkedList.swift; sourceTree = "<group>"; };
+		B47641CC2869A6CE00EE924C /* LinkedListTest.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = LinkedListTest.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		B47641CE2869A6CE00EE924C /* LinkedListTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkedListTest.swift; sourceTree = "<group>"; };
+		B49E5517286A97700001E4B4 /* QueueTest.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = QueueTest.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		B49E5519286A97700001E4B4 /* QueueTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QueueTest.swift; sourceTree = "<group>"; };
 		C7694E76259C3EC00053667F /* BankManagerConsoleApp */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = BankManagerConsoleApp; sourceTree = BUILT_PRODUCTS_DIR; };
 		C7694E79259C3EC00053667F /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
 		C7D65D1A259C8190005510E0 /* BankManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = BankManager.swift; path = ../../BankManager.swift; sourceTree = "<group>"; };
 		C94DB616F794B9E5C84424B6 /* Pods-BankManagerConsoleApp.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BankManagerConsoleApp.debug.xcconfig"; path = "Target Support Files/Pods-BankManagerConsoleApp/Pods-BankManagerConsoleApp.debug.xcconfig"; sourceTree = "<group>"; };
+		D762D05D2869B13600E8235F /* Node.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Node.swift; sourceTree = "<group>"; };
+		D7BE3A66286A9D9000CED030 /* LinkedList+extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "LinkedList+extension.swift"; sourceTree = "<group>"; };
+		D7BE3A68286A9D9B00CED030 /* Queue+extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Queue+extension.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		B47641C92869A6CE00EE924C /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		B49E5514286A97700001E4B4 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		C7694E73259C3EC00053667F /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -45,10 +85,28 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		B47641CD2869A6CE00EE924C /* LinkedListTest */ = {
+			isa = PBXGroup;
+			children = (
+				B47641CE2869A6CE00EE924C /* LinkedListTest.swift */,
+			);
+			path = LinkedListTest;
+			sourceTree = "<group>";
+		};
+		B49E5518286A97700001E4B4 /* QueueTest */ = {
+			isa = PBXGroup;
+			children = (
+				B49E5519286A97700001E4B4 /* QueueTest.swift */,
+			);
+			path = QueueTest;
+			sourceTree = "<group>";
+		};
 		C7694E6D259C3EC00053667F = {
 			isa = PBXGroup;
 			children = (
 				C7694E78259C3EC00053667F /* BankManagerConsoleApp */,
+				B47641CD2869A6CE00EE924C /* LinkedListTest */,
+				B49E5518286A97700001E4B4 /* QueueTest */,
 				C7694E77259C3EC00053667F /* Products */,
 				EBEE956ED02C9D70217FADAE /* Pods */,
 				C9DF57C5B83CB916161A78CB /* Frameworks */,
@@ -59,6 +117,8 @@
 			isa = PBXGroup;
 			children = (
 				C7694E76259C3EC00053667F /* BankManagerConsoleApp */,
+				B47641CC2869A6CE00EE924C /* LinkedListTest.xctest */,
+				B49E5517286A97700001E4B4 /* QueueTest.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -66,8 +126,12 @@
 		C7694E78259C3EC00053667F /* BankManagerConsoleApp */ = {
 			isa = PBXGroup;
 			children = (
-				C7D65D1A259C8190005510E0 /* BankManager.swift */,
 				C7694E79259C3EC00053667F /* main.swift */,
+				C7D65D1A259C8190005510E0 /* BankManager.swift */,
+				D762D05D2869B13600E8235F /* Node.swift */,
+				B47641C62869A6BC00EE924C /* LinkedList.swift */,
+				B47038142869E3C800DB790C /* Queue.swift */,
+				D7BE3A6A286A9E6C00CED030 /* Extension */,
 			);
 			path = BankManagerConsoleApp;
 			sourceTree = "<group>";
@@ -78,6 +142,15 @@
 				304C19EEE45F7DC65C6D643A /* Pods_BankManagerConsoleApp.framework */,
 			);
 			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		D7BE3A6A286A9E6C00CED030 /* Extension */ = {
+			isa = PBXGroup;
+			children = (
+				D7BE3A66286A9D9000CED030 /* LinkedList+extension.swift */,
+				D7BE3A68286A9D9B00CED030 /* Queue+extension.swift */,
+			);
+			name = Extension;
 			sourceTree = "<group>";
 		};
 		EBEE956ED02C9D70217FADAE /* Pods */ = {
@@ -92,6 +165,40 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
+		B47641CB2869A6CE00EE924C /* LinkedListTest */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = B47641D02869A6CE00EE924C /* Build configuration list for PBXNativeTarget "LinkedListTest" */;
+			buildPhases = (
+				B47641C82869A6CE00EE924C /* Sources */,
+				B47641C92869A6CE00EE924C /* Frameworks */,
+				B47641CA2869A6CE00EE924C /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = LinkedListTest;
+			productName = LinkedListTest;
+			productReference = B47641CC2869A6CE00EE924C /* LinkedListTest.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		B49E5516286A97700001E4B4 /* QueueTest */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = B49E551D286A97700001E4B4 /* Build configuration list for PBXNativeTarget "QueueTest" */;
+			buildPhases = (
+				B49E5513286A97700001E4B4 /* Sources */,
+				B49E5514286A97700001E4B4 /* Frameworks */,
+				B49E5515286A97700001E4B4 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = QueueTest;
+			productName = QueueTest;
+			productReference = B49E5517286A97700001E4B4 /* QueueTest.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 		C7694E75259C3EC00053667F /* BankManagerConsoleApp */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = C7694E7D259C3EC00053667F /* Build configuration list for PBXNativeTarget "BankManagerConsoleApp" */;
@@ -117,9 +224,15 @@
 		C7694E6E259C3EC00053667F /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastSwiftUpdateCheck = 1210;
+				LastSwiftUpdateCheck = 1330;
 				LastUpgradeCheck = 1210;
 				TargetAttributes = {
+					B47641CB2869A6CE00EE924C = {
+						CreatedOnToolsVersion = 13.3;
+					};
+					B49E5516286A97700001E4B4 = {
+						CreatedOnToolsVersion = 13.3;
+					};
 					C7694E75259C3EC00053667F = {
 						CreatedOnToolsVersion = 12.1;
 					};
@@ -139,9 +252,28 @@
 			projectRoot = "";
 			targets = (
 				C7694E75259C3EC00053667F /* BankManagerConsoleApp */,
+				B47641CB2869A6CE00EE924C /* LinkedListTest */,
+				B49E5516286A97700001E4B4 /* QueueTest */,
 			);
 		};
 /* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		B47641CA2869A6CE00EE924C /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		B49E5515286A97700001E4B4 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
 		D7053AAC2869877200C12928 /* ShellScript */ = {
@@ -159,7 +291,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "# Type a script or drag a script file from your workspace to insert its path.\n\"${PODS_ROOT}/SwiftLint/swiftlint\"\n";
+			shellScript = "# Type a script or drag a script file from your workspace to insert its path.\n#\"${PODS_ROOT}/SwiftLint/swiftlint\"\n";
 		};
 		E5589D14F0B1120AFD5882B5 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -186,18 +318,113 @@
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		B47641C82869A6CE00EE924C /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				B47641D32869A6D700EE924C /* LinkedList.swift in Sources */,
+				B47038162869E3C800DB790C /* Queue.swift in Sources */,
+				D762D0602869B22C00E8235F /* Node.swift in Sources */,
+				D762D05B2869B12E00E8235F /* main.swift in Sources */,
+				D762D05C2869B13100E8235F /* BankManager.swift in Sources */,
+				B49AECE62869B83000E22E19 /* LinkedListTest.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		B49E5513286A97700001E4B4 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				B49E551F286A97840001E4B4 /* LinkedList.swift in Sources */,
+				B49E5521286A97890001E4B4 /* Node.swift in Sources */,
+				B49E551A286A97700001E4B4 /* QueueTest.swift in Sources */,
+				B49E5520286A97860001E4B4 /* main.swift in Sources */,
+				B49E551E286A97820001E4B4 /* Queue.swift in Sources */,
+				B49E5522286A978C0001E4B4 /* BankManager.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		C7694E72259C3EC00053667F /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D7BE3A69286A9D9B00CED030 /* Queue+extension.swift in Sources */,
+				B47641C72869A6BC00EE924C /* LinkedList.swift in Sources */,
+				B47038152869E3C800DB790C /* Queue.swift in Sources */,
+				D7BE3A67286A9D9000CED030 /* LinkedList+extension.swift in Sources */,
 				C7694E7A259C3EC00053667F /* main.swift in Sources */,
 				C7D65D1B259C8190005510E0 /* BankManager.swift in Sources */,
+				D762D05E2869B13600E8235F /* Node.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin XCBuildConfiguration section */
+		B47641D12869A6CE00EE924C /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 12.3;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = finnn.LinkedListTest;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		B47641D22869A6CE00EE924C /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 12.3;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = finnn.LinkedListTest;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
+		B49E551B286A97700001E4B4 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 12.3;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = finnn.QueueTest;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		B49E551C286A97700001E4B4 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 12.3;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = finnn.QueueTest;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
 		C7694E7B259C3EC00053667F /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -336,6 +563,24 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		B47641D02869A6CE00EE924C /* Build configuration list for PBXNativeTarget "LinkedListTest" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				B47641D12869A6CE00EE924C /* Debug */,
+				B47641D22869A6CE00EE924C /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		B49E551D286A97700001E4B4 /* Build configuration list for PBXNativeTarget "QueueTest" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				B49E551B286A97700001E4B4 /* Debug */,
+				B49E551C286A97700001E4B4 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		C7694E71259C3EC00053667F /* Build configuration list for PBXProject "BankManagerConsoleApp" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
+++ b/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
@@ -7,6 +7,10 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		B4509684286BDE6C00412206 /* LinkedList+extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7BE3A66286A9D9000CED030 /* LinkedList+extension.swift */; };
+		B4509685286BDE6C00412206 /* LinkedList+extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7BE3A66286A9D9000CED030 /* LinkedList+extension.swift */; };
+		B4509687286BDE7700412206 /* Queue+extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7BE3A68286A9D9B00CED030 /* Queue+extension.swift */; };
+		B4509688286BDE7700412206 /* Queue+extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7BE3A68286A9D9B00CED030 /* Queue+extension.swift */; };
 		B47038152869E3C800DB790C /* Queue.swift in Sources */ = {isa = PBXBuildFile; fileRef = B47038142869E3C800DB790C /* Queue.swift */; };
 		B47038162869E3C800DB790C /* Queue.swift in Sources */ = {isa = PBXBuildFile; fileRef = B47038142869E3C800DB790C /* Queue.swift */; };
 		B47641C72869A6BC00EE924C /* LinkedList.swift in Sources */ = {isa = PBXBuildFile; fileRef = B47641C62869A6BC00EE924C /* LinkedList.swift */; };
@@ -327,7 +331,9 @@
 				B47641D32869A6D700EE924C /* LinkedList.swift in Sources */,
 				B47038162869E3C800DB790C /* Queue.swift in Sources */,
 				D762D0602869B22C00E8235F /* Node.swift in Sources */,
+				B4509684286BDE6C00412206 /* LinkedList+extension.swift in Sources */,
 				D762D05B2869B12E00E8235F /* main.swift in Sources */,
+				B4509687286BDE7700412206 /* Queue+extension.swift in Sources */,
 				D762D05C2869B13100E8235F /* BankManager.swift in Sources */,
 				B49AECE62869B83000E22E19 /* LinkedListTest.swift in Sources */,
 			);
@@ -340,7 +346,9 @@
 				B49E551F286A97840001E4B4 /* LinkedList.swift in Sources */,
 				B49E5521286A97890001E4B4 /* Node.swift in Sources */,
 				B49E551A286A97700001E4B4 /* QueueTest.swift in Sources */,
+				B4509685286BDE6C00412206 /* LinkedList+extension.swift in Sources */,
 				B49E5520286A97860001E4B4 /* main.swift in Sources */,
+				B4509688286BDE7700412206 /* Queue+extension.swift in Sources */,
 				B49E551E286A97820001E4B4 /* Queue.swift in Sources */,
 				B49E5522286A978C0001E4B4 /* BankManager.swift in Sources */,
 			);

--- a/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
+++ b/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		C7694E7A259C3EC00053667F /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7694E79259C3EC00053667F /* main.swift */; };
 		C7D65D1B259C8190005510E0 /* BankManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7D65D1A259C8190005510E0 /* BankManager.swift */; };
+		DF3483F13516D01F69048FC1 /* Pods_BankManagerConsoleApp.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 304C19EEE45F7DC65C6D643A /* Pods_BankManagerConsoleApp.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -24,9 +25,12 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		304C19EEE45F7DC65C6D643A /* Pods_BankManagerConsoleApp.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_BankManagerConsoleApp.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		81FCEB3562D7DEEE97ED0217 /* Pods-BankManagerConsoleApp.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BankManagerConsoleApp.release.xcconfig"; path = "Target Support Files/Pods-BankManagerConsoleApp/Pods-BankManagerConsoleApp.release.xcconfig"; sourceTree = "<group>"; };
 		C7694E76259C3EC00053667F /* BankManagerConsoleApp */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = BankManagerConsoleApp; sourceTree = BUILT_PRODUCTS_DIR; };
 		C7694E79259C3EC00053667F /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
 		C7D65D1A259C8190005510E0 /* BankManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = BankManager.swift; path = ../../BankManager.swift; sourceTree = "<group>"; };
+		C94DB616F794B9E5C84424B6 /* Pods-BankManagerConsoleApp.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BankManagerConsoleApp.debug.xcconfig"; path = "Target Support Files/Pods-BankManagerConsoleApp/Pods-BankManagerConsoleApp.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -34,6 +38,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				DF3483F13516D01F69048FC1 /* Pods_BankManagerConsoleApp.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -45,6 +50,8 @@
 			children = (
 				C7694E78259C3EC00053667F /* BankManagerConsoleApp */,
 				C7694E77259C3EC00053667F /* Products */,
+				EBEE956ED02C9D70217FADAE /* Pods */,
+				C9DF57C5B83CB916161A78CB /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -65,6 +72,23 @@
 			path = BankManagerConsoleApp;
 			sourceTree = "<group>";
 		};
+		C9DF57C5B83CB916161A78CB /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				304C19EEE45F7DC65C6D643A /* Pods_BankManagerConsoleApp.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		EBEE956ED02C9D70217FADAE /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				C94DB616F794B9E5C84424B6 /* Pods-BankManagerConsoleApp.debug.xcconfig */,
+				81FCEB3562D7DEEE97ED0217 /* Pods-BankManagerConsoleApp.release.xcconfig */,
+			);
+			path = Pods;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -72,9 +96,11 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = C7694E7D259C3EC00053667F /* Build configuration list for PBXNativeTarget "BankManagerConsoleApp" */;
 			buildPhases = (
+				E5589D14F0B1120AFD5882B5 /* [CP] Check Pods Manifest.lock */,
 				C7694E72259C3EC00053667F /* Sources */,
 				C7694E73259C3EC00053667F /* Frameworks */,
 				C7694E74259C3EC00053667F /* CopyFiles */,
+				D7053AAC2869877200C12928 /* ShellScript */,
 			);
 			buildRules = (
 			);
@@ -116,6 +142,48 @@
 			);
 		};
 /* End PBXProject section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		D7053AAC2869877200C12928 /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "# Type a script or drag a script file from your workspace to insert its path.\n\"${PODS_ROOT}/SwiftLint/swiftlint\"\n";
+		};
+		E5589D14F0B1120AFD5882B5 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-BankManagerConsoleApp-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		C7694E72259C3EC00053667F /* Sources */ = {
@@ -247,6 +315,7 @@
 		};
 		C7694E7E259C3EC00053667F /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = C94DB616F794B9E5C84424B6 /* Pods-BankManagerConsoleApp.debug.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -256,6 +325,7 @@
 		};
 		C7694E7F259C3EC00053667F /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 81FCEB3562D7DEEE97ED0217 /* Pods-BankManagerConsoleApp.release.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/BankManagerConsoleApp/BankManagerConsoleApp.xcworkspace/contents.xcworkspacedata
+++ b/BankManagerConsoleApp/BankManagerConsoleApp.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "group:BankManagerConsoleApp.xcodeproj">
+   </FileRef>
+   <FileRef
+      location = "group:Pods/Pods.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/BankManagerConsoleApp/BankManagerConsoleApp.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/BankManagerConsoleApp/BankManagerConsoleApp.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/BankManagerConsoleApp/BankManagerConsoleApp/LinkedList+extension.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/LinkedList+extension.swift
@@ -1,0 +1,36 @@
+//
+//  LinkedList+extension.swift
+//  BankManagerConsoleApp
+//
+//  Created by finnn, bard on 2022/06/28.
+//
+
+extension LinkedList: Sequence, IteratorProtocol {
+    mutating func next() -> T? {
+        defer { currentNode = currentNode?.next }
+        
+        return currentNode?.data
+    }
+}
+
+extension LinkedList: CustomStringConvertible, CustomDebugStringConvertible {
+    var description: String {
+        let stringArray = self.map { "\($0)" }
+        let returnArrray = stringArray.joined(separator: ", ")
+        return "[\(returnArrray)]"
+    }
+    
+    var debugDescription: String {
+        let stringArray = self.map { "\($0)" }
+        let returnArrray = stringArray.joined(separator: ", ")
+        return "[\(returnArrray)]"
+    }
+}
+
+extension LinkedList: ExpressibleByArrayLiteral {
+    init(arrayLiteral elements: T...) {
+        self.init()
+        elements.forEach { self.enqueue(data: $0) }
+    }
+}
+

--- a/BankManagerConsoleApp/BankManagerConsoleApp/LinkedList+extension.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/LinkedList+extension.swift
@@ -33,4 +33,3 @@ extension LinkedList: ExpressibleByArrayLiteral {
         elements.forEach { self.enqueue(data: $0) }
     }
 }
-

--- a/BankManagerConsoleApp/BankManagerConsoleApp/LinkedList+extension.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/LinkedList+extension.swift
@@ -30,6 +30,6 @@ extension LinkedList: CustomStringConvertible, CustomDebugStringConvertible {
 extension LinkedList: ExpressibleByArrayLiteral {
     init(arrayLiteral elements: T...) {
         self.init()
-        elements.forEach { self.enqueue(data: $0) }
+        elements.forEach { self.add(node: Node<T>(data: $0)) }
     }
 }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/LinkedList.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/LinkedList.swift
@@ -1,0 +1,48 @@
+//
+//  LinkedList.swift
+//  BankManagerConsoleApp
+//
+//  Created byfinnn, bard on 2022/06/27.
+//
+
+struct LinkedList<T> {
+    var head: Node<T>?
+    var tail: Node<T>?
+    var nodeCount: Int = 0
+    lazy var currentNode:Node<T>? = head
+    
+    mutating func enqueue(data: T) {
+        let node = Node<T>(data: data)
+        nodeCount += 1
+        if head == nil {
+            head = node
+            tail = node
+        } else {
+            tail?.next = node
+            node.previous = tail
+            tail = node
+        }
+    }
+    
+    mutating func dequeue() -> T? {
+        nodeCount -= 1
+        let returnData = head?.data
+        
+        head?.next?.previous = nil
+        head = head?.next
+        
+        return returnData
+    }
+    
+    mutating func clear() {
+        while nodeCount != 0 {
+            head = head?.next
+            head?.previous?.next = nil
+            head?.previous = nil
+            nodeCount -= 1
+        }
+        
+        head = nil
+        tail = nil
+    }
+}

--- a/BankManagerConsoleApp/BankManagerConsoleApp/LinkedList.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/LinkedList.swift
@@ -9,7 +9,7 @@ struct LinkedList<T> {
     var head: Node<T>?
     var tail: Node<T>?
     var nodeCount: Int = 0
-    lazy var currentNode:Node<T>? = head
+    lazy var currentNode: Node<T>? = head
     
     mutating func enqueue(data: T) {
         let node = Node<T>(data: data)

--- a/BankManagerConsoleApp/BankManagerConsoleApp/LinkedList.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/LinkedList.swift
@@ -11,22 +11,20 @@ struct LinkedList<T> {
     var nodeCount: Int = 0
     lazy var currentNode: Node<T>? = head
     
-    mutating func enqueue(data: T) {
-        let node = Node<T>(data: data)
+    mutating func add(node: Node<T>) {
         nodeCount += 1
         if head == nil {
             head = node
             tail = node
         } else {
             tail?.next = node
-            node.previous = tail
             tail = node
         }
     }
     
-    mutating func dequeue() -> T? {
+    mutating func removeFirst() -> Node<T>? {
         nodeCount -= 1
-        let returnData = head?.data
+        let returnData = head
         
         head?.next?.previous = nil
         head = head?.next

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Node.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Node.swift
@@ -1,0 +1,16 @@
+//
+//  Node.swift
+//  BankManagerConsoleApp
+//
+//  Created by finnn, bard on 2022/06/27.
+//
+
+class Node<T> {
+    var next: Node<T>?
+    var previous: Node<T>?
+    var data: T
+    
+    init(data: T) {
+        self.data = data
+    }
+}

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Node.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Node.swift
@@ -5,7 +5,7 @@
 //  Created by finnn, bard on 2022/06/27.
 //
 
-class Node<T> {
+final class Node<T> {
     var next: Node<T>?
     var previous: Node<T>?
     var data: T

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Queue+extension.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Queue+extension.swift
@@ -1,0 +1,27 @@
+//
+//  Queue+extension.swift
+//  BankManagerConsoleApp
+//
+//  Created by finnn, bard on 2022/06/28.
+//
+
+extension Queue: CustomStringConvertible, CustomDebugStringConvertible {
+    var description: String {
+        let stringArray = self.map { "\($0)" }
+        let returnArrray = stringArray.joined(separator: ", ")
+        return "[\(returnArrray)]"
+    }
+    
+    var debugDescription: String {
+        let stringArray = self.map { "\($0)" }
+        let returnArrray = stringArray.joined(separator: ", ")
+        return "[\(returnArrray)]"
+    }
+}
+
+extension Queue: ExpressibleByArrayLiteral {
+    init(arrayLiteral elements: T...) {
+        self.init()
+        elements.forEach { self.enqueue(data: $0) }
+    }
+}

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Queue.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Queue.swift
@@ -1,0 +1,46 @@
+//
+//  Queue.swift
+//  BankManagerConsoleApp
+//
+//  Created by finnn, bard on 2022/06/27.
+//
+
+struct Queue<T: Equatable> {
+    private var linkedList = LinkedList<T>()
+    var isEmpty: Bool {
+        linkedList.nodeCount == 0
+    }
+    var peek: T? {
+        linkedList.head?.data
+    }
+    
+    mutating func enqueue(data: T) {
+        linkedList.enqueue(data: data)
+    }
+    
+    mutating func dequeue() -> T? {
+        return linkedList.dequeue()
+    }
+    
+    mutating func clear() {
+        linkedList.clear()
+    }
+}
+
+extension Queue: Sequence, IteratorProtocol {
+    mutating func next() -> T? {
+        return linkedList.next()
+    }
+}
+
+extension Queue: Equatable {
+    static func == (lhs: Queue<T>, rhs: Queue<T>) -> Bool {
+        guard lhs.linkedList.nodeCount == rhs.linkedList.nodeCount else { return false }
+        
+        for (lhsElement, rhsElement) in zip(lhs, rhs) {
+            guard lhsElement == rhsElement else { return false }
+        }
+        
+        return true
+    }
+}

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Queue.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Queue.swift
@@ -15,11 +15,11 @@ struct Queue<T: Equatable> {
     }
     
     mutating func enqueue(data: T) {
-        linkedList.enqueue(data: data)
+        linkedList.add(node: Node<T>(data: data))
     }
     
     mutating func dequeue() -> T? {
-        return linkedList.dequeue()
+        return linkedList.removeFirst()?.data
     }
     
     mutating func clear() {

--- a/BankManagerConsoleApp/BankManagerConsoleApp/main.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/main.swift
@@ -1,7 +1,5 @@
 //
 //  BankManagerConsoleApp - main.swift
-//  Created by yagom. 
+//  Created by finnn, bard. 
 //  Copyright © yagom academy. All rights reserved.
 // 
-
-import Foundation

--- a/BankManagerConsoleApp/LinkedListTest/LinkedListTest.swift
+++ b/BankManagerConsoleApp/LinkedListTest/LinkedListTest.swift
@@ -19,7 +19,7 @@ class LinkedListTest: XCTestCase {
         sut = nil
     }
 
-    func test_enqueue함수에데이터를넣으면_배열에순서대로잘들어가는지() {
+    func test_add함수에데이터를넣으면_배열에순서대로잘들어가는지() {
         // given
         let input = [1,2,3,4,5]
         
@@ -35,7 +35,7 @@ class LinkedListTest: XCTestCase {
         XCTAssertEqual(data, result[0])
     }
     
-    func test_dequeue함수가_배열의첫번째숫자를잘반환하는지() {
+    func test_removeFirst함수가_배열의첫번째숫자를잘반환하는지() {
         // given
         let input = [1,2,3,4,5]
         sut?.add(node: Node<Int>(data: input[0]))
@@ -45,12 +45,12 @@ class LinkedListTest: XCTestCase {
 
         // when
         let result = sut?.removeFirst()?.data
-        
+        Ω
         // then
         XCTAssertEqual(input[0], result)
     }
     
-    func test_clear() {
+    func test_clear함수를실행하고_isEmpty가true를반환하는지() {
         // given
         let input = [1,2,3,4,5]
         sut?.add(node: Node<Int>(data: input[0]))

--- a/BankManagerConsoleApp/LinkedListTest/LinkedListTest.swift
+++ b/BankManagerConsoleApp/LinkedListTest/LinkedListTest.swift
@@ -24,10 +24,10 @@ class LinkedListTest: XCTestCase {
         let input = [1,2,3,4,5]
         
         // when
-        sut?.enqueue(data: input[0])
-        sut?.enqueue(data: input[1])
-        sut?.enqueue(data: input[2])
-        sut?.enqueue(data: input[3])
+        sut?.add(node: Node<Int>(data: input[0]))
+        sut?.add(node: Node<Int>(data: input[1]))
+        sut?.add(node: Node<Int>(data: input[2]))
+        sut?.add(node: Node<Int>(data: input[3]))
         let result = [1, 2, 3, 4]
         guard let data = sut?.head?.data else { return }
         
@@ -35,16 +35,16 @@ class LinkedListTest: XCTestCase {
         XCTAssertEqual(data, result[0])
     }
     
-    func test_dequeue함수가_배열의마지막숫자를잘반환하는지() {
+    func test_dequeue함수가_배열의첫번째숫자를잘반환하는지() {
         // given
         let input = [1,2,3,4,5]
-        sut?.enqueue(data: input[0])
-        sut?.enqueue(data: input[1])
-        sut?.enqueue(data: input[2])
-        sut?.enqueue(data: input[3])
-        
+        sut?.add(node: Node<Int>(data: input[0]))
+        sut?.add(node: Node<Int>(data: input[1]))
+        sut?.add(node: Node<Int>(data: input[2]))
+        sut?.add(node: Node<Int>(data: input[3]))
+
         // when
-        let result = sut?.dequeue()
+        let result = sut?.removeFirst()?.data
         
         // then
         XCTAssertEqual(input[0], result)
@@ -53,10 +53,10 @@ class LinkedListTest: XCTestCase {
     func test_clear() {
         // given
         let input = [1,2,3,4,5]
-        sut?.enqueue(data: input[0])
-        sut?.enqueue(data: input[1])
-        sut?.enqueue(data: input[2])
-        sut?.enqueue(data: input[3])
+        sut?.add(node: Node<Int>(data: input[0]))
+        sut?.add(node: Node<Int>(data: input[1]))
+        sut?.add(node: Node<Int>(data: input[2]))
+        sut?.add(node: Node<Int>(data: input[3]))
         
         // when
         sut?.clear()

--- a/BankManagerConsoleApp/LinkedListTest/LinkedListTest.swift
+++ b/BankManagerConsoleApp/LinkedListTest/LinkedListTest.swift
@@ -1,0 +1,68 @@
+//
+//  LinkedListTest.swift
+//  LinkedListTest
+//
+//  Created by finnn, bard on 2022/06/27.
+//
+
+import XCTest
+
+class LinkedListTest: XCTestCase {
+
+    var sut: LinkedList<Int>?
+    
+    override func setUpWithError() throws {
+        sut = LinkedList<Int>()
+    }
+
+    override func tearDownWithError() throws {
+        sut = nil
+    }
+
+    func test_enqueue함수에데이터를넣으면_배열에순서대로잘들어가는지() {
+        // given
+        let input = [1,2,3,4,5]
+        
+        // when
+        sut?.enqueue(data: input[0])
+        sut?.enqueue(data: input[1])
+        sut?.enqueue(data: input[2])
+        sut?.enqueue(data: input[3])
+        let result = [1, 2, 3, 4]
+        guard let data = sut?.head?.data else { return }
+        
+        // then
+        XCTAssertEqual(data, result[0])
+    }
+    
+    func test_dequeue함수가_배열의마지막숫자를잘반환하는지() {
+        // given
+        let input = [1,2,3,4,5]
+        sut?.enqueue(data: input[0])
+        sut?.enqueue(data: input[1])
+        sut?.enqueue(data: input[2])
+        sut?.enqueue(data: input[3])
+        
+        // when
+        let result = sut?.dequeue()
+        
+        // then
+        XCTAssertEqual(input[0], result)
+    }
+    
+    func test_clear() {
+        // given
+        let input = [1,2,3,4,5]
+        sut?.enqueue(data: input[0])
+        sut?.enqueue(data: input[1])
+        sut?.enqueue(data: input[2])
+        sut?.enqueue(data: input[3])
+        
+        // when
+        sut?.clear()
+        let result = 0
+        
+        //then
+        XCTAssertEqual(result, sut?.nodeCount)
+    }
+}

--- a/BankManagerConsoleApp/LinkedListTest/LinkedListTest.swift
+++ b/BankManagerConsoleApp/LinkedListTest/LinkedListTest.swift
@@ -19,7 +19,7 @@ class LinkedListTest: XCTestCase {
         sut = nil
     }
 
-    func test_add함수에데이터를넣으면_배열에순서대로잘들어가는지() {
+    func test_add함수에데이터를넣으면_배열에순서대로잘들어가는지1() {
         // given
         let input = [1,2,3,4,5]
         
@@ -35,7 +35,23 @@ class LinkedListTest: XCTestCase {
         XCTAssertEqual(data, result[0])
     }
     
-    func test_removeFirst함수가_배열의첫번째숫자를잘반환하는지() {
+    func test_add함수에데이터를넣으면_배열에순서대로잘들어가는지2() {
+        // given
+        let input = [1,2,3,4,5]
+        
+        // when
+        sut?.add(node: Node<Int>(data: input[0]))
+        sut?.add(node: Node<Int>(data: input[1]))
+        sut?.add(node: Node<Int>(data: input[2]))
+        sut?.add(node: Node<Int>(data: input[3]))
+        let result = [1, 2, 3, 4]
+        guard let data = sut?.head?.data else { return }
+        
+        // then
+        XCTAssertNotEqual(data, result[2])
+    }
+    
+    func test_removeFirst함수가_배열의첫번째숫자를잘반환하는지1() {
         // given
         let input = [1,2,3,4,5]
         sut?.add(node: Node<Int>(data: input[0]))
@@ -45,12 +61,27 @@ class LinkedListTest: XCTestCase {
 
         // when
         let result = sut?.removeFirst()?.data
-        Ω
+        
         // then
         XCTAssertEqual(input[0], result)
     }
     
-    func test_clear함수를실행하고_isEmpty가true를반환하는지() {
+    func test_removeFirst함수가_배열의첫번째숫자를잘반환하는지2() {
+        // given
+        let input = [1,2,3,4,5]
+        sut?.add(node: Node<Int>(data: input[0]))
+        sut?.add(node: Node<Int>(data: input[1]))
+        sut?.add(node: Node<Int>(data: input[2]))
+        sut?.add(node: Node<Int>(data: input[3]))
+
+        // when
+        let result = sut?.removeFirst()?.data
+        
+        // then
+        XCTAssertNotEqual(input[2], result)
+    }
+    
+    func test_clear함수를실행하고_isEmpty가true를반환하는지1() {
         // given
         let input = [1,2,3,4,5]
         sut?.add(node: Node<Int>(data: input[0]))
@@ -63,6 +94,22 @@ class LinkedListTest: XCTestCase {
         let result = 0
         
         //then
-        XCTAssertEqual(result, sut?.nodeCount)
+        XCTAssertEqual(sut?.nodeCount, result)
+    }
+    
+    func test_clear함수를실행하고_isEmpty가true를반환하는지2() {
+        // given
+        let input = [1,2,3,4,5]
+        sut?.add(node: Node<Int>(data: input[0]))
+        sut?.add(node: Node<Int>(data: input[1]))
+        sut?.add(node: Node<Int>(data: input[2]))
+        sut?.add(node: Node<Int>(data: input[3]))
+        
+        // when
+        sut?.clear()
+        let result = 1
+        
+        //then
+        XCTAssertNotEqual(sut?.nodeCount, result)
     }
 }

--- a/BankManagerConsoleApp/Podfile
+++ b/BankManagerConsoleApp/Podfile
@@ -1,0 +1,10 @@
+# Uncomment the next line to define a global platform for your project
+# platform :ios, '9.0'
+
+target 'BankManagerConsoleApp' do
+  # Comment the next line if you don't want to use dynamic frameworks
+  use_frameworks!
+  pod 'SwiftLint'
+  # Pods for BankManagerConsoleApp
+
+end

--- a/BankManagerConsoleApp/Podfile.lock
+++ b/BankManagerConsoleApp/Podfile.lock
@@ -1,0 +1,16 @@
+PODS:
+  - SwiftLint (0.47.1)
+
+DEPENDENCIES:
+  - SwiftLint
+
+SPEC REPOS:
+  trunk:
+    - SwiftLint
+
+SPEC CHECKSUMS:
+  SwiftLint: f80f1be7fa96d30e0aa68e58d45d4ea1ccaac519
+
+PODFILE CHECKSUM: 9e1867977b1cb50c425944a5bb7eb2f842b0b726
+
+COCOAPODS: 1.11.3

--- a/BankManagerConsoleApp/QueueTest/QueueTest.swift
+++ b/BankManagerConsoleApp/QueueTest/QueueTest.swift
@@ -28,10 +28,10 @@ class QueueTest: XCTestCase {
         sut?.enqueue(data: input[1])
         sut?.enqueue(data: input[2])
         sut?.enqueue(data: input[3])
-        let result: Queue<Int> = [1, 2, 3, 4]
+        let result: String = "\([1, 2, 3, 4])"
         
         // then
-        XCTAssertEqual(sut, result)
+        XCTAssertEqual(sut?.debugDescription, result)
     }
     
     func test_enqueue함수에데이터를넣으면_배열에순서대로잘들어가는지2() {
@@ -49,7 +49,22 @@ class QueueTest: XCTestCase {
         XCTAssertFalse(sut == result)
     }
     
-    func test_dequeue함수가_배열의마지막숫자를잘반환하는지() {
+    func test_enqueue를했을때_debugDescription이enqueu한값을잘반환하는지() {
+        // given
+        let input = [1,2,3,4,5]
+        
+        // when
+        sut?.enqueue(data: input[0])
+        sut?.enqueue(data: input[1])
+        sut?.enqueue(data: input[2])
+        sut?.enqueue(data: input[3])
+        let result: String = "\([1, 2, 3, 4])"
+        
+        // then
+        XCTAssertTrue(sut?.debugDescription == result)
+    }
+    
+    func test_dequeue함수가_배열의첫번째숫자를잘반환하는지() {
         // given
         let input = [1,2,3,4,5]
         sut?.enqueue(data: input[0])
@@ -95,7 +110,7 @@ class QueueTest: XCTestCase {
         XCTAssertEqual(sut?.peek, result)
     }
     
-    func test_clear함수를실행하고_isEmpty가true를반환하는지() {
+    func test_clear함수를실행하고_배열과_비교해서_true와_false를_잘_반환하는지() {
         // given
         let input = [1,2,3,4,5]
         sut?.enqueue(data: input[0])
@@ -108,6 +123,10 @@ class QueueTest: XCTestCase {
         guard let result = sut?.isEmpty else { return }
         
         // then
-        XCTAssertTrue(result)
+        if result  {
+            XCTAssertTrue(result)
+        } else {
+            XCTAssertFalse(result)
+        }
     }
 }

--- a/BankManagerConsoleApp/QueueTest/QueueTest.swift
+++ b/BankManagerConsoleApp/QueueTest/QueueTest.swift
@@ -49,7 +49,22 @@ class QueueTest: XCTestCase {
         XCTAssertFalse(sut == result)
     }
     
-    func test_enqueue를했을때_debugDescription이enqueu한값을잘반환하는지() {
+    func test_enqueue함수에데이터를넣으면_배열에순서대로잘들어가는지3() {
+        // given
+        let input = [1,2,3,4,5]
+        
+        // when
+        sut?.enqueue(data: input[0])
+        sut?.enqueue(data: input[1])
+        sut?.enqueue(data: input[2])
+        sut?.enqueue(data: input[3])
+        let result: Queue<Int> = [1, 2, 3]
+        
+        // then
+        XCTAssertFalse(sut == result)
+    }
+    
+    func test_enqueue를했을때_debugDescription이enqueu한값을잘반환하는지1() {
         // given
         let input = [1,2,3,4,5]
         
@@ -62,6 +77,21 @@ class QueueTest: XCTestCase {
         
         // then
         XCTAssertTrue(sut?.debugDescription == result)
+    }
+    
+    func test_enqueue를했을때_debugDescription이enqueu한값을잘반환하는지2() {
+        // given
+        let input = [1,2,3,4,5]
+        
+        // when
+        sut?.enqueue(data: input[0])
+        sut?.enqueue(data: input[1])
+        sut?.enqueue(data: input[2])
+        sut?.enqueue(data: input[3])
+        let result: String = "\([1, 2, 3])"
+        
+        // then
+        XCTAssertFalse(sut?.debugDescription == result)
     }
     
     func test_dequeue함수가_배열의첫번째숫자를잘반환하는지() {
@@ -92,10 +122,10 @@ class QueueTest: XCTestCase {
         let result = true
         
         //then
-        XCTAssertEqual(result, sut?.isEmpty)
+        XCTAssertEqual(sut?.isEmpty, result)
     }
     
-    func test_peek잘_동작하는지_확인() {
+    func test_peek잘_동작하는지_확인1() {
         // given
         let input = [1,2,3,4,5]
         sut?.enqueue(data: input[0])
@@ -105,6 +135,39 @@ class QueueTest: XCTestCase {
         
         // when
         let result = 1
+        
+        // then
+        XCTAssertEqual(sut?.peek, result)
+    }
+    
+    func test_peek잘_동작하는지_확인2() {
+        // given
+        let input = [1,2,3,4,5]
+        sut?.enqueue(data: input[0])
+        sut?.enqueue(data: input[1])
+        sut?.enqueue(data: input[2])
+        sut?.enqueue(data: input[3])
+        let dequeuedData = sut?.dequeue()
+        
+        // when
+        let result = 2
+        
+        // then
+        XCTAssertEqual(sut?.peek, result)
+    }
+    
+    func test_peek잘_동작하는지_확인() {
+        // given
+        let input = [1,2,3,4,5]
+        sut?.enqueue(data: input[0])
+        sut?.enqueue(data: input[1])
+        sut?.enqueue(data: input[2])
+        sut?.enqueue(data: input[3])
+        let dequeuedData1 = sut?.dequeue()
+        let dequeuedData2 = sut?.dequeue()
+        
+        // when
+        let result = 3
         
         // then
         XCTAssertEqual(sut?.peek, result)

--- a/BankManagerConsoleApp/QueueTest/QueueTest.swift
+++ b/BankManagerConsoleApp/QueueTest/QueueTest.swift
@@ -1,0 +1,113 @@
+//
+//  QueueTest.swift
+//  QueueTest
+//
+//  Created by finnn, bard on 2022/06/28.
+//
+
+import XCTest
+
+class QueueTest: XCTestCase {
+
+    var sut: Queue<Int>?
+    
+    override func setUpWithError() throws {
+        sut = Queue<Int>()
+    }
+
+    override func tearDownWithError() throws {
+        sut = nil
+    }
+
+    func test_enqueue함수에데이터를넣으면_배열에순서대로잘들어가는지1() {
+        // given
+        let input = [1,2,3,4,5]
+        
+        // when
+        sut?.enqueue(data: input[0])
+        sut?.enqueue(data: input[1])
+        sut?.enqueue(data: input[2])
+        sut?.enqueue(data: input[3])
+        let result: Queue<Int> = [1, 2, 3, 4]
+        
+        // then
+        XCTAssertEqual(sut, result)
+    }
+    
+    func test_enqueue함수에데이터를넣으면_배열에순서대로잘들어가는지2() {
+        // given
+        let input = [1,2,3,4,5]
+        
+        // when
+        sut?.enqueue(data: input[0])
+        sut?.enqueue(data: input[1])
+        sut?.enqueue(data: input[2])
+        sut?.enqueue(data: input[3])
+        let result: Queue<Int> = [1, 2, 3, 4, 5]
+        
+        // then
+        XCTAssertFalse(sut == result)
+    }
+    
+    func test_dequeue함수가_배열의마지막숫자를잘반환하는지() {
+        // given
+        let input = [1,2,3,4,5]
+        sut?.enqueue(data: input[0])
+        sut?.enqueue(data: input[1])
+        sut?.enqueue(data: input[2])
+        sut?.enqueue(data: input[3])
+        
+        // when
+        let result = sut?.dequeue()
+        
+        // then
+        XCTAssertEqual(input[0], result)
+    }
+    
+    func test_clear함수를실행하면큐내부가비어있는지() {
+        // given
+        let input = [1,2,3,4,5]
+        sut?.enqueue(data: input[0])
+        sut?.enqueue(data: input[1])
+        sut?.enqueue(data: input[2])
+        sut?.enqueue(data: input[3])
+        
+        // when
+        sut?.clear()
+        let result = true
+        
+        //then
+        XCTAssertEqual(result, sut?.isEmpty)
+    }
+    
+    func test_peek잘_동작하는지_확인() {
+        // given
+        let input = [1,2,3,4,5]
+        sut?.enqueue(data: input[0])
+        sut?.enqueue(data: input[1])
+        sut?.enqueue(data: input[2])
+        sut?.enqueue(data: input[3])
+        
+        // when
+        let result = 1
+        
+        // then
+        XCTAssertEqual(sut?.peek, result)
+    }
+    
+    func test_clear함수를실행하고_isEmpty가true를반환하는지() {
+        // given
+        let input = [1,2,3,4,5]
+        sut?.enqueue(data: input[0])
+        sut?.enqueue(data: input[1])
+        sut?.enqueue(data: input[2])
+        sut?.enqueue(data: input[3])
+        
+        // when
+        sut?.clear()
+        guard let result = sut?.isEmpty else { return }
+        
+        // then
+        XCTAssertTrue(result)
+    }
+}


### PR DESCRIPTION
안녕하세요 우디! ☺️ @Wody95 
STEP1 PR 보내드립니다!
잘 부탁드립니다~🙏

---

# 은행 창구 매니저 STEP1 PR

---


## 궁금한점 🤔
```shell
Could not find module 'BankManagerConsoleApp' for target 'x86_64-apple-
macos'; found: arm64-apple-macos, 
at:/Users/Kim-DongYong/Library/Developer/Xcode/DerivedData/BankManagerConsoleApp-
acslyqhrplbojmgnotygnhtucvdv/Index/Build/Products/Debug/BankManagerConsoleApp
.swiftmodule
```
이번 프로젝트에서 `UnitTest`를 진행하면서 `@testable import`를 해주려고 했습니다.
그런데, Command line tool 프로그램을 만들때 M1 맥북을 사용하는 경우는 위와 같은 에러가 발생하며, 작동하지 않는 것을 발견했습니다.
어찌저찌 `@testable`을 적어주지 않고, 각 파일에서 직접 Target Membership을 체크해주는 것으로 해결하였는데요, 이렇게 해결하는 것이 올바른 방법이 아니라는 생각이 들어 어떻게 해결하면 좋을지 질문드립니다 🥲


## 고민한점 🤔
1. `class vs struct`
- `Queue` 타입과 `LinkedList` 타입을 초반에는 class로 구현했었습니다. 하지만 `Sequence`, `IteratorProtocol` 프로토콜을 채택해서 구현하는 과정에서, `next()` 메서드가 호출 될 때, 다음 노드를 가르키는 `currentNode`가 다시 원래 head를 가르키지 않고, 남아있는 것을 확인했습니다.
- class가 아닌, struct 타입으로 변경해서 해결했습니다.
 
2. `Queue vs LinkedList`
- 현재 `Queue`에 구현해야하는 필수 기능들이 `Enqueue`, `Dequeue`, `Clear`, `Peek`, `isEmpty`이 있는데, LinkedList를 구현하다보니 `Queue`에 구현해야 할 기능들을 모두 `LinkedList` 내부에 구현을 해버렸습니다
- 이에, `Queue`와 `LinkedList` 내부에서 꼭 필요한 기능들이 무엇인가를 생각해서 `Queue`내부에 필요한 기능들은 `Queue`내부에서 구현을 해주고 `LinkedList`내부에서 필요한 기능들을 `LinkedList` 내부에 구현을 해줌으로써, 기능을 최대한 나누어 보았습니다.