### PR TITLE
은행창구 매니저 [STEP 1] 애종, stone

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,7 +92,7 @@ playground.xcworkspace
 # you should judge for yourself, the pros and cons are mentioned at:
 # https://guides.cocoapods.org/using/using-cocoapods.html#should-i-check-the-pods-directory-into-source-control
 #
-# Pods/
+Pods/
 
 # Carthage
 #

--- a/BankManagerConsoleApp/.swiftlint.yml
+++ b/BankManagerConsoleApp/.swiftlint.yml
@@ -1,0 +1,3 @@
+excluded:
+  - Pods
+

--- a/BankManagerConsoleApp/.swiftlint.yml
+++ b/BankManagerConsoleApp/.swiftlint.yml
@@ -1,3 +1,6 @@
+disabled_rules:
+- trailing_whitespace
+
 excluded:
   - Pods
 

--- a/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
+++ b/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		5462C1BE2910B6E70011E035 /* LinkedList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5462C1BD2910B6E70011E035 /* LinkedList.swift */; };
+		5462C1C02910B6FE0011E035 /* Queue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5462C1BF2910B6FE0011E035 /* Queue.swift */; };
 		575692E72910B538009DF06D /* Node.swift in Sources */ = {isa = PBXBuildFile; fileRef = 575692E62910B538009DF06D /* Node.swift */; };
 		C7694E7A259C3EC00053667F /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7694E79259C3EC00053667F /* main.swift */; };
 		C7D65D1B259C8190005510E0 /* BankManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7D65D1A259C8190005510E0 /* BankManager.swift */; };
@@ -28,6 +30,8 @@
 /* Begin PBXFileReference section */
 		09090D565C49A2739F7BAF68 /* Pods_BankManagerConsoleApp.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_BankManagerConsoleApp.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		1E3B7322EADF6245F6300C31 /* Pods-BankManagerConsoleApp.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BankManagerConsoleApp.debug.xcconfig"; path = "Target Support Files/Pods-BankManagerConsoleApp/Pods-BankManagerConsoleApp.debug.xcconfig"; sourceTree = "<group>"; };
+		5462C1BD2910B6E70011E035 /* LinkedList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkedList.swift; sourceTree = "<group>"; };
+		5462C1BF2910B6FE0011E035 /* Queue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Queue.swift; sourceTree = "<group>"; };
 		575692E52910B111009DF06D /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
 		575692E62910B538009DF06D /* Node.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Node.swift; sourceTree = "<group>"; };
 		BEC075595EA0E05CE26D017B /* Pods-BankManagerConsoleApp.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BankManagerConsoleApp.release.xcconfig"; path = "Target Support Files/Pods-BankManagerConsoleApp/Pods-BankManagerConsoleApp.release.xcconfig"; sourceTree = "<group>"; };
@@ -81,6 +85,8 @@
 				C7D65D1A259C8190005510E0 /* BankManager.swift */,
 				C7694E79259C3EC00053667F /* main.swift */,
 				575692E62910B538009DF06D /* Node.swift */,
+				5462C1BD2910B6E70011E035 /* LinkedList.swift */,
+				5462C1BF2910B6FE0011E035 /* Queue.swift */,
 			);
 			path = BankManagerConsoleApp;
 			sourceTree = "<group>";
@@ -213,8 +219,10 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				5462C1C02910B6FE0011E035 /* Queue.swift in Sources */,
 				575692E72910B538009DF06D /* Node.swift in Sources */,
 				C7694E7A259C3EC00053667F /* main.swift in Sources */,
+				5462C1BE2910B6E70011E035 /* LinkedList.swift in Sources */,
 				C7D65D1B259C8190005510E0 /* BankManager.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
+++ b/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		575692E72910B538009DF06D /* Node.swift in Sources */ = {isa = PBXBuildFile; fileRef = 575692E62910B538009DF06D /* Node.swift */; };
 		C7694E7A259C3EC00053667F /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7694E79259C3EC00053667F /* main.swift */; };
 		C7D65D1B259C8190005510E0 /* BankManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7D65D1A259C8190005510E0 /* BankManager.swift */; };
 		CCCADA0316455AFE653D03F4 /* Pods_BankManagerConsoleApp.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 09090D565C49A2739F7BAF68 /* Pods_BankManagerConsoleApp.framework */; };
@@ -27,6 +28,8 @@
 /* Begin PBXFileReference section */
 		09090D565C49A2739F7BAF68 /* Pods_BankManagerConsoleApp.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_BankManagerConsoleApp.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		1E3B7322EADF6245F6300C31 /* Pods-BankManagerConsoleApp.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BankManagerConsoleApp.debug.xcconfig"; path = "Target Support Files/Pods-BankManagerConsoleApp/Pods-BankManagerConsoleApp.debug.xcconfig"; sourceTree = "<group>"; };
+		575692E52910B111009DF06D /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
+		575692E62910B538009DF06D /* Node.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Node.swift; sourceTree = "<group>"; };
 		BEC075595EA0E05CE26D017B /* Pods-BankManagerConsoleApp.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BankManagerConsoleApp.release.xcconfig"; path = "Target Support Files/Pods-BankManagerConsoleApp/Pods-BankManagerConsoleApp.release.xcconfig"; sourceTree = "<group>"; };
 		C7694E76259C3EC00053667F /* BankManagerConsoleApp */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = BankManagerConsoleApp; sourceTree = BUILT_PRODUCTS_DIR; };
 		C7694E79259C3EC00053667F /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
@@ -56,6 +59,7 @@
 		C7694E6D259C3EC00053667F = {
 			isa = PBXGroup;
 			children = (
+				575692E52910B111009DF06D /* .swiftlint.yml */,
 				C7694E78259C3EC00053667F /* BankManagerConsoleApp */,
 				C7694E77259C3EC00053667F /* Products */,
 				C841639CED9BEB6113E3AD0E /* Pods */,
@@ -76,6 +80,7 @@
 			children = (
 				C7D65D1A259C8190005510E0 /* BankManager.swift */,
 				C7694E79259C3EC00053667F /* main.swift */,
+				575692E62910B538009DF06D /* Node.swift */,
 			);
 			path = BankManagerConsoleApp;
 			sourceTree = "<group>";
@@ -101,6 +106,7 @@
 				C7694E73259C3EC00053667F /* Frameworks */,
 				C7694E74259C3EC00053667F /* CopyFiles */,
 				5462C1BC2910AB640011E035 /* ShellScript */,
+				575692E42910AF2F009DF06D /* ShellScript */,
 			);
 			buildRules = (
 			);
@@ -183,6 +189,23 @@
 			shellPath = /bin/sh;
 			shellScript = "\"${PODS_ROOT}/SwiftLint/swiftlint\" \n";
 		};
+		575692E42910AF2F009DF06D /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "# Type a script or drag a script file from your workspace to insert its path.\n";
+		};
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
@@ -190,6 +213,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				575692E72910B538009DF06D /* Node.swift in Sources */,
 				C7694E7A259C3EC00053667F /* main.swift in Sources */,
 				C7D65D1B259C8190005510E0 /* BankManager.swift in Sources */,
 			);

--- a/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
+++ b/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		C7694E7A259C3EC00053667F /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7694E79259C3EC00053667F /* main.swift */; };
 		C7D65D1B259C8190005510E0 /* BankManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7D65D1A259C8190005510E0 /* BankManager.swift */; };
+		CCCADA0316455AFE653D03F4 /* Pods_BankManagerConsoleApp.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 09090D565C49A2739F7BAF68 /* Pods_BankManagerConsoleApp.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -24,6 +25,9 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		09090D565C49A2739F7BAF68 /* Pods_BankManagerConsoleApp.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_BankManagerConsoleApp.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		1E3B7322EADF6245F6300C31 /* Pods-BankManagerConsoleApp.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BankManagerConsoleApp.debug.xcconfig"; path = "Target Support Files/Pods-BankManagerConsoleApp/Pods-BankManagerConsoleApp.debug.xcconfig"; sourceTree = "<group>"; };
+		BEC075595EA0E05CE26D017B /* Pods-BankManagerConsoleApp.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BankManagerConsoleApp.release.xcconfig"; path = "Target Support Files/Pods-BankManagerConsoleApp/Pods-BankManagerConsoleApp.release.xcconfig"; sourceTree = "<group>"; };
 		C7694E76259C3EC00053667F /* BankManagerConsoleApp */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = BankManagerConsoleApp; sourceTree = BUILT_PRODUCTS_DIR; };
 		C7694E79259C3EC00053667F /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
 		C7D65D1A259C8190005510E0 /* BankManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = BankManager.swift; path = ../../BankManager.swift; sourceTree = "<group>"; };
@@ -34,17 +38,28 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				CCCADA0316455AFE653D03F4 /* Pods_BankManagerConsoleApp.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		76924BD570EAB34D042C6ACC /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				09090D565C49A2739F7BAF68 /* Pods_BankManagerConsoleApp.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
 		C7694E6D259C3EC00053667F = {
 			isa = PBXGroup;
 			children = (
 				C7694E78259C3EC00053667F /* BankManagerConsoleApp */,
 				C7694E77259C3EC00053667F /* Products */,
+				C841639CED9BEB6113E3AD0E /* Pods */,
+				76924BD570EAB34D042C6ACC /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -65,6 +80,15 @@
 			path = BankManagerConsoleApp;
 			sourceTree = "<group>";
 		};
+		C841639CED9BEB6113E3AD0E /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				1E3B7322EADF6245F6300C31 /* Pods-BankManagerConsoleApp.debug.xcconfig */,
+				BEC075595EA0E05CE26D017B /* Pods-BankManagerConsoleApp.release.xcconfig */,
+			);
+			path = Pods;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -72,9 +96,11 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = C7694E7D259C3EC00053667F /* Build configuration list for PBXNativeTarget "BankManagerConsoleApp" */;
 			buildPhases = (
+				53708E849A45CBCD8376C45F /* [CP] Check Pods Manifest.lock */,
 				C7694E72259C3EC00053667F /* Sources */,
 				C7694E73259C3EC00053667F /* Frameworks */,
 				C7694E74259C3EC00053667F /* CopyFiles */,
+				5462C1BC2910AB640011E035 /* ShellScript */,
 			);
 			buildRules = (
 			);
@@ -92,7 +118,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 1210;
-				LastUpgradeCheck = 1210;
+				LastUpgradeCheck = 1340;
 				TargetAttributes = {
 					C7694E75259C3EC00053667F = {
 						CreatedOnToolsVersion = 12.1;
@@ -116,6 +142,48 @@
 			);
 		};
 /* End PBXProject section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		53708E849A45CBCD8376C45F /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-BankManagerConsoleApp-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		5462C1BC2910AB640011E035 /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/SwiftLint/swiftlint\" \n";
+		};
+/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		C7694E72259C3EC00053667F /* Sources */ = {
@@ -247,7 +315,9 @@
 		};
 		C7694E7E259C3EC00053667F /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 1E3B7322EADF6245F6300C31 /* Pods-BankManagerConsoleApp.debug.xcconfig */;
 			buildSettings = {
+				CODE_SIGN_IDENTITY = "-";
 				CODE_SIGN_STYLE = Automatic;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
@@ -256,7 +326,9 @@
 		};
 		C7694E7F259C3EC00053667F /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = BEC075595EA0E05CE26D017B /* Pods-BankManagerConsoleApp.release.xcconfig */;
 			buildSettings = {
+				CODE_SIGN_IDENTITY = "-";
 				CODE_SIGN_STYLE = Automatic;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;

--- a/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
+++ b/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
@@ -9,6 +9,11 @@
 /* Begin PBXBuildFile section */
 		5462C1BE2910B6E70011E035 /* LinkedList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5462C1BD2910B6E70011E035 /* LinkedList.swift */; };
 		5462C1C02910B6FE0011E035 /* Queue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5462C1BF2910B6FE0011E035 /* Queue.swift */; };
+		54ACDD602910E187002B74E4 /* Queue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5462C1BF2910B6FE0011E035 /* Queue.swift */; };
+		54ACDD612910E189002B74E4 /* LinkedList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5462C1BD2910B6E70011E035 /* LinkedList.swift */; };
+		54ACDD622910E18B002B74E4 /* Node.swift in Sources */ = {isa = PBXBuildFile; fileRef = 575692E62910B538009DF06D /* Node.swift */; };
+		54ACDD632910E190002B74E4 /* QueueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54ACDD5B2910E183002B74E4 /* QueueTests.swift */; };
+		54ACDD642910E190002B74E4 /* QueueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54ACDD5B2910E183002B74E4 /* QueueTests.swift */; };
 		575692E72910B538009DF06D /* Node.swift in Sources */ = {isa = PBXBuildFile; fileRef = 575692E62910B538009DF06D /* Node.swift */; };
 		C7694E7A259C3EC00053667F /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7694E79259C3EC00053667F /* main.swift */; };
 		C7D65D1B259C8190005510E0 /* BankManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7D65D1A259C8190005510E0 /* BankManager.swift */; };
@@ -32,6 +37,8 @@
 		1E3B7322EADF6245F6300C31 /* Pods-BankManagerConsoleApp.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BankManagerConsoleApp.debug.xcconfig"; path = "Target Support Files/Pods-BankManagerConsoleApp/Pods-BankManagerConsoleApp.debug.xcconfig"; sourceTree = "<group>"; };
 		5462C1BD2910B6E70011E035 /* LinkedList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkedList.swift; sourceTree = "<group>"; };
 		5462C1BF2910B6FE0011E035 /* Queue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Queue.swift; sourceTree = "<group>"; };
+		54ACDD592910E183002B74E4 /* QueueTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = QueueTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		54ACDD5B2910E183002B74E4 /* QueueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QueueTests.swift; sourceTree = "<group>"; };
 		575692E52910B111009DF06D /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
 		575692E62910B538009DF06D /* Node.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Node.swift; sourceTree = "<group>"; };
 		BEC075595EA0E05CE26D017B /* Pods-BankManagerConsoleApp.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BankManagerConsoleApp.release.xcconfig"; path = "Target Support Files/Pods-BankManagerConsoleApp/Pods-BankManagerConsoleApp.release.xcconfig"; sourceTree = "<group>"; };
@@ -41,6 +48,13 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		54ACDD562910E183002B74E4 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		C7694E73259C3EC00053667F /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -52,6 +66,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		54ACDD5A2910E183002B74E4 /* QueueTests */ = {
+			isa = PBXGroup;
+			children = (
+				54ACDD5B2910E183002B74E4 /* QueueTests.swift */,
+			);
+			path = QueueTests;
+			sourceTree = "<group>";
+		};
 		76924BD570EAB34D042C6ACC /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
@@ -65,6 +87,7 @@
 			children = (
 				575692E52910B111009DF06D /* .swiftlint.yml */,
 				C7694E78259C3EC00053667F /* BankManagerConsoleApp */,
+				54ACDD5A2910E183002B74E4 /* QueueTests */,
 				C7694E77259C3EC00053667F /* Products */,
 				C841639CED9BEB6113E3AD0E /* Pods */,
 				76924BD570EAB34D042C6ACC /* Frameworks */,
@@ -75,6 +98,7 @@
 			isa = PBXGroup;
 			children = (
 				C7694E76259C3EC00053667F /* BankManagerConsoleApp */,
+				54ACDD592910E183002B74E4 /* QueueTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -103,6 +127,23 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
+		54ACDD582910E183002B74E4 /* QueueTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 54ACDD5D2910E183002B74E4 /* Build configuration list for PBXNativeTarget "QueueTests" */;
+			buildPhases = (
+				54ACDD552910E183002B74E4 /* Sources */,
+				54ACDD562910E183002B74E4 /* Frameworks */,
+				54ACDD572910E183002B74E4 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = QueueTests;
+			productName = QueueTests;
+			productReference = 54ACDD592910E183002B74E4 /* QueueTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 		C7694E75259C3EC00053667F /* BankManagerConsoleApp */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = C7694E7D259C3EC00053667F /* Build configuration list for PBXNativeTarget "BankManagerConsoleApp" */;
@@ -129,9 +170,12 @@
 		C7694E6E259C3EC00053667F /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastSwiftUpdateCheck = 1210;
+				LastSwiftUpdateCheck = 1340;
 				LastUpgradeCheck = 1340;
 				TargetAttributes = {
+					54ACDD582910E183002B74E4 = {
+						CreatedOnToolsVersion = 13.4.1;
+					};
 					C7694E75259C3EC00053667F = {
 						CreatedOnToolsVersion = 12.1;
 					};
@@ -151,9 +195,20 @@
 			projectRoot = "";
 			targets = (
 				C7694E75259C3EC00053667F /* BankManagerConsoleApp */,
+				54ACDD582910E183002B74E4 /* QueueTests */,
 			);
 		};
 /* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		54ACDD572910E183002B74E4 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
 		53708E849A45CBCD8376C45F /* [CP] Check Pods Manifest.lock */ = {
@@ -215,11 +270,23 @@
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		54ACDD552910E183002B74E4 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				54ACDD612910E189002B74E4 /* LinkedList.swift in Sources */,
+				54ACDD602910E187002B74E4 /* Queue.swift in Sources */,
+				54ACDD622910E18B002B74E4 /* Node.swift in Sources */,
+				54ACDD632910E190002B74E4 /* QueueTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		C7694E72259C3EC00053667F /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 				5462C1C02910B6FE0011E035 /* Queue.swift in Sources */,
+				54ACDD642910E190002B74E4 /* QueueTests.swift in Sources */,
 				575692E72910B538009DF06D /* Node.swift in Sources */,
 				C7694E7A259C3EC00053667F /* main.swift in Sources */,
 				5462C1BE2910B6E70011E035 /* LinkedList.swift in Sources */,
@@ -230,6 +297,38 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin XCBuildConfiguration section */
+		54ACDD5E2910E183002B74E4 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 12.3;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.lws2269.QueueTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		54ACDD5F2910E183002B74E4 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 12.3;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.lws2269.QueueTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
 		C7694E7B259C3EC00053667F /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -370,6 +469,15 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		54ACDD5D2910E183002B74E4 /* Build configuration list for PBXNativeTarget "QueueTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				54ACDD5E2910E183002B74E4 /* Debug */,
+				54ACDD5F2910E183002B74E4 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		C7694E71259C3EC00053667F /* Build configuration list for PBXProject "BankManagerConsoleApp" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/BankManagerConsoleApp/BankManagerConsoleApp.xcworkspace/contents.xcworkspacedata
+++ b/BankManagerConsoleApp/BankManagerConsoleApp.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "group:BankManagerConsoleApp.xcodeproj">
+   </FileRef>
+   <FileRef
+      location = "group:Pods/Pods.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/BankManagerConsoleApp/BankManagerConsoleApp.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/BankManagerConsoleApp/BankManagerConsoleApp.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/BankManagerConsoleApp/BankManagerConsoleApp/LinkedList.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/LinkedList.swift
@@ -14,12 +14,28 @@ struct LinkedList<T> {
         return self.head == nil
     }
     
-    mutating func appendNode(_ node: T) {
+    mutating func appendNode(_ value: T) {
+        let node = Node<T>(data: value)
         
+        if self.isEmpty {
+            self.head = node
+        }
+        
+        self.tail?.next = node
+        self.tail = node
     }
     
     mutating func removeHead() -> T? {
-        return self.head?.data
+        guard !self.isEmpty else { return nil }
+        
+        if self.head === self.tail {
+            self.tail = nil
+        }
+        let removedValue = self.head?.data
+        
+        self.head = self.head?.next
+        
+        return removedValue
     }
     
     mutating func removeAll() {

--- a/BankManagerConsoleApp/BankManagerConsoleApp/LinkedList.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/LinkedList.swift
@@ -3,11 +3,11 @@
 import Foundation
 
 struct LinkedList<T> {
-    var head: Node<T>?
-    var tail: Node<T>?
+    private var head: Node<T>?
+    private var tail: Node<T>?
 
     var headData: T? {
-        return head?.data
+        return self.head?.data
     }
     
     var isEmpty: Bool {

--- a/BankManagerConsoleApp/BankManagerConsoleApp/LinkedList.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/LinkedList.swift
@@ -1,0 +1,29 @@
+//  Created by stone, 애종 on 2022/11/01.
+
+import Foundation
+
+struct LinkedList<T> {
+    var head: Node<T>?
+    var tail: Node<T>?
+
+    var headData: T? {
+        return head?.data
+    }
+    
+    var isEmpty: Bool {
+        return self.head == nil
+    }
+    
+    mutating func appendNode(_ node: T) {
+        
+    }
+    
+    mutating func removeHead() -> T? {
+        return self.head?.data
+    }
+    
+    mutating func removeAll() {
+        self.head = nil
+        self.tail = nil
+    }
+}

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Node.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Node.swift
@@ -1,0 +1,10 @@
+//  Created by stone, 애종 on 2022/11/01.
+
+class Node<T> {
+    let data: T
+    var next: Node?
+    
+    init(data: T) {
+        self.data = data
+    }
+}

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Node.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Node.swift
@@ -1,6 +1,6 @@
 //  Created by stone, 애종 on 2022/11/01.
 
-class Node<T> {
+final class Node<T> {
     let data: T
     var next: Node?
     

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Queue.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Queue.swift
@@ -1,10 +1,10 @@
 //  Created by stone, 애종 on 2022/11/01.
 
 struct Queue<T> {
-    var linkedList = LinkedList<T>()
+    private var linkedList = LinkedList<T>()
     
     var peek: T? {
-        return linkedList.headData
+        return self.linkedList.headData
     }
     
     var isEmpty: Bool {

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Queue.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Queue.swift
@@ -1,3 +1,25 @@
 //  Created by stone, 애종 on 2022/11/01.
 
-import Foundation
+struct Queue<T> {
+    var linkedList = LinkedList<T>()
+    
+    var peek: T? {
+        return linkedList.headData
+    }
+    
+    var isEmpty: Bool {
+        return self.linkedList.isEmpty
+    }
+    
+    mutating func enqueue(_ item: T) {
+        self.linkedList.appendNode(item)
+    }
+    
+    mutating func dequeue() -> T? {
+        return self.linkedList.removeHead()
+    }
+    
+    mutating func clear() {
+        self.linkedList.removeAll()
+    }
+}

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Queue.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Queue.swift
@@ -1,0 +1,3 @@
+//  Created by stone, 애종 on 2022/11/01.
+
+import Foundation

--- a/BankManagerConsoleApp/BankManagerConsoleApp/main.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/main.swift
@@ -4,4 +4,3 @@
 //  Copyright © yagom academy. All rights reserved.
 // 
 
-import Foundation

--- a/BankManagerConsoleApp/BankManagerConsoleApp/main.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/main.swift
@@ -4,3 +4,4 @@
 //  Copyright © yagom academy. All rights reserved.
 // 
 
+import Foundation

--- a/BankManagerConsoleApp/Podfile
+++ b/BankManagerConsoleApp/Podfile
@@ -1,0 +1,11 @@
+# Uncomment the next line to define a global platform for your project
+# platform :ios, '9.0'
+
+target 'BankManagerConsoleApp' do
+  # Comment the next line if you don't want to use dynamic frameworks
+  use_frameworks!
+
+  # Pods for BankManagerConsoleApp
+  pod 'SwiftLint'
+
+end

--- a/BankManagerConsoleApp/Podfile.lock
+++ b/BankManagerConsoleApp/Podfile.lock
@@ -1,0 +1,16 @@
+PODS:
+  - SwiftLint (0.49.1)
+
+DEPENDENCIES:
+  - SwiftLint
+
+SPEC REPOS:
+  trunk:
+    - SwiftLint
+
+SPEC CHECKSUMS:
+  SwiftLint: 32ee33ded0636d0905ef6911b2b67bbaeeedafa5
+
+PODFILE CHECKSUM: e2f2686f92b0f2c3ffe3669d3b5750b908a877c9
+
+COCOAPODS: 1.11.3

--- a/BankManagerConsoleApp/QueueTests/QueueTests.swift
+++ b/BankManagerConsoleApp/QueueTests/QueueTests.swift
@@ -1,0 +1,47 @@
+//
+//  QueueTests.swift
+//  QueueTests
+//
+//  Created by leewonseok on 2022/11/01.
+//
+
+import XCTest
+
+class QueueTests: XCTestCase {
+    var sut: Queue<String>!
+    
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        sut = Queue()
+    }
+
+    override func tearDownWithError() throws {
+        try super.tearDownWithError()
+        sut = nil
+    }
+    
+    func test_Queue에_euqueue하고_dequeue했을때_같은_값이_나오는지() {
+        let result = "ABCD"
+        
+        sut.enqueue(result)
+        
+        XCTAssertEqual(result, sut.dequeue())
+    }
+    
+    func test_비어있는_Queue가_isEmpty가_맞는지() {
+        XCTAssertEqual(true, sut.isEmpty)
+    }
+    
+    
+    func test_Queue에_5개의_값을_넣고_5개의_값을_뺐을때_isEmpty가_맞는지() {
+        for _ in 1...5 {
+            sut.enqueue("ABC")
+        }
+        
+        for _ in 1...5 {
+            let _ = sut.dequeue()
+        }
+        
+        XCTAssertEqual(true, sut.isEmpty)
+    }
+}

--- a/BankManagerConsoleApp/QueueTests/QueueTests.swift
+++ b/BankManagerConsoleApp/QueueTests/QueueTests.swift
@@ -1,9 +1,4 @@
-//
-//  QueueTests.swift
-//  QueueTests
-//
-//  Created by leewonseok on 2022/11/01.
-//
+//  Created by stone, 애종 on 2022/11/01.
 
 import XCTest
 
@@ -41,6 +36,24 @@ class QueueTests: XCTestCase {
         for _ in 1...5 {
             let _ = sut.dequeue()
         }
+        
+        XCTAssertEqual(true, sut.isEmpty)
+    }
+    
+    func test_Queue에_5개의_값을_넣고_peek했을때_가장처음넣은값이_맞는지() {
+        for number in 1...5 {
+            sut.enqueue("\(number)")
+        }
+        
+        XCTAssertEqual("1", sut.peek)
+    }
+    
+    func test_Queue에_5개의_값을_넣고_clear함수호출시_isEmpty가true를반환하는지() {
+        for number in 1...5 {
+            sut.enqueue("\(number)")
+        }
+        
+        sut.clear()
         
         XCTAssertEqual(true, sut.isEmpty)
     }


### PR DESCRIPTION
안녕하세요. 제임스(@inwoodev)! 이번 프로젝트 리뷰를 부탁드리게 된 애종, stone입니다!
이번 스텝에서는 대기열(큐, Queue) 타입만 구현하면 되어서 내용은 많지 않지만 잘 부탁드립니다!

## 구현내용
 - Node
    - data
        - 해당 Node의 값을 담는 프로퍼티입니다.
    - next
        - 다음 Node의 값을 담는 프로퍼티입니다.
- LinkedList
    - head
        - LinkedList의 첫번째 Node입니다.
    - tail
        - LinkedList의 마지막 Node입니다.
    - headData
        - 첫번째 Node의 값을 가져오는 연산프로퍼티입니다.
    - isEmpty
        - LinkedList가 비어있는지 확인할 수 있는 연산프로퍼티입니다.
    - appendNode(_ value: T)
        - LinkedList의 끝에 값을 append하는 함수입니다.
    - removeHead() -> T?
        - LinkedList의 첫번째 값을 제거하고 반환하는 함수입니다.
    - removeAll()
        - head와 tail을 nil로 할당함으로써 초기화하는 함수입니다.
- Queue
    - peek
        - LinkedList - headData를 호출하는 연산프로퍼티입니다. 
    - isEmpty
        - LinkedList - isEmpty를 호출하는 연산프로퍼티입니다.
    - enqueue(_ item: T)
        - LinkedList에 값을 추가하는 함수입니다.
    - dequeue() -> T?
        - LinkedList에서 값을 가져오고 가져온 값을 제거하는 함수입니다.
    - clear
        - linkedList의 내부 요소를 초기화하는 함수입니다.

## 고민되었던 점
- 이번 스텝에서는 없습니다!

	
## 조언을 얻고 싶은 부분
- UnitTest를 추가하는 과정에서 아키텍쳐와 관련된 것으로 보이는 오류 메세지가 출력됩니다.
![](https://i.imgur.com/wjpVfQ5.png)
    - 현재 저희 둘 다 M1칩을 사용해 arm64 아키텍처로 확인됩니다. 하지만 target은 x86_64의 아키텍처를 사용해 BankManagerConsoleApp을 찾지 못한다는 말 같습니다. 이 부분에 대해 고민해보고 해결방법을 강구했지만 속 시원한 해결책은 찾지를 못했습니다.
    
    
    -   ![](https://i.imgur.com/brusDrM.png)
    `@testable import BankManagerConsoleApp`대신 Target Membership의 체크박스에 직접 체크해주는 방법으로 Unit Test를 구현했습니다.
    
  
