### PR TITLE
은행창구 매니저 [STEP 1] zhilly, 미니

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,7 +92,7 @@ playground.xcworkspace
 # you should judge for yourself, the pros and cons are mentioned at:
 # https://guides.cocoapods.org/using/using-cocoapods.html#should-i-check-the-pods-directory-into-source-control
 #
-# Pods/
+Pods/
 
 # Carthage
 #

--- a/BankManager.swift
+++ b/BankManager.swift
@@ -1,7 +1,7 @@
 //
-//  BankManager.swift
-//  Created by yagom.
-//  Copyright © yagom academy. All rights reserved.
+//  CustomerQueueTests.swift
+//  CustomerQueueTests
 //
+//  Copyright (c) 2022 Zhilly, Minii All rights reserved.
 
 import Foundation

--- a/BankManagerConsoleApp/.swiftlint.yml
+++ b/BankManagerConsoleApp/.swiftlint.yml
@@ -1,0 +1,9 @@
+excluded:
+    - Pods
+    - ManagerQueueTests
+disabled_rules:
+    - trailing_whitespace
+line_length: 
+  warning: 100
+  error: 120
+  ignores_comments: true

--- a/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
+++ b/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
@@ -10,6 +10,9 @@
 		18A08DBC290F7C9500DEE94C /* Node.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4D3C98B290F6680005355A4 /* Node.swift */; };
 		18A08DBE290FACAD00DEE94C /* CustomerQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18A08DBD290FACAD00DEE94C /* CustomerQueue.swift */; };
 		18C2F22A290F62CB006418E3 /* CustomerQueueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18C2F229290F62CB006418E3 /* CustomerQueueTests.swift */; };
+		18EC9D4D2910B4D20084F258 /* LinkedList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18EC9D4C2910B4D20084F258 /* LinkedList.swift */; };
+		18EC9D4E2910B5790084F258 /* CustomerQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18A08DBD290FACAD00DEE94C /* CustomerQueue.swift */; };
+		18EC9D4F2910B5C60084F258 /* LinkedList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18EC9D4C2910B4D20084F258 /* LinkedList.swift */; };
 		23532D697DD3A987F9860EED /* Pods_BankManagerConsoleApp.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A5E96D3635EA11402B6E5108 /* Pods_BankManagerConsoleApp.framework */; };
 		B4D3C98C290F6680005355A4 /* Node.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4D3C98B290F6680005355A4 /* Node.swift */; };
 		C7694E7A259C3EC00053667F /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7694E79259C3EC00053667F /* main.swift */; };
@@ -32,6 +35,7 @@
 		18A08DBD290FACAD00DEE94C /* CustomerQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomerQueue.swift; sourceTree = "<group>"; };
 		18C2F227290F62CB006418E3 /* ManagerQueueTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ManagerQueueTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		18C2F229290F62CB006418E3 /* CustomerQueueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomerQueueTests.swift; sourceTree = "<group>"; };
+		18EC9D4C2910B4D20084F258 /* LinkedList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkedList.swift; sourceTree = "<group>"; };
 		A5E96D3635EA11402B6E5108 /* Pods_BankManagerConsoleApp.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_BankManagerConsoleApp.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		B4D3C98B290F6680005355A4 /* Node.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Node.swift; sourceTree = "<group>"; };
 		B773D3558629ED8B19BFE330 /* Pods-BankManagerConsoleApp.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BankManagerConsoleApp.release.xcconfig"; path = "Target Support Files/Pods-BankManagerConsoleApp/Pods-BankManagerConsoleApp.release.xcconfig"; sourceTree = "<group>"; };
@@ -95,6 +99,7 @@
 				C7694E79259C3EC00053667F /* main.swift */,
 				B4D3C98B290F6680005355A4 /* Node.swift */,
 				18A08DBD290FACAD00DEE94C /* CustomerQueue.swift */,
+				18EC9D4C2910B4D20084F258 /* LinkedList.swift */,
 			);
 			path = BankManagerConsoleApp;
 			sourceTree = "<group>";
@@ -140,8 +145,8 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = C7694E7D259C3EC00053667F /* Build configuration list for PBXNativeTarget "BankManagerConsoleApp" */;
 			buildPhases = (
-				B49267DF2910AA5F00C47AB7 /* ShellScript */,
 				F1EAB3E6FD31E090BF55154C /* [CP] Check Pods Manifest.lock */,
+				B49267DF2910AA5F00C47AB7 /* ShellScript */,
 				C7694E72259C3EC00053667F /* Sources */,
 				C7694E73259C3EC00053667F /* Frameworks */,
 				C7694E74259C3EC00053667F /* CopyFiles */,
@@ -251,6 +256,8 @@
 			files = (
 				18A08DBC290F7C9500DEE94C /* Node.swift in Sources */,
 				18C2F22A290F62CB006418E3 /* CustomerQueueTests.swift in Sources */,
+				18EC9D4F2910B5C60084F258 /* LinkedList.swift in Sources */,
+				18EC9D4E2910B5790084F258 /* CustomerQueue.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -260,6 +267,7 @@
 			files = (
 				B4D3C98C290F6680005355A4 /* Node.swift in Sources */,
 				18A08DBE290FACAD00DEE94C /* CustomerQueue.swift in Sources */,
+				18EC9D4D2910B4D20084F258 /* LinkedList.swift in Sources */,
 				C7694E7A259C3EC00053667F /* main.swift in Sources */,
 				C7D65D1B259C8190005510E0 /* BankManager.swift in Sources */,
 			);

--- a/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
+++ b/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
@@ -7,6 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		18A08DBA290F7C7900DEE94C /* CustomerQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18A08DB9290F7C7900DEE94C /* CustomerQueue.swift */; };
+		18A08DBB290F7C9200DEE94C /* CustomerQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18A08DB9290F7C7900DEE94C /* CustomerQueue.swift */; };
+		18A08DBC290F7C9500DEE94C /* Node.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4D3C98B290F6680005355A4 /* Node.swift */; };
 		18C2F22A290F62CB006418E3 /* CustomerQueueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18C2F229290F62CB006418E3 /* CustomerQueueTests.swift */; };
 		B4D3C98C290F6680005355A4 /* Node.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4D3C98B290F6680005355A4 /* Node.swift */; };
 		C7694E7A259C3EC00053667F /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7694E79259C3EC00053667F /* main.swift */; };
@@ -26,6 +29,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		18A08DB9290F7C7900DEE94C /* CustomerQueue.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = CustomerQueue.swift; path = ../../../../../CustomerQueue.swift; sourceTree = "<group>"; };
 		18C2F227290F62CB006418E3 /* ManagerQueueTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ManagerQueueTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		18C2F229290F62CB006418E3 /* CustomerQueueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomerQueueTests.swift; sourceTree = "<group>"; };
 		B4D3C98B290F6680005355A4 /* Node.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Node.swift; sourceTree = "<group>"; };
@@ -81,6 +85,7 @@
 		C7694E78259C3EC00053667F /* BankManagerConsoleApp */ = {
 			isa = PBXGroup;
 			children = (
+				18A08DB9290F7C7900DEE94C /* CustomerQueue.swift */,
 				C7D65D1A259C8190005510E0 /* BankManager.swift */,
 				C7694E79259C3EC00053667F /* main.swift */,
 				B4D3C98B290F6680005355A4 /* Node.swift */,
@@ -176,7 +181,9 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				18A08DBC290F7C9500DEE94C /* Node.swift in Sources */,
 				18C2F22A290F62CB006418E3 /* CustomerQueueTests.swift in Sources */,
+				18A08DBB290F7C9200DEE94C /* CustomerQueue.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -185,6 +192,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				B4D3C98C290F6680005355A4 /* Node.swift in Sources */,
+				18A08DBA290F7C7900DEE94C /* CustomerQueue.swift in Sources */,
 				C7694E7A259C3EC00053667F /* main.swift in Sources */,
 				C7D65D1B259C8190005510E0 /* BankManager.swift in Sources */,
 			);

--- a/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
+++ b/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
@@ -7,9 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		18A08DBA290F7C7900DEE94C /* CustomerQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18A08DB9290F7C7900DEE94C /* CustomerQueue.swift */; };
-		18A08DBB290F7C9200DEE94C /* CustomerQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18A08DB9290F7C7900DEE94C /* CustomerQueue.swift */; };
 		18A08DBC290F7C9500DEE94C /* Node.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4D3C98B290F6680005355A4 /* Node.swift */; };
+		18A08DBE290FACAD00DEE94C /* CustomerQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18A08DBD290FACAD00DEE94C /* CustomerQueue.swift */; };
 		18C2F22A290F62CB006418E3 /* CustomerQueueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18C2F229290F62CB006418E3 /* CustomerQueueTests.swift */; };
 		B4D3C98C290F6680005355A4 /* Node.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4D3C98B290F6680005355A4 /* Node.swift */; };
 		C7694E7A259C3EC00053667F /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7694E79259C3EC00053667F /* main.swift */; };
@@ -29,7 +28,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		18A08DB9290F7C7900DEE94C /* CustomerQueue.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = CustomerQueue.swift; path = ../../../../../CustomerQueue.swift; sourceTree = "<group>"; };
+		18A08DBD290FACAD00DEE94C /* CustomerQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomerQueue.swift; sourceTree = "<group>"; };
 		18C2F227290F62CB006418E3 /* ManagerQueueTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ManagerQueueTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		18C2F229290F62CB006418E3 /* CustomerQueueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomerQueueTests.swift; sourceTree = "<group>"; };
 		B4D3C98B290F6680005355A4 /* Node.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Node.swift; sourceTree = "<group>"; };
@@ -85,10 +84,10 @@
 		C7694E78259C3EC00053667F /* BankManagerConsoleApp */ = {
 			isa = PBXGroup;
 			children = (
-				18A08DB9290F7C7900DEE94C /* CustomerQueue.swift */,
 				C7D65D1A259C8190005510E0 /* BankManager.swift */,
 				C7694E79259C3EC00053667F /* main.swift */,
 				B4D3C98B290F6680005355A4 /* Node.swift */,
+				18A08DBD290FACAD00DEE94C /* CustomerQueue.swift */,
 			);
 			path = BankManagerConsoleApp;
 			sourceTree = "<group>";
@@ -183,7 +182,6 @@
 			files = (
 				18A08DBC290F7C9500DEE94C /* Node.swift in Sources */,
 				18C2F22A290F62CB006418E3 /* CustomerQueueTests.swift in Sources */,
-				18A08DBB290F7C9200DEE94C /* CustomerQueue.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -192,7 +190,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				B4D3C98C290F6680005355A4 /* Node.swift in Sources */,
-				18A08DBA290F7C7900DEE94C /* CustomerQueue.swift in Sources */,
+				18A08DBE290FACAD00DEE94C /* CustomerQueue.swift in Sources */,
 				C7694E7A259C3EC00053667F /* main.swift in Sources */,
 				C7D65D1B259C8190005510E0 /* BankManager.swift in Sources */,
 			);

--- a/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
+++ b/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
@@ -3,13 +3,14 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 50;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
 		18A08DBC290F7C9500DEE94C /* Node.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4D3C98B290F6680005355A4 /* Node.swift */; };
 		18A08DBE290FACAD00DEE94C /* CustomerQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18A08DBD290FACAD00DEE94C /* CustomerQueue.swift */; };
 		18C2F22A290F62CB006418E3 /* CustomerQueueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18C2F229290F62CB006418E3 /* CustomerQueueTests.swift */; };
+		23532D697DD3A987F9860EED /* Pods_BankManagerConsoleApp.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A5E96D3635EA11402B6E5108 /* Pods_BankManagerConsoleApp.framework */; };
 		B4D3C98C290F6680005355A4 /* Node.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4D3C98B290F6680005355A4 /* Node.swift */; };
 		C7694E7A259C3EC00053667F /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7694E79259C3EC00053667F /* main.swift */; };
 		C7D65D1B259C8190005510E0 /* BankManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7D65D1A259C8190005510E0 /* BankManager.swift */; };
@@ -31,10 +32,13 @@
 		18A08DBD290FACAD00DEE94C /* CustomerQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomerQueue.swift; sourceTree = "<group>"; };
 		18C2F227290F62CB006418E3 /* ManagerQueueTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ManagerQueueTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		18C2F229290F62CB006418E3 /* CustomerQueueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomerQueueTests.swift; sourceTree = "<group>"; };
+		A5E96D3635EA11402B6E5108 /* Pods_BankManagerConsoleApp.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_BankManagerConsoleApp.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		B4D3C98B290F6680005355A4 /* Node.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Node.swift; sourceTree = "<group>"; };
+		B773D3558629ED8B19BFE330 /* Pods-BankManagerConsoleApp.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BankManagerConsoleApp.release.xcconfig"; path = "Target Support Files/Pods-BankManagerConsoleApp/Pods-BankManagerConsoleApp.release.xcconfig"; sourceTree = "<group>"; };
 		C7694E76259C3EC00053667F /* BankManagerConsoleApp */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = BankManagerConsoleApp; sourceTree = BUILT_PRODUCTS_DIR; };
 		C7694E79259C3EC00053667F /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
 		C7D65D1A259C8190005510E0 /* BankManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = BankManager.swift; path = ../../BankManager.swift; sourceTree = "<group>"; };
+		F5545506CB12DDDAF2D6FE55 /* Pods-BankManagerConsoleApp.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BankManagerConsoleApp.debug.xcconfig"; path = "Target Support Files/Pods-BankManagerConsoleApp/Pods-BankManagerConsoleApp.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -49,6 +53,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				23532D697DD3A987F9860EED /* Pods_BankManagerConsoleApp.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -69,6 +74,8 @@
 				C7694E78259C3EC00053667F /* BankManagerConsoleApp */,
 				18C2F228290F62CB006418E3 /* ManagerQueueTests */,
 				C7694E77259C3EC00053667F /* Products */,
+				C9C8E87DE1049E270DD56BCF /* Pods */,
+				CE7E174F50E2FACF9C9810CE /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -90,6 +97,23 @@
 				18A08DBD290FACAD00DEE94C /* CustomerQueue.swift */,
 			);
 			path = BankManagerConsoleApp;
+			sourceTree = "<group>";
+		};
+		C9C8E87DE1049E270DD56BCF /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				F5545506CB12DDDAF2D6FE55 /* Pods-BankManagerConsoleApp.debug.xcconfig */,
+				B773D3558629ED8B19BFE330 /* Pods-BankManagerConsoleApp.release.xcconfig */,
+			);
+			path = Pods;
+			sourceTree = "<group>";
+		};
+		CE7E174F50E2FACF9C9810CE /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				A5E96D3635EA11402B6E5108 /* Pods_BankManagerConsoleApp.framework */,
+			);
+			name = Frameworks;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -116,6 +140,8 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = C7694E7D259C3EC00053667F /* Build configuration list for PBXNativeTarget "BankManagerConsoleApp" */;
 			buildPhases = (
+				B49267DF2910AA5F00C47AB7 /* ShellScript */,
+				F1EAB3E6FD31E090BF55154C /* [CP] Check Pods Manifest.lock */,
 				C7694E72259C3EC00053667F /* Sources */,
 				C7694E73259C3EC00053667F /* Frameworks */,
 				C7694E74259C3EC00053667F /* CopyFiles */,
@@ -174,6 +200,49 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		B49267DF2910AA5F00C47AB7 /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "${PODS_ROOT}/SwiftLint/swiftlint\n";
+		};
+		F1EAB3E6FD31E090BF55154C /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-BankManagerConsoleApp-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		18C2F223290F62CB006418E3 /* Sources */ = {
@@ -354,6 +423,7 @@
 		};
 		C7694E7E259C3EC00053667F /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = F5545506CB12DDDAF2D6FE55 /* Pods-BankManagerConsoleApp.debug.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "-";
 				CODE_SIGN_STYLE = Automatic;
@@ -365,6 +435,7 @@
 		};
 		C7694E7F259C3EC00053667F /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = B773D3558629ED8B19BFE330 /* Pods-BankManagerConsoleApp.release.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "-";
 				CODE_SIGN_STYLE = Automatic;

--- a/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
+++ b/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		18C2F22A290F62CB006418E3 /* CustomerQueueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18C2F229290F62CB006418E3 /* CustomerQueueTests.swift */; };
+		B4D3C98C290F6680005355A4 /* Node.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4D3C98B290F6680005355A4 /* Node.swift */; };
 		C7694E7A259C3EC00053667F /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7694E79259C3EC00053667F /* main.swift */; };
 		C7D65D1B259C8190005510E0 /* BankManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7D65D1A259C8190005510E0 /* BankManager.swift */; };
 /* End PBXBuildFile section */
@@ -27,6 +28,7 @@
 /* Begin PBXFileReference section */
 		18C2F227290F62CB006418E3 /* ManagerQueueTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ManagerQueueTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		18C2F229290F62CB006418E3 /* CustomerQueueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomerQueueTests.swift; sourceTree = "<group>"; };
+		B4D3C98B290F6680005355A4 /* Node.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Node.swift; sourceTree = "<group>"; };
 		C7694E76259C3EC00053667F /* BankManagerConsoleApp */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = BankManagerConsoleApp; sourceTree = BUILT_PRODUCTS_DIR; };
 		C7694E79259C3EC00053667F /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
 		C7D65D1A259C8190005510E0 /* BankManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = BankManager.swift; path = ../../BankManager.swift; sourceTree = "<group>"; };
@@ -81,6 +83,7 @@
 			children = (
 				C7D65D1A259C8190005510E0 /* BankManager.swift */,
 				C7694E79259C3EC00053667F /* main.swift */,
+				B4D3C98B290F6680005355A4 /* Node.swift */,
 			);
 			path = BankManagerConsoleApp;
 			sourceTree = "<group>";
@@ -129,7 +132,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 1400;
-				LastUpgradeCheck = 1210;
+				LastUpgradeCheck = 1400;
 				TargetAttributes = {
 					18C2F226290F62CB006418E3 = {
 						CreatedOnToolsVersion = 14.0;
@@ -181,6 +184,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				B4D3C98C290F6680005355A4 /* Node.swift in Sources */,
 				C7694E7A259C3EC00053667F /* main.swift in Sources */,
 				C7D65D1B259C8190005510E0 /* BankManager.swift in Sources */,
 			);
@@ -195,6 +199,7 @@
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
+				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = BH7V49ZZ2G;
 				GENERATE_INFOPLIST_FILE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 12.3;
@@ -212,6 +217,7 @@
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
+				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = BH7V49ZZ2G;
 				GENERATE_INFOPLIST_FILE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 12.3;
@@ -257,6 +263,7 @@
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
+				DEAD_CODE_STRIPPING = YES;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
@@ -318,6 +325,7 @@
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
+				DEAD_CODE_STRIPPING = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
@@ -341,7 +349,9 @@
 		C7694E7E259C3EC00053667F /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CODE_SIGN_IDENTITY = "-";
 				CODE_SIGN_STYLE = Automatic;
+				DEAD_CODE_STRIPPING = YES;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 			};
@@ -350,7 +360,9 @@
 		C7694E7F259C3EC00053667F /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CODE_SIGN_IDENTITY = "-";
 				CODE_SIGN_STYLE = Automatic;
+				DEAD_CODE_STRIPPING = YES;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 			};

--- a/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
+++ b/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		18C2F22A290F62CB006418E3 /* CustomerQueueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18C2F229290F62CB006418E3 /* CustomerQueueTests.swift */; };
 		C7694E7A259C3EC00053667F /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7694E79259C3EC00053667F /* main.swift */; };
 		C7D65D1B259C8190005510E0 /* BankManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7D65D1A259C8190005510E0 /* BankManager.swift */; };
 /* End PBXBuildFile section */
@@ -24,12 +25,21 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		18C2F227290F62CB006418E3 /* ManagerQueueTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ManagerQueueTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		18C2F229290F62CB006418E3 /* CustomerQueueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomerQueueTests.swift; sourceTree = "<group>"; };
 		C7694E76259C3EC00053667F /* BankManagerConsoleApp */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = BankManagerConsoleApp; sourceTree = BUILT_PRODUCTS_DIR; };
 		C7694E79259C3EC00053667F /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
 		C7D65D1A259C8190005510E0 /* BankManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = BankManager.swift; path = ../../BankManager.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		18C2F224290F62CB006418E3 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		C7694E73259C3EC00053667F /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -40,10 +50,19 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		18C2F228290F62CB006418E3 /* ManagerQueueTests */ = {
+			isa = PBXGroup;
+			children = (
+				18C2F229290F62CB006418E3 /* CustomerQueueTests.swift */,
+			);
+			path = ManagerQueueTests;
+			sourceTree = "<group>";
+		};
 		C7694E6D259C3EC00053667F = {
 			isa = PBXGroup;
 			children = (
 				C7694E78259C3EC00053667F /* BankManagerConsoleApp */,
+				18C2F228290F62CB006418E3 /* ManagerQueueTests */,
 				C7694E77259C3EC00053667F /* Products */,
 			);
 			sourceTree = "<group>";
@@ -52,6 +71,7 @@
 			isa = PBXGroup;
 			children = (
 				C7694E76259C3EC00053667F /* BankManagerConsoleApp */,
+				18C2F227290F62CB006418E3 /* ManagerQueueTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -68,6 +88,23 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
+		18C2F226290F62CB006418E3 /* ManagerQueueTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 18C2F22D290F62CB006418E3 /* Build configuration list for PBXNativeTarget "ManagerQueueTests" */;
+			buildPhases = (
+				18C2F223290F62CB006418E3 /* Sources */,
+				18C2F224290F62CB006418E3 /* Frameworks */,
+				18C2F225290F62CB006418E3 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = ManagerQueueTests;
+			productName = ManagerQueueTests;
+			productReference = 18C2F227290F62CB006418E3 /* ManagerQueueTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 		C7694E75259C3EC00053667F /* BankManagerConsoleApp */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = C7694E7D259C3EC00053667F /* Build configuration list for PBXNativeTarget "BankManagerConsoleApp" */;
@@ -91,9 +128,12 @@
 		C7694E6E259C3EC00053667F /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastSwiftUpdateCheck = 1210;
+				LastSwiftUpdateCheck = 1400;
 				LastUpgradeCheck = 1210;
 				TargetAttributes = {
+					18C2F226290F62CB006418E3 = {
+						CreatedOnToolsVersion = 14.0;
+					};
 					C7694E75259C3EC00053667F = {
 						CreatedOnToolsVersion = 12.1;
 					};
@@ -113,11 +153,30 @@
 			projectRoot = "";
 			targets = (
 				C7694E75259C3EC00053667F /* BankManagerConsoleApp */,
+				18C2F226290F62CB006418E3 /* ManagerQueueTests */,
 			);
 		};
 /* End PBXProject section */
 
+/* Begin PBXResourcesBuildPhase section */
+		18C2F225290F62CB006418E3 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
 /* Begin PBXSourcesBuildPhase section */
+		18C2F223290F62CB006418E3 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				18C2F22A290F62CB006418E3 /* CustomerQueueTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		C7694E72259C3EC00053667F /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -130,6 +189,40 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin XCBuildConfiguration section */
+		18C2F22B290F62CB006418E3 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = BH7V49ZZ2G;
+				GENERATE_INFOPLIST_FILE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 12.3;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.QueueTypeTest.ManagerQueueTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		18C2F22C290F62CB006418E3 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = BH7V49ZZ2G;
+				GENERATE_INFOPLIST_FILE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 12.3;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.QueueTypeTest.ManagerQueueTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
 		C7694E7B259C3EC00053667F /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -266,6 +359,15 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		18C2F22D290F62CB006418E3 /* Build configuration list for PBXNativeTarget "ManagerQueueTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				18C2F22B290F62CB006418E3 /* Debug */,
+				18C2F22C290F62CB006418E3 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		C7694E71259C3EC00053667F /* Build configuration list for PBXProject "BankManagerConsoleApp" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/xcshareddata/xcschemes/BankManagerConsoleApp.xcscheme
+++ b/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/xcshareddata/xcschemes/BankManagerConsoleApp.xcscheme
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1400"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "C7694E75259C3EC00053667F"
+               BuildableName = "BankManagerConsoleApp"
+               BlueprintName = "BankManagerConsoleApp"
+               ReferencedContainer = "container:BankManagerConsoleApp.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "18C2F226290F62CB006418E3"
+               BuildableName = "ManagerQueueTests.xctest"
+               BlueprintName = "ManagerQueueTests"
+               ReferencedContainer = "container:BankManagerConsoleApp.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES"
+      viewDebuggingEnabled = "No">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "C7694E75259C3EC00053667F"
+            BuildableName = "BankManagerConsoleApp"
+            BlueprintName = "BankManagerConsoleApp"
+            ReferencedContainer = "container:BankManagerConsoleApp.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "C7694E75259C3EC00053667F"
+            BuildableName = "BankManagerConsoleApp"
+            BlueprintName = "BankManagerConsoleApp"
+            ReferencedContainer = "container:BankManagerConsoleApp.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/xcshareddata/xcschemes/ManagerQueueTests.xcscheme
+++ b/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/xcshareddata/xcschemes/ManagerQueueTests.xcscheme
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1400"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "18C2F226290F62CB006418E3"
+               BuildableName = "ManagerQueueTests.xctest"
+               BlueprintName = "ManagerQueueTests"
+               ReferencedContainer = "container:BankManagerConsoleApp.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/BankManagerConsoleApp/BankManagerConsoleApp.xcworkspace/contents.xcworkspacedata
+++ b/BankManagerConsoleApp/BankManagerConsoleApp.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "group:BankManagerConsoleApp.xcodeproj">
+   </FileRef>
+   <FileRef
+      location = "group:Pods/Pods.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/BankManagerConsoleApp/BankManagerConsoleApp.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/BankManagerConsoleApp/BankManagerConsoleApp.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/BankManagerConsoleApp/BankManagerConsoleApp/CustomerQueue.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/CustomerQueue.swift
@@ -1,0 +1,33 @@
+//
+//  CustomerQueue.swift
+//  BankManagerConsoleApp
+//
+//  Copyright (c) 2022 Minii All rights reserved.
+
+import Foundation
+
+struct CustomerQueue<T> {
+    var head: Node<T>?
+    var tail: Node<T>?
+    
+    var isEmpty: Bool {
+        return false
+    }
+    
+    func enqueue(value: T) {
+        
+    }
+    
+    func dequeue() -> T? {
+        return nil
+    }
+    
+    func clear() {
+        
+    }
+    
+    func peek() -> T? {
+        return nil
+    }
+}
+

--- a/BankManagerConsoleApp/BankManagerConsoleApp/CustomerQueue.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/CustomerQueue.swift
@@ -30,4 +30,3 @@ struct CustomerQueue<T> {
         return nil
     }
 }
-

--- a/BankManagerConsoleApp/BankManagerConsoleApp/CustomerQueue.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/CustomerQueue.swift
@@ -7,26 +7,25 @@
 import Foundation
 
 struct CustomerQueue<T> {
-    var head: Node<T>?
-    var tail: Node<T>?
+    private var linkedList = LinkedList<T>()
     
     var isEmpty: Bool {
-        return false
+        return linkedList.isEmpty
     }
     
-    func enqueue(value: T) {
-        
+    mutating func enqueue(value: T) {
+        linkedList.append(data: value)
     }
     
-    func dequeue() -> T? {
-        return nil
+    mutating func dequeue() -> T? {
+        return linkedList.removeFirst()
     }
     
-    func clear() {
-        
+    mutating func clear() {
+        linkedList.removeAll()
     }
     
     func peek() -> T? {
-        return nil
+        return linkedList.first()
     }
 }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/LinkedList.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/LinkedList.swift
@@ -1,0 +1,50 @@
+//
+//  LinkedList.swift
+//  BankManagerConsoleApp
+//
+//  Copyright (c) 2022 Minii All rights reserved.
+
+struct LinkedList<T> {
+    private var head: Node<T>?
+    private var tail: Node<T>?
+    
+    var isEmpty: Bool {
+        return head == nil
+    }
+    
+    mutating func append(data: T) {
+        let newNode = Node(data: data)
+        
+        if isEmpty {
+            head = newNode
+        } else {
+            tail?.next = newNode
+        }
+        
+        tail = newNode
+    }
+    
+    mutating func removeFirst() -> T? {
+        if isEmpty {
+            return nil
+        }
+        
+        if head == tail {
+            tail = nil
+        }
+        
+        let data = head?.data
+        head = head?.next
+        
+        return data
+    }
+    
+    func first() -> T? {
+        return head?.data
+    }
+    
+    mutating func removeAll() {
+        head = nil
+        tail = nil
+    }
+}

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Node.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Node.swift
@@ -4,9 +4,13 @@
 //
 //  Copyright (c) 2022 Zhilly, Minii All rights reserved.
 
-class Node<T> {
+class Node<T>: Equatable {
     let data: T
     var next: Node?
+    
+    static func == (lhs: Node<T>, rhs: Node<T>) -> Bool {
+        return lhs === rhs
+    }
     
     init(data: T) {
         self.data = data

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Node.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Node.swift
@@ -1,0 +1,14 @@
+//
+//  CustomerQueueTests.swift
+//  CustomerQueueTests
+//
+//  Copyright (c) 2022 Zhilly, Minii All rights reserved.
+
+class Node<T> {
+    let data: T
+    var next: Node?
+    
+    init(data: T) {
+        self.data = data
+    }
+}

--- a/BankManagerConsoleApp/BankManagerConsoleApp/main.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/main.swift
@@ -1,7 +1,7 @@
 //
-//  BankManagerConsoleApp - main.swift
-//  Created by yagom. 
-//  Copyright © yagom academy. All rights reserved.
-// 
+//  CustomerQueueTests.swift
+//  CustomerQueueTests
+//
+//  Copyright (c) 2022 Zhilly, Minii All rights reserved.
 
 import Foundation

--- a/BankManagerConsoleApp/ManagerQueueTests/CustomerQueueTests.swift
+++ b/BankManagerConsoleApp/ManagerQueueTests/CustomerQueueTests.swift
@@ -1,0 +1,14 @@
+//
+//  CustomerQueueTests.swift
+//  CustomerQueueTests
+//
+//  Copyright (c) 2022 Zhilly, Minii All rights reserved.
+        
+
+import XCTest
+
+final class CustomerQueueTests: XCTestCase {
+    override func setUpWithError() throws { }
+
+    override func tearDownWithError() throws { }
+}

--- a/BankManagerConsoleApp/ManagerQueueTests/CustomerQueueTests.swift
+++ b/BankManagerConsoleApp/ManagerQueueTests/CustomerQueueTests.swift
@@ -8,7 +8,74 @@
 import XCTest
 
 final class CustomerQueueTests: XCTestCase {
-    override func setUpWithError() throws { }
-
-    override func tearDownWithError() throws { }
+    var sut: CustomerQueue<Int>!
+    
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        
+        sut = CustomerQueue()
+    }
+    
+    override func tearDownWithError() throws {
+        try super.tearDownWithError()
+        
+        sut = nil
+    }
+    
+    func test_값_100을_Enqueue한후_Dequeue를_한값이_100과_동일한가() {
+        // given
+        let inputValue = 100
+        
+        // when
+        sut.enqueue(value: inputValue)
+        
+        // then
+        let result = sut.dequeue()
+        XCTAssertEqual(result, inputValue)
+    }
+    
+    func test_빈큐의_isEmpty의_값이_true인가() {
+        // given
+        
+        // when
+        let result = sut.isEmpty
+        
+        // then
+        XCTAssertTrue(result)
+    }
+    
+    func test_큐에_값_100을_Enqueue한후_isEmpty의_값이_false인가() {
+        // given
+        let inputValue = 100
+        
+        // when
+        sut.enqueue(value: inputValue)
+        let result = sut.isEmpty
+        
+        // then
+        XCTAssertFalse(result)
+        
+    }
+    
+    func test_값_100_200_300을_Enqueue한후_peek을_한결과와_head의_Data가_동일한가() {
+        // given
+        let inputValues = [100, 200, 300]
+        
+        // when
+        inputValues.forEach { sut.enqueue(value: $0) }
+        let result = sut.peek()
+        
+        // then
+        XCTAssertEqual(result, 100)
+    }
+    
+    func test_head가_없는_경우_peek의_결과가_nil과_동일한가() {
+        // given
+        
+        // when
+        let result = sut.peek()
+        
+        // then
+        XCTAssertNil(result)
+    }
 }

--- a/BankManagerConsoleApp/Podfile
+++ b/BankManagerConsoleApp/Podfile
@@ -1,0 +1,10 @@
+# Uncomment the next line to define a global platform for your project
+# platform :ios, '9.0'
+
+target 'BankManagerConsoleApp' do
+  # Comment the next line if you don't want to use dynamic frameworks
+  use_frameworks!
+  pod 'SwiftLint' , '0.49'
+  # Pods for BankManagerConsoleApp
+
+end

--- a/BankManagerConsoleApp/Podfile.lock
+++ b/BankManagerConsoleApp/Podfile.lock
@@ -1,0 +1,16 @@
+PODS:
+  - SwiftLint (0.49.0)
+
+DEPENDENCIES:
+  - SwiftLint (= 0.49)
+
+SPEC REPOS:
+  trunk:
+    - SwiftLint
+
+SPEC CHECKSUMS:
+  SwiftLint: 414d099c0f305c6c73e56139efb468666e535ece
+
+PODFILE CHECKSUM: 54b311068a0994312b4f8f13456006d7954b6be8
+
+COCOAPODS: 1.11.3


### PR DESCRIPTION
안녕하세요 Tony(@Monsteel) 🙌🙌🙌🙌
이번 프로젝트 같이 하게 된 zhilly랑 미니입니다.
Step1 구현 완료되어서 PR 발송합니다.

### 고민했던 점
> `Queue 타입 구현을 위한 Linked-list 타입을 직접 구현합니다.`의 의미

지난번 큐를 구현하는 과제에서는 Linked-list를 구현하는 방식을 활용하여서 큐를 구현하였습니다. 하지만 `Queue 타입 구현을 위한 Linked-list` 라는 구문을 보고 Queue를 구현하기 위한 새로운 타입을 구현하라는 의미인지에 대해서 고민하게 되었습니다. 이에 대해서 추상적인 자료구조를 구현하기 쉽고, 재사용성을 높일 수 있는 Linked-list 타입을 구현하였습니다. 또한, Linked-list 타입을 구현함으로써 재사용성을 높이는 것과 다른 코더가 보았을 때 이해하기 쉬운 코드 중 어떤 것을 활용해야 더 적절한 것인가에 대해서 고민했습니다.
 
> LinkedList는 `struct` vs `class`

LinkedList 타입을 정의하기 위해서 어떤 사용자 정의 타입을 활용하는 가에 대해서 고민하게 되었습니다. 저희가 사용하는 Node 타입은 ARC를 이용해서 관리 해줘야 한다고 생각했습니다. 하지만, LinkedList는 큐 타입 내부에서 선언되어서 활용되는 변수이기 때문에 ARC로 관리되지도 않고, 추가적인 상속을 구현하지 않을 것이라고 생각하였습니다. 그래서 애플에서 기본적으로 struct를 사용하라고 권장하기 때문에 우선적으로 struct로 구현하였습니다.

> `SwiftLint` 라이브러리를 SPM으로 관리할지, CocoaPods으로 관리할지

SPM이 first-party이기 때문에 쉽게 관리할 수 있다고 생각하였습니다. 하지만, CocoaPods 이 제일 기본적인 방법이라고도 생각했고, 라이브러리도 제일 많기 때문에 이번에 프로젝트에 `SwiftLint`를 추가할 때에는 CocoaPods을 이용해보았습니다.

### 조언을 얻고 싶은 부분
> 현업에서 컨벤션을 조율하는 방법
- 현업에서는 컨벤션을 어떻게 조율하나요?
- 컨벤션을 조율하기 위해서 `SwiftLint`와 같은 외부 라이브러리를 적극 활용하나요?
- 만약 활용한다면, 내부에 구현되어 있는 규칙들을 활용하게 되나요? 아니면, 직접 규칙을 구현하여서 활용하게 되나요?

> 만약 여러개의 라이브러리를 사용할 때 어떤 라이브러리는 CocoaPods만 지원하고 다른 라이브러리는 SPM만 지원한다고 했을 때, 하나의 프로젝트에서도 CocoaPods과 SPM을 같이 사용하기도 하나요??