### PR TITLE
은행창구 매니저 [STEP 1] woong, 준호

### DIFF
--- a/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
+++ b/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		C7694E7A259C3EC00053667F /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7694E79259C3EC00053667F /* main.swift */; };
 		C7D65D1B259C8190005510E0 /* BankManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7D65D1A259C8190005510E0 /* BankManager.swift */; };
 		D2C159302910AF23005C15C5 /* Node.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2C1592F2910AF23005C15C5 /* Node.swift */; };
+		EB413A1C2910B00800B3A432 /* LinkedList.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB413A1B2910B00800B3A432 /* LinkedList.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -29,6 +30,7 @@
 		C7694E79259C3EC00053667F /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
 		C7D65D1A259C8190005510E0 /* BankManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = BankManager.swift; path = ../../BankManager.swift; sourceTree = "<group>"; };
 		D2C1592F2910AF23005C15C5 /* Node.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Node.swift; sourceTree = "<group>"; };
+		EB413A1B2910B00800B3A432 /* LinkedList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkedList.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -64,6 +66,7 @@
 				C7D65D1A259C8190005510E0 /* BankManager.swift */,
 				C7694E79259C3EC00053667F /* main.swift */,
 				D2C1592F2910AF23005C15C5 /* Node.swift */,
+				EB413A1B2910B00800B3A432 /* LinkedList.swift */,
 			);
 			path = BankManagerConsoleApp;
 			sourceTree = "<group>";
@@ -127,6 +130,7 @@
 			files = (
 				D2C159302910AF23005C15C5 /* Node.swift in Sources */,
 				C7694E7A259C3EC00053667F /* main.swift in Sources */,
+				EB413A1C2910B00800B3A432 /* LinkedList.swift in Sources */,
 				C7D65D1B259C8190005510E0 /* BankManager.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
+++ b/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		C7694E7A259C3EC00053667F /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7694E79259C3EC00053667F /* main.swift */; };
 		C7D65D1B259C8190005510E0 /* BankManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7D65D1A259C8190005510E0 /* BankManager.swift */; };
+		D2C159302910AF23005C15C5 /* Node.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2C1592F2910AF23005C15C5 /* Node.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -27,6 +28,7 @@
 		C7694E76259C3EC00053667F /* BankManagerConsoleApp */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = BankManagerConsoleApp; sourceTree = BUILT_PRODUCTS_DIR; };
 		C7694E79259C3EC00053667F /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
 		C7D65D1A259C8190005510E0 /* BankManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = BankManager.swift; path = ../../BankManager.swift; sourceTree = "<group>"; };
+		D2C1592F2910AF23005C15C5 /* Node.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Node.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -61,6 +63,7 @@
 			children = (
 				C7D65D1A259C8190005510E0 /* BankManager.swift */,
 				C7694E79259C3EC00053667F /* main.swift */,
+				D2C1592F2910AF23005C15C5 /* Node.swift */,
 			);
 			path = BankManagerConsoleApp;
 			sourceTree = "<group>";
@@ -122,6 +125,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D2C159302910AF23005C15C5 /* Node.swift in Sources */,
 				C7694E7A259C3EC00053667F /* main.swift in Sources */,
 				C7D65D1B259C8190005510E0 /* BankManager.swift in Sources */,
 			);

--- a/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
+++ b/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
@@ -352,7 +352,7 @@
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = net.yagom.QueueTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = auto;
+				SDKROOT = macosx;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
 				SWIFT_EMIT_LOC_STRINGS = NO;
 				SWIFT_VERSION = 5.0;
@@ -372,7 +372,7 @@
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = net.yagom.QueueTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = auto;
+				SDKROOT = macosx;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
 				SWIFT_EMIT_LOC_STRINGS = NO;
 				SWIFT_VERSION = 5.0;

--- a/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
+++ b/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
@@ -12,6 +12,10 @@
 		D2C159302910AF23005C15C5 /* Node.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2C1592F2910AF23005C15C5 /* Node.swift */; };
 		D2C159322910B130005C15C5 /* Queue.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2C159312910B130005C15C5 /* Queue.swift */; };
 		EB413A1C2910B00800B3A432 /* LinkedList.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB413A1B2910B00800B3A432 /* LinkedList.swift */; };
+		EB413A552910BCD200B3A432 /* QueueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB413A542910BCD200B3A432 /* QueueTests.swift */; };
+		EB413A5D2910BF9D00B3A432 /* LinkedList.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB413A1B2910B00800B3A432 /* LinkedList.swift */; };
+		EB413A5E2910BFA100B3A432 /* Node.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2C1592F2910AF23005C15C5 /* Node.swift */; };
+		EB413A5F2910BFBF00B3A432 /* Queue.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2C159312910B130005C15C5 /* Queue.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -33,10 +37,19 @@
 		D2C1592F2910AF23005C15C5 /* Node.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Node.swift; sourceTree = "<group>"; };
 		D2C159312910B130005C15C5 /* Queue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Queue.swift; sourceTree = "<group>"; };
 		EB413A1B2910B00800B3A432 /* LinkedList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkedList.swift; sourceTree = "<group>"; };
+		EB413A522910BCD200B3A432 /* QueueTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = QueueTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		EB413A542910BCD200B3A432 /* QueueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QueueTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
 		C7694E73259C3EC00053667F /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		EB413A4F2910BCD200B3A432 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -50,6 +63,7 @@
 			isa = PBXGroup;
 			children = (
 				C7694E78259C3EC00053667F /* BankManagerConsoleApp */,
+				EB413A532910BCD200B3A432 /* QueueTests */,
 				C7694E77259C3EC00053667F /* Products */,
 			);
 			sourceTree = "<group>";
@@ -58,6 +72,7 @@
 			isa = PBXGroup;
 			children = (
 				C7694E76259C3EC00053667F /* BankManagerConsoleApp */,
+				EB413A522910BCD200B3A432 /* QueueTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -72,6 +87,14 @@
 				D2C159312910B130005C15C5 /* Queue.swift */,
 			);
 			path = BankManagerConsoleApp;
+			sourceTree = "<group>";
+		};
+		EB413A532910BCD200B3A432 /* QueueTests */ = {
+			isa = PBXGroup;
+			children = (
+				EB413A542910BCD200B3A432 /* QueueTests.swift */,
+			);
+			path = QueueTests;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -94,17 +117,37 @@
 			productReference = C7694E76259C3EC00053667F /* BankManagerConsoleApp */;
 			productType = "com.apple.product-type.tool";
 		};
+		EB413A512910BCD200B3A432 /* QueueTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = EB413A582910BCD200B3A432 /* Build configuration list for PBXNativeTarget "QueueTests" */;
+			buildPhases = (
+				EB413A4E2910BCD200B3A432 /* Sources */,
+				EB413A4F2910BCD200B3A432 /* Frameworks */,
+				EB413A502910BCD200B3A432 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = QueueTests;
+			productName = QueueTests;
+			productReference = EB413A522910BCD200B3A432 /* QueueTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
 		C7694E6E259C3EC00053667F /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastSwiftUpdateCheck = 1210;
+				LastSwiftUpdateCheck = 1400;
 				LastUpgradeCheck = 1210;
 				TargetAttributes = {
 					C7694E75259C3EC00053667F = {
 						CreatedOnToolsVersion = 12.1;
+					};
+					EB413A512910BCD200B3A432 = {
+						CreatedOnToolsVersion = 14.0.1;
 					};
 				};
 			};
@@ -122,9 +165,20 @@
 			projectRoot = "";
 			targets = (
 				C7694E75259C3EC00053667F /* BankManagerConsoleApp */,
+				EB413A512910BCD200B3A432 /* QueueTests */,
 			);
 		};
 /* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		EB413A502910BCD200B3A432 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		C7694E72259C3EC00053667F /* Sources */ = {
@@ -136,6 +190,17 @@
 				C7694E7A259C3EC00053667F /* main.swift in Sources */,
 				EB413A1C2910B00800B3A432 /* LinkedList.swift in Sources */,
 				C7D65D1B259C8190005510E0 /* BankManager.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		EB413A4E2910BCD200B3A432 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				EB413A5D2910BF9D00B3A432 /* LinkedList.swift in Sources */,
+				EB413A552910BCD200B3A432 /* QueueTests.swift in Sources */,
+				EB413A5E2910BFA100B3A432 /* Node.swift in Sources */,
+				EB413A5F2910BFBF00B3A432 /* Queue.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -275,6 +340,46 @@
 			};
 			name = Release;
 		};
+		EB413A562910BCD200B3A432 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				MACOSX_DEPLOYMENT_TARGET = 12.3;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = net.yagom.QueueTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = auto;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		EB413A572910BCD200B3A432 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				MACOSX_DEPLOYMENT_TARGET = 12.3;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = net.yagom.QueueTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = auto;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -292,6 +397,15 @@
 			buildConfigurations = (
 				C7694E7E259C3EC00053667F /* Debug */,
 				C7694E7F259C3EC00053667F /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		EB413A582910BCD200B3A432 /* Build configuration list for PBXNativeTarget "QueueTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				EB413A562910BCD200B3A432 /* Debug */,
+				EB413A572910BCD200B3A432 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
+++ b/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		C7694E7A259C3EC00053667F /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7694E79259C3EC00053667F /* main.swift */; };
 		C7D65D1B259C8190005510E0 /* BankManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7D65D1A259C8190005510E0 /* BankManager.swift */; };
 		D2C159302910AF23005C15C5 /* Node.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2C1592F2910AF23005C15C5 /* Node.swift */; };
+		D2C159322910B130005C15C5 /* Queue.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2C159312910B130005C15C5 /* Queue.swift */; };
 		EB413A1C2910B00800B3A432 /* LinkedList.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB413A1B2910B00800B3A432 /* LinkedList.swift */; };
 /* End PBXBuildFile section */
 
@@ -30,6 +31,7 @@
 		C7694E79259C3EC00053667F /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
 		C7D65D1A259C8190005510E0 /* BankManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = BankManager.swift; path = ../../BankManager.swift; sourceTree = "<group>"; };
 		D2C1592F2910AF23005C15C5 /* Node.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Node.swift; sourceTree = "<group>"; };
+		D2C159312910B130005C15C5 /* Queue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Queue.swift; sourceTree = "<group>"; };
 		EB413A1B2910B00800B3A432 /* LinkedList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkedList.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -67,6 +69,7 @@
 				C7694E79259C3EC00053667F /* main.swift */,
 				D2C1592F2910AF23005C15C5 /* Node.swift */,
 				EB413A1B2910B00800B3A432 /* LinkedList.swift */,
+				D2C159312910B130005C15C5 /* Queue.swift */,
 			);
 			path = BankManagerConsoleApp;
 			sourceTree = "<group>";
@@ -128,6 +131,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D2C159322910B130005C15C5 /* Queue.swift in Sources */,
 				D2C159302910AF23005C15C5 /* Node.swift in Sources */,
 				C7694E7A259C3EC00053667F /* main.swift in Sources */,
 				EB413A1C2910B00800B3A432 /* LinkedList.swift in Sources */,

--- a/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/xcshareddata/xcschemes/QueueTests.xcscheme
+++ b/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/xcshareddata/xcschemes/QueueTests.xcscheme
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1400"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "EB413A512910BCD200B3A432"
+               BuildableName = "QueueTests.xctest"
+               BlueprintName = "QueueTests"
+               ReferencedContainer = "container:BankManagerConsoleApp.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/BankManagerConsoleApp/BankManagerConsoleApp/LinkedList.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/LinkedList.swift
@@ -1,0 +1,42 @@
+//
+//  LinkedList.swift
+//  BankManagerConsoleApp
+//
+//  Created by junho, woong on 2022/11/01.
+//
+
+struct LinkedList<T> {
+    private var head: Node<T>?
+    private var tail: Node<T>?
+    var firstValue: T? {
+        return head?.data
+    }
+    var isEmpty: Bool {
+        return head == nil
+    }
+    
+    mutating func addLast(_ element: T) {
+        let newNode: Node<T> = Node(data: element)
+        guard let last = tail else {
+            head = newNode
+            tail = newNode
+            return
+        }
+        last.next = newNode
+        tail = newNode
+    }
+    
+    mutating func removeFirst() -> T? {
+        guard let first = head else {
+            return nil
+        }
+        head = first.next
+        tail = isEmpty ? nil : tail
+        return first.data
+    }
+    
+    mutating func removeAll() {
+        head = nil
+        tail = nil
+    }
+}

--- a/BankManagerConsoleApp/BankManagerConsoleApp/LinkedList.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/LinkedList.swift
@@ -8,7 +8,7 @@
 struct LinkedList<T> {
     private var head: Node<T>?
     private var tail: Node<T>?
-    var firstValue: T? {
+    var headData: T? {
         return head?.data
     }
     var isEmpty: Bool {

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Node.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Node.swift
@@ -6,7 +6,7 @@
 //
 
 final class Node<T> {
-    private (set) var data: T?
+    private(set) var data: T?
     var next: Node<T>?
     
     init(data: T?, next: Node? = nil) {

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Node.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Node.swift
@@ -5,8 +5,8 @@
 //  Created by junho, woong on 2022/11/01.
 //
 
-class Node<T> {
-    var data: T?
+final class Node<T> {
+    private (set) var data: T?
     var next: Node<T>?
     
     init(data: T?, next: Node? = nil) {

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Node.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Node.swift
@@ -1,0 +1,16 @@
+//
+//  Node.swift
+//  BankManagerConsoleApp
+//
+//  Created by junho, woong on 2022/11/01.
+//
+
+class Node<T> {
+    var data: T?
+    var next: Node<T>?
+    
+    init(data: T?, next: Node? = nil) {
+        self.data = data
+        self.next = next
+    }
+}

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Queue.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Queue.swift
@@ -1,0 +1,30 @@
+//
+//  Queue.swift
+//  BankManagerConsoleApp
+//
+//  Created by junho, woong on 2022/11/01.
+//
+
+struct Queue<T> {
+    
+    private var linkedList: LinkedList<T> = LinkedList()
+    var isEmpty: Bool {
+        return linkedList.isEmpty
+    }
+    
+    mutating func enqueue(_ element: T) {
+        linkedList.addLast(element)
+    }
+    
+    mutating func dequeue() -> T? {
+        return linkedList.removeFirst()
+    }
+
+    mutating func clear() {
+        linkedList.removeAll()
+    }
+    
+    func peek() -> T? {
+        return linkedList.firstValue
+    }
+}

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Queue.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Queue.swift
@@ -6,7 +6,6 @@
 //
 
 struct Queue<T> {
-    
     private var linkedList: LinkedList<T> = LinkedList()
     var isEmpty: Bool {
         return linkedList.isEmpty
@@ -25,6 +24,6 @@ struct Queue<T> {
     }
     
     func peek() -> T? {
-        return linkedList.firstValue
+        return linkedList.headData
     }
 }

--- a/BankManagerConsoleApp/QueueTests/QueueTests.swift
+++ b/BankManagerConsoleApp/QueueTests/QueueTests.swift
@@ -68,4 +68,34 @@ final class QueueTests: XCTestCase {
         // then
         XCTAssertTrue(result)
     }
+    
+    func test_enqueue하면_isEmpty가_false인지() {
+        // given
+        let input: Int = 3
+
+        // when
+        sut.enqueue(input)
+        let result: Bool = sut.isEmpty
+
+        // then
+        XCTAssertFalse(result)
+    }
+    
+    func test_ABC를_enqueue하고_4번_dequeue하면_nil인지() {
+        // given
+        let input: [String] = ["A", "B", "C"]
+        
+        // when
+        input.forEach { sut.enqueue($0) }
+
+        for _ in 0..<input.count {
+            sut.dequeue()
+        }
+        let result: Any? = sut.dequeue()
+        
+        // then
+        XCTAssertNil(result)
+    }
+    
+    
 }

--- a/BankManagerConsoleApp/QueueTests/QueueTests.swift
+++ b/BankManagerConsoleApp/QueueTests/QueueTests.swift
@@ -1,0 +1,71 @@
+//
+//  QueueTests.swift
+//  QueueTests
+//
+//  Created by junho lee on 2022/11/01.
+//
+
+import XCTest
+@testable import BankManagerConsoleApp
+
+final class QueueTests: XCTestCase {
+    var sut: Queue<Any>!
+    
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        sut = Queue()
+    }
+
+    override func tearDownWithError() throws {
+        try super.tearDownWithError()
+        sut = nil
+    }
+    
+    func test_3을_enqueue하고_peek하면_3을반환하는지() {
+        // given
+        let input: Int = 3
+        
+        // when
+        sut.enqueue(input)
+        let result: Int = sut.peek() as! Int
+        
+        // then
+        XCTAssertEqual(result, input)
+    }
+    
+    func test_ABC를_enqueue하고_dequeue하면_enqueue한순서대로_반환하는지() {
+        // given
+        let input: [String] = ["A", "B", "C"]
+        
+        // when
+        input.forEach { sut.enqueue($0) }
+        var result: [String] = []
+        for _ in 0..<input.count {
+            result.append(sut.dequeue() as! String)
+        }
+        
+        // then
+        XCTAssertEqual(result, input)
+    }
+    
+    func test_빈queue에서_dequeue하면_nil을반환하는지() {
+        // when
+        let result: Any? = sut.dequeue()
+        
+        // then
+        XCTAssertNil(result)
+    }
+    
+    func test_enqueue한뒤_clear하면_isEmpty가_true인지() {
+        // given
+        let input: Int = 3
+        
+        // when
+        sut.enqueue(input)
+        sut.clear()
+        let result: Bool = sut.isEmpty
+        
+        // then
+        XCTAssertTrue(result)
+    }
+}


### PR DESCRIPTION

@lina0322
안녕하세요, 엘림! 은행 창구 매니저에서 함께하게 된 준호, 웅입니다.
STEP-1 구현하여 PR보냅니다.

## 구현내용
* Node
    - 데이터를 저장해줄 data 변수 / 다음 데이터의 주소값을 저장해줄 next 변수로 구성하였습니다.
    - 다음 Node의 주소값을 저장하기 위해 struct대신 reference type인 class로 구현하였습니다.
    - data 프로퍼티는 외부에서 접근하여 읽기만 하기 때문에 private(set) 키워드를 추가했습니다.
    - Node 클래스는 더 이상 상속하지 않기때문에 class 앞에 final 키워드를 추가했습니다.
* LinkedList
    - Node를 연결한 자료 구조형을 만들었습니다.
    - class로 구현해줄 마땅한 이유가 없어서 struct로 구현하였습니다.
    - 첫 노드를 가리키는 head와 마지막 노드를 가리키는 tail 프로퍼티를 만들었습니다.
    - head와 tail 프로퍼티에는 구현한 범위 밖에서 접근하지 못하도록 private 키워드를 추가했습니다.
    - 첫 노드의 값을 반환하는 firstValue 와 LinkedList가 비었는지 확인하는 isEmpty 연산 프로퍼티를 만들었습니다.
    - 끝에 노드를 추가하는 addLast(), 첫 번째 노드를 빼는 removeFirst(), 모든 노드를 지워주는 removeAll() 메서드를 만들었습니다.
* Queue
    - 요구사항에 따라 isEmpty, enqueue, dequeue, clear, peek을 구현하였습니다.
    - 다양한 데이터를 취급할 수 있도록 Generic 타입을 활용하였습니다.
* QueueTests
    - Queue의 기본 동작인 Enqueue, Dequeue, Clear, Peek, isEmpty을 테스트하는 케이스를 추가했습니다.

## 고민되었던 점
* Unit Test 관련 오류 해결
    - UnitTest 진행 시, sut를 정의해주면 아래 오류가 발생하였습니다.
    - 결론적으로 이 문제는 해결되었고, 문제의 원인으로는 테스트 코드와 관련된 모든 타입 파일(Node.swift, LinkedList.swift, Queue.swift)의 Target Membership을 지정해주지 않아 발생한 오류였습니다. (아래 그림 참조)
    > undefined symbol: nominal type descriptor for ...

    |수정 전|수정 후|
    |:---:|:---:|
    |![](https://i.imgur.com/xghtsQA.png)|![](https://i.imgur.com/ZbIAhiO.png)|

## 조언을 얻고 싶은 부분
* Unit Test에서 실제 앱 타깃에 있는 코드들에 접근하기 위한 키워드인 ```@testable```을 붙여서 ```@testable import ~~~```만 추가해도 이전 프로젝트들에서는 문제가 없었는 데, 이번에는 왜 직접 target membership을 지정해줘야 했는 지 궁금합니다. Console App이기 때문일까요?