### PR TITLE
은행 창구 매니저 [Step 3] som, Dragon, Ayaan

### DIFF
--- a/BankManager.swift
+++ b/BankManager.swift
@@ -1,7 +1,0 @@
-//
-//  BankManager.swift
-//  Created by yagom.
-//  Copyright © yagom academy. All rights reserved.
-//
-
-import Foundation

--- a/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
+++ b/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
@@ -12,7 +12,6 @@
 		AE81AB35290FEE8A00C59DC8 /* NodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE81AB34290FEE8A00C59DC8 /* NodeTests.swift */; };
 		AE81AB3B290FF34600C59DC8 /* Node.swift in Sources */ = {isa = PBXBuildFile; fileRef = D33190A2290FE46900D3182D /* Node.swift */; };
 		C7694E7A259C3EC00053667F /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7694E79259C3EC00053667F /* main.swift */; };
-		C7D65D1B259C8190005510E0 /* BankManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7D65D1A259C8190005510E0 /* BankManager.swift */; };
 		D00901952911093000965085 /* LinkedList.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE093F212910E2B8004EAA1F /* LinkedList.swift */; };
 		D009019A2912257600965085 /* Customer.swift in Sources */ = {isa = PBXBuildFile; fileRef = D00901992912257600965085 /* Customer.swift */; };
 		D009019C2912258200965085 /* Banker.swift in Sources */ = {isa = PBXBuildFile; fileRef = D009019B2912258200965085 /* Banker.swift */; };
@@ -50,7 +49,6 @@
 		B9046BF2B0EFF50FACB7AD03 /* Pods_BankManagerConsoleApp.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_BankManagerConsoleApp.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		C7694E76259C3EC00053667F /* BankManagerConsoleApp */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = BankManagerConsoleApp; sourceTree = BUILT_PRODUCTS_DIR; };
 		C7694E79259C3EC00053667F /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
-		C7D65D1A259C8190005510E0 /* BankManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = BankManager.swift; path = ../../BankManager.swift; sourceTree = "<group>"; };
 		D00901992912257600965085 /* Customer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Customer.swift; sourceTree = "<group>"; };
 		D009019B2912258200965085 /* Banker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Banker.swift; sourceTree = "<group>"; };
 		D009019E29123C1A00965085 /* Console.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Console.swift; sourceTree = "<group>"; };
@@ -144,7 +142,6 @@
 		C7694E78259C3EC00053667F /* BankManagerConsoleApp */ = {
 			isa = PBXGroup;
 			children = (
-				C7D65D1A259C8190005510E0 /* BankManager.swift */,
 				C7694E79259C3EC00053667F /* main.swift */,
 				D009019E29123C1A00965085 /* Console.swift */,
 				D34CAC10291227F3008A7D99 /* Bank.swift */,
@@ -410,7 +407,6 @@
 				D009019C2912258200965085 /* Banker.swift in Sources */,
 				D009019F29123C1A00965085 /* Console.swift in Sources */,
 				AE093F222910E2B8004EAA1F /* LinkedList.swift in Sources */,
-				C7D65D1B259C8190005510E0 /* BankManager.swift in Sources */,
 				D009019A2912257600965085 /* Customer.swift in Sources */,
 				D362AAFC2914D0D900E4AA50 /* CustomerQueue.swift in Sources */,
 				D34CAC08291223CA008A7D99 /* BankingService.swift in Sources */,

--- a/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
+++ b/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
@@ -27,6 +27,7 @@
 		D3561FA92910F83D00324321 /* LinkedListTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3561FA82910F83D00324321 /* LinkedListTests.swift */; };
 		D3561FAD2910F86400324321 /* Node.swift in Sources */ = {isa = PBXBuildFile; fileRef = D33190A2290FE46900D3182D /* Node.swift */; };
 		D3561FAE2910F86B00324321 /* LinkedList.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE093F212910E2B8004EAA1F /* LinkedList.swift */; };
+		D362AAFC2914D0D900E4AA50 /* CustomerQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = D362AAFB2914D0D900E4AA50 /* CustomerQueue.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -62,6 +63,7 @@
 		D3561FA62910F83D00324321 /* LinkedListTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = LinkedListTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		D3561FA82910F83D00324321 /* LinkedListTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkedListTests.swift; sourceTree = "<group>"; };
 		D3561FAF29110D8700324321 /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
+		D362AAFB2914D0D900E4AA50 /* CustomerQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomerQueue.swift; sourceTree = "<group>"; };
 		FAAD76CDFEEBAF59E8333246 /* Pods-BankManagerConsoleApp.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BankManagerConsoleApp.release.xcconfig"; path = "Target Support Files/Pods-BankManagerConsoleApp/Pods-BankManagerConsoleApp.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -168,6 +170,7 @@
 				D33190A2290FE46900D3182D /* Node.swift */,
 				D013F1F1290FE7230060EC9E /* Queue.swift */,
 				AE093F212910E2B8004EAA1F /* LinkedList.swift */,
+				D362AAFB2914D0D900E4AA50 /* CustomerQueue.swift */,
 			);
 			path = Queue;
 			sourceTree = "<group>";
@@ -409,6 +412,7 @@
 				AE093F222910E2B8004EAA1F /* LinkedList.swift in Sources */,
 				C7D65D1B259C8190005510E0 /* BankManager.swift in Sources */,
 				D009019A2912257600965085 /* Customer.swift in Sources */,
+				D362AAFC2914D0D900E4AA50 /* CustomerQueue.swift in Sources */,
 				D34CAC08291223CA008A7D99 /* BankingService.swift in Sources */,
 				D013F1F2290FE7230060EC9E /* Queue.swift in Sources */,
 				D34CAC11291227F3008A7D99 /* Bank.swift in Sources */,

--- a/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/xcshareddata/xcschemes/BankManagerConsoleApp.xcscheme
+++ b/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/xcshareddata/xcschemes/BankManagerConsoleApp.xcscheme
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1340"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "C7694E75259C3EC00053667F"
+               BuildableName = "BankManagerConsoleApp"
+               BlueprintName = "BankManagerConsoleApp"
+               ReferencedContainer = "container:BankManagerConsoleApp.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "C7694E75259C3EC00053667F"
+            BuildableName = "BankManagerConsoleApp"
+            BlueprintName = "BankManagerConsoleApp"
+            ReferencedContainer = "container:BankManagerConsoleApp.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "C7694E75259C3EC00053667F"
+            BuildableName = "BankManagerConsoleApp"
+            BlueprintName = "BankManagerConsoleApp"
+            ReferencedContainer = "container:BankManagerConsoleApp.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
@@ -9,9 +9,6 @@ class Bank {
     private var customerQueue: CustomerQueue = CustomerQueue()
     private let customerCount: Int
     private let semaphore: DispatchSemaphore = DispatchSemaphore(value: 1)
-    var workResult: (customerCount: Int, time: Double) {
-        return (customerCount, Double(customerCount) * 0.7)
-    }
     
     init() {
         customerCount = Int.random(in: 10...30)
@@ -31,7 +28,29 @@ class Bank {
         }
     }
     
-    func entrustBankerService() {
+    func startBankingService(completion: @escaping (Int, Double) -> Void) {
+        let group: DispatchGroup = DispatchGroup()
+        let startingTime: Date = Date()
+        
+        DispatchQueue.global().async(group: group) {
+            self.entrustBankerService()
+        }
+        
+        DispatchQueue.global().async(group: group) {
+            self.entrustBankerService()
+        }
+        
+        DispatchQueue.global().async(group: group) {
+            self.entrustBankerService()
+        }
+        
+        group.wait()
+        
+        let totalServiceTime: Double = Date().timeIntervalSince(startingTime)
+        completion(customerCount, totalServiceTime)
+    }
+    
+    private func entrustBankerService() {
         guard let currentCustomer: Customer = requestCustomer() else {
             return
         }
@@ -41,17 +60,7 @@ class Bank {
         }
     }
     
-    func startBankingService() {
-        let group: DispatchGroup = DispatchGroup()
-        
-        DispatchQueue.global().async(group: group) {
-            self.entrustBankerService()
-        }
-        
-        group.wait()
-    }
-    
-    func requestCustomer() -> Customer? {
+    private func requestCustomer() -> Customer? {
         semaphore.wait()
         
         defer {

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
@@ -4,7 +4,7 @@
 
 struct Bank {
     private let banker: Banker = Banker()
-    private var customerQueue: Queue<Customer> = Queue<Customer>()
+    private var customerQueue: CustomerQueue = CustomerQueue()
     private let customerCount: Int
     var workResult: (customerCount: Int, time: Double) {
         return (customerCount, Double(customerCount) * 0.7)

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
@@ -14,27 +14,20 @@ class Bank {
     private let loanBankerCount: Int
     private let customerCount: Int
     
-    init() {
-        customerCount = Int.random(in: 10...30)
-        depositBankerCount = 2
-        loanBankerCount = 1
-        setCustomerQueue()
+    init(customers: [Customer], depositBankerCount: Int, loanBankerCount: Int) {
+        self.depositBankerCount = depositBankerCount
+        self.loanBankerCount = loanBankerCount
+        customerCount = customers.count
+        setCustomerQueue(from: customers)
     }
     
-    private func setCustomerQueue() {
-        for count in 1...customerCount {
-            guard let randomBankingService: BankingService = BankingService.random() else {
-                return
-            }
-            
-            let customer: Customer = Customer(waitingNumber: count,
-                                              bankingService: randomBankingService)
-            
-            switch customer.bankingService {
+    private func setCustomerQueue(from customers: [Customer]) {
+        customers.forEach {
+            switch $0.bankingService {
             case .loan:
-                loanCustomerQueue.enqueue(customer)
+                loanCustomerQueue.enqueue($0)
             case .deposit:
-                depositCustomerQueue.enqueue(customer)
+                depositCustomerQueue.enqueue($0)
             }
         }
     }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
@@ -58,6 +58,7 @@ class Bank {
         group.wait()
         
         let totalServiceTime: Double = Date().timeIntervalSince(startingTime)
+        
         completion(customerCount, totalServiceTime)
     }
     

--- a/BankManagerConsoleApp/BankManagerConsoleApp/BankingService/BankingService.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/BankingService/BankingService.swift
@@ -16,14 +16,14 @@ extension BankingServiceProtocol {
     }
 }
 
-enum BankingService: BankingServiceProtocol {
-    case loan
-    case deposit
+enum BankingService: String, BankingServiceProtocol {
+    case loan = "대출"
+    case deposit = "예금"
     
     var processTime: Double {
         switch self {
         case .loan:
-            return 0.7
+            return 1.1
         case .deposit:
             return 0.7
         }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/BankingService/BankingService.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/BankingService/BankingService.swift
@@ -16,9 +16,18 @@ extension BankingServiceProtocol {
     }
 }
 
-enum BankingService: String, BankingServiceProtocol {
-    case loan = "대출"
-    case deposit = "예금"
+enum BankingService: BankingServiceProtocol {
+    case loan
+    case deposit
+    
+    var name: String {
+        switch self {
+        case .loan:
+            return "대출"
+        case .deposit:
+            return "예금"
+        }
+    }
     
     var processTime: Double {
         switch self {

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Console.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Console.swift
@@ -58,7 +58,7 @@ struct Console {
     }
     
     private func openBank() -> WorkResult {
-        let bank: Bank = Bank()
+        let bank: Bank = Bank(customers: Customer.make(), depositBankerCount: 2, loanBankerCount: 1)
         var count: Int = 0
         var totalTime: Double = 0.0
         

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Console.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Console.swift
@@ -58,11 +58,16 @@ struct Console {
     }
     
     private func openBank() -> WorkResult {
-        var bank: Bank = Bank()
+        let bank: Bank = Bank()
+        var count: Int = 0
+        var totalTime: Double = 0.0
         
-        bank.startBankingService()
+        bank.startBankingService { (customerCount, totalServiceTime) in
+            count = customerCount
+            totalTime = totalServiceTime
+        }
         
-        return bank.workResult
+        return (count, totalTime)
     }
     
     private func printCompleteMessage(about workResult: WorkResult) {

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Console.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Console.swift
@@ -84,9 +84,7 @@ enum ConsoleError: LocalizedError {
     public var errorDescription: String? {
         switch self {
         case .invalidError:
-            let errorMessage: String = "잘못된 입력입니다."
-            
-            return errorMessage
+            return "잘못된 입력입니다."
         }
     }
 }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Console.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Console.swift
@@ -51,10 +51,10 @@ struct Console {
         guard let input: String = readLine(),
               let flagRawValue: Int = Int(input),
               let flag: Flag = Flag.init(rawValue: flagRawValue) else {
-                  return.failure(.invalidError)
+                  return .failure(.invalidError)
               }
     
-        return.success(flag)
+        return .success(flag)
     }
     
     private func openBank() -> WorkResult {

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Person/Banker.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Person/Banker.swift
@@ -3,9 +3,13 @@
 //  Copyright © yagom academy. All rights reserved.
 
 struct Banker {
-    func work(_ customer: Customer) {
+    func work(_ customer: Customer, completion: @escaping () -> Void) {
         let startingMessage: String = "\(customer.waitingNumber)번 고객 업무 시작"
         let endingMessage: String = "\(customer.waitingNumber)번 고객 업무 완료"
+        
+        defer {
+            completion()
+        }
         
         print(startingMessage)
         customer.bankingService.request()

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Person/Banker.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Person/Banker.swift
@@ -4,8 +4,8 @@
 
 struct Banker {
     func work(_ customer: Customer, completion: @escaping () -> Void) {
-        let startingMessage: String = "\(customer.waitingNumber)번 고객 업무 시작"
-        let endingMessage: String = "\(customer.waitingNumber)번 고객 업무 완료"
+        let startingMessage: String = "\(customer.waitingNumber)번 고객 \(customer.bankingService.rawValue)업무 시작"
+        let endingMessage: String = "\(customer.waitingNumber)번 고객 \(customer.bankingService.rawValue)업무 완료"
         
         defer {
             completion()

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Person/Banker.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Person/Banker.swift
@@ -4,8 +4,8 @@
 
 struct Banker {
     func work(_ customer: Customer, completion: @escaping () -> Void) {
-        let startingMessage: String = "\(customer.waitingNumber)번 고객 \(customer.bankingService.rawValue)업무 시작"
-        let endingMessage: String = "\(customer.waitingNumber)번 고객 \(customer.bankingService.rawValue)업무 완료"
+        let startingMessage: String = "\(customer.waitingNumber)번 고객 \(customer.bankingService.name)업무 시작"
+        let endingMessage: String = "\(customer.waitingNumber)번 고객 \(customer.bankingService.name)업무 완료"
         
         print(startingMessage)
         customer.bankingService.request()

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Person/Banker.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Person/Banker.swift
@@ -7,12 +7,10 @@ struct Banker {
         let startingMessage: String = "\(customer.waitingNumber)번 고객 \(customer.bankingService.rawValue)업무 시작"
         let endingMessage: String = "\(customer.waitingNumber)번 고객 \(customer.bankingService.rawValue)업무 완료"
         
-        defer {
-            completion()
-        }
-        
         print(startingMessage)
         customer.bankingService.request()
         print(endingMessage)
+        
+        completion()
     }
 }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Person/Customer.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Person/Customer.swift
@@ -12,6 +12,21 @@ struct Customer {
     }
 }
 
+extension Customer {
+    static func make(count: Int = Int.random(in: 10...30)) -> [Customer] {
+        var customers: [Customer] = []
+        
+        for waitingNumber in 1...count {
+            let bankingService: BankingService = BankingService.random() ?? .deposit
+            let customer: Customer = Customer(waitingNumber: waitingNumber, bankingService: bankingService)
+            
+            customers.append(customer)
+        }
+        
+        return customers
+    }
+}
+
 extension Customer: Equatable {
     static func == (lhs: Customer, rhs: Customer) -> Bool {
         return (lhs.waitingNumber == rhs.waitingNumber) && (lhs.bankingService == rhs.bankingService)

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Queue/CustomerQueue.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Queue/CustomerQueue.swift
@@ -1,0 +1,8 @@
+//  BankManagerConsoleApp - CustomerQueue.swift
+//  Created by Ayaan/Dragon/som on 2022/11/04.
+//  Copyright © yagom academy. All rights reserved.
+
+struct CustomerQueue: Queue {
+    typealias Element = Customer
+    var linkedList: LinkedList<Element> = LinkedList<Element>()
+}

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Queue/LinkedList.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Queue/LinkedList.swift
@@ -54,12 +54,12 @@ struct LinkedList<T: Equatable> {
         return currentTail.data
     }
     
-    func searchFirstNode(from data: T) -> Node<T>? {
+    func searchFirstIndex(of data: T) -> Int? {
         var currentNode: Node<T>? = head
         
-        while currentNode != nil {
+        for index in 0..<count {
             if currentNode?.data == data {
-                return currentNode
+                return index
             }
             
             currentNode = currentNode?.nextNode

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Queue/LinkedList.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Queue/LinkedList.swift
@@ -113,7 +113,7 @@ struct LinkedList<T: Equatable> {
     }
     
     @discardableResult
-    mutating func removeFrist(of data: T) -> T? {
+    mutating func removeFirst(of data: T) -> T? {
         var currentNode: Node<T>? = head
         var currentPosition: Int = 0
         

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Queue/LinkedList.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Queue/LinkedList.swift
@@ -31,6 +31,7 @@ struct LinkedList<T: Equatable> {
         count += 1
     }
     
+    @discardableResult
     mutating func removeFirst() -> T? {
         guard let currentHead: Node<T> = head else {
             return nil
@@ -42,6 +43,7 @@ struct LinkedList<T: Equatable> {
         return currentHead.data
     }
     
+    @discardableResult
     mutating func removeLast() -> T? {
         guard let currentTail: Node<T> = tail else {
             return nil
@@ -54,69 +56,78 @@ struct LinkedList<T: Equatable> {
         return currentTail.data
     }
     
-    func searchFirstIndex(of data: T) -> Int? {
-        var currentNode: Node<T>? = head
-        
-        for index in 0..<count {
-            if currentNode?.data == data {
-                return index
-            }
-            
-            currentNode = currentNode?.nextNode
-        }
-        
-        return nil
-    }
-    
-    func searchNode(at index: Int) -> Node<T>? {
-        guard count >= index else {
+    func searchNode(at nodePosition: Int) -> Node<T>? {
+        let targetPosition: Int = nodePosition - 1
+        guard (targetPosition < count) == true else {
             return nil
         }
         
         var currentNode: Node<T>? = head
         
-        for _ in 1..<index {
-            currentNode = currentNode?.nextNode
+        for position in 0..<count {
+            if position == targetPosition {
+                break
+            } else {
+                currentNode = currentNode?.nextNode
+            }
         }
         
         return currentNode
     }
     
-    mutating func remove(at index: Int) -> T? {
-        guard let node: Node<T> = searchNode(at: index) else {
+    @discardableResult
+    mutating func remove(at nodePosition: Int) -> T? {
+        if nodePosition == 0 {
+            return removeFirst()
+        } else if nodePosition == count - 1 {
+            return removeLast()
+        } else if let node: Node<T> = searchNode(at: nodePosition) {
+            node.previousNode?.nextNode = node.nextNode
+            node.nextNode?.previousNode = node.previousNode
+            
+            return node.data
+        } else {
             return nil
         }
-        
-        let previousNode: Node<T>? = node.previousNode
-        let nextNode: Node<T>? = node.nextNode
-        
-        previousNode?.nextNode = nextNode
-        nextNode?.previousNode = previousNode
-        count -= 1
-        
-        return node.data
     }
     
-    mutating func insert(at index: Int, data: T) {
-        guard count >= index else {
-            return
-        }
-        
-        var currentNode: Node<T>? = head
-        
-        for _ in 1..<index {
-            currentNode = currentNode?.nextNode
-        }
-        
+    mutating func insert(at nodePosition: Int, data: T) {
         let node: Node<T> = Node(data: data)
-        let previousNode: Node<T>? = currentNode?.previousNode
+
+        if nodePosition == count {
+            append(data)
+        } else if nodePosition == 0 {
+            node.nextNode = head
+            head?.previousNode = node
+            
+            head = node
+        } else if let currentNodePosition: Node<T> = searchNode(at: nodePosition) {
+            let previousNode: Node<T>? = currentNodePosition.previousNode
+            
+            node.previousNode = previousNode
+            node.nextNode = currentNodePosition
+            
+            previousNode?.nextNode = node
+            currentNodePosition.previousNode = node
+        }
+    }
+    
+    @discardableResult
+    mutating func removeFrist(of data: T) -> T? {
+        var currentNode: Node<T>? = head
+        var currentPosition: Int = 0
         
-        node.previousNode = previousNode
-        previousNode?.nextNode = node
-        node.nextNode = currentNode
-        currentNode?.previousNode = node
+        repeat {
+            if currentNode?.data == data {
+                remove(at: currentPosition)
+                return currentNode?.data
+            } else {
+                currentNode = currentNode?.nextNode
+                currentPosition += 1
+            }
+        } while currentNode != nil
         
-        count += 1
+        return nil
     }
     
     mutating func removeAll() {

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Queue/Queue.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Queue/Queue.swift
@@ -2,17 +2,26 @@
 //  Created by Ayaan/Dragon/som on 2022/10/31.
 //  Copyright © yagom academy. All rights reserved.
 
-struct Queue<Element: Equatable> {
-    private var linkedList: LinkedList<Element> = LinkedList<Element>()
+protocol Queue {
+    associatedtype Element where Element: Equatable
+    var linkedList: LinkedList<Element> { get set }
+    var isEmpty: Bool { get }
+    var first: Element? { get }
+    var last: Element? { get }
     
+    mutating func enqueue(_ data: Element)
+    mutating func dequeue() -> Element?
+    mutating func clear()
+    func peek() -> Element?
+}
+
+extension Queue {
     var isEmpty: Bool {
         return linkedList.isEmpty
     }
-    
     var first: Element? {
         return linkedList.first
     }
-    
     var last: Element? {
         return linkedList.last
     }
@@ -20,15 +29,12 @@ struct Queue<Element: Equatable> {
     mutating func enqueue(_ data: Element) {
         linkedList.append(data)
     }
-    
     mutating func dequeue() -> Element? {
         return linkedList.removeFirst()
     }
-    
     mutating func clear() {
         linkedList.removeAll()
     }
-    
     func peek() -> Element? {
         return first
     }

--- a/BankManagerConsoleApp/LinkedListTests/LinkedListTests.swift
+++ b/BankManagerConsoleApp/LinkedListTests/LinkedListTests.swift
@@ -279,7 +279,7 @@ class LinkedListTests: XCTestCase {
         }
         
         //when
-        let removeResult: Int? = sut.removeFrist(of: 1)
+        let removeResult: Int? = sut.removeFirst(of: 1)
         let searchResult: Node<Int>? = sut.searchNode(at: 1)
         
         //then
@@ -296,7 +296,7 @@ class LinkedListTests: XCTestCase {
         }
         
         //when
-        let removeResult: Int? = sut.removeFrist(of: 10)
+        let removeResult: Int? = sut.removeFirst(of: 10)
         let searchResult: Node<Int>? = sut.searchNode(at: 10)
         
         //then
@@ -313,7 +313,7 @@ class LinkedListTests: XCTestCase {
         }
         
         //when
-        let removeResult: Int? = sut.removeFrist(of: 5)
+        let removeResult: Int? = sut.removeFirst(of: 5)
         let searchResult: Node<Int>? = sut.searchNode(at: 5)
         
         //then

--- a/BankManagerConsoleApp/LinkedListTests/LinkedListTests.swift
+++ b/BankManagerConsoleApp/LinkedListTests/LinkedListTests.swift
@@ -95,36 +95,6 @@ class LinkedListTests: XCTestCase {
         XCTAssertEqual(result, 20)
     }
     
-    func test_1부터_10까지의_정수로_이루어진_배열을_차례대로_append된_LinkedList에_정수_11로_searchFirstNode한_경우_결과는_nil이다() {
-        //given
-        let data: [Int] = Array(1...10)
-        
-        data.forEach {
-            sut.append($0)
-        }
-        
-        //when
-        let result: Node<Int>? = sut.searchFirstNode(from: 11)
-        
-        //then
-        XCTAssertNil(result)
-    }
-    
-    func test_1부터_10까지의_정수로_이루어진_배열을_차례대로_append된_LinkedList에_정수_5를_searchFirstNode한_경우_결과값의_data는_5와_같다() {
-        //given
-        let data: [Int] = Array(1...10)
-        
-        data.forEach {
-            sut.append($0)
-        }
-        
-        //when
-        let result: Node<Int>? = sut.searchFirstNode(from: 5)
-        
-        //then
-        XCTAssertEqual(result?.data, 5)
-    }
-    
     func test_1부터_10까지의_정수로_이루어진_배열을_차례대로_append된_LinkedList에_20번째를_searchNode한_경우_결과는_nil이다() {
         //given
         let data: [Int] = Array(1...10)
@@ -138,6 +108,36 @@ class LinkedListTests: XCTestCase {
         
         //then
         XCTAssertNil(result)
+    }
+    
+    func test_1부터_10까지의_정수로_이루어진_배열을_차례대로_append된_LinkedList에_0번째를_searchNode한_경우_결과값의_data는_1과_같다() {
+        //given
+        let data: [Int] = Array(1...10)
+        
+        data.forEach {
+            sut.append($0)
+        }
+        
+        //when
+        let result: Node<Int>? = sut.searchNode(at: 1)
+        
+        //then
+        XCTAssertEqual(result?.data, 1)
+    }
+    
+    func test_1부터_10까지의_정수로_이루어진_배열을_차례대로_append된_LinkedList에_10번째를_searchNode한_경우_결과값의_data는_10과_같다() {
+        //given
+        let data: [Int] = Array(1...10)
+        
+        data.forEach {
+            sut.append($0)
+        }
+        
+        //when
+        let result: Node<Int>? = sut.searchNode(at: 10)
+        
+        //then
+        XCTAssertEqual(result?.data, 10)
     }
     
     func test_1부터_10까지의_정수로_이루어진_배열을_차례대로_append된_LinkedList에_7번째를_searchNode한_경우_결과값의_data는_7과_같다() {
@@ -222,6 +222,38 @@ class LinkedListTests: XCTestCase {
         XCTAssertNil(secondResult)
     }
     
+    func test_1부터_10까지의_정수로_이루어진_배열을_차례대로_append된_LinkedList에_0번째에_정수60를_insert한_후_1번째를_searchNode한_경우_결과값의_data는_60과_같다() {
+        //given
+        let data: [Int] = Array(1...10)
+        
+        data.forEach {
+            sut.append($0)
+        }
+        
+        //when
+        sut.insert(at: 0, data: 60)
+        let result: Node<Int>? = sut.searchNode(at: 1)
+        
+        //then
+        XCTAssertEqual(result?.data, 60)
+    }
+    
+    func test_1부터_10까지의_정수로_이루어진_배열을_차례대로_append된_LinkedList의_10번째_정수60를_insert한_후_11번째를_searchNode한_경우_결과값의_data는_60과_같다() {
+        //given
+        let data: [Int] = Array(1...10)
+        
+        data.forEach {
+            sut.append($0)
+        }
+        
+        //when
+        sut.insert(at: 10, data: 60)
+        let result: Node<Int>? = sut.searchNode(at: 11)
+
+        //then
+        XCTAssertEqual(result?.data, 60)
+    }
+    
     func test_1부터_10까지의_정수로_이루어진_배열을_차례대로_append된_LinkedList에_6번째에_정수60를_insert한_후_6번째를_searchNode한_경우_결과값의_data는_60과_같다() {
         //given
         let data: [Int] = Array(1...10)
@@ -236,6 +268,57 @@ class LinkedListTests: XCTestCase {
         
         //then
         XCTAssertEqual(result?.data, 60)
+    }
+    
+    func test_1부터_10까지의_정수로_이루어진_배열을_차례대로_append된_LinkedList에_1에_해당하는_값을_removeFirst한_경우_결과값은_1과_같고_LinkedList의_1번째를_searchNode한_결과값의_data는_2와_같다() {
+        //given
+        let data: [Int] = Array(1...10)
+        
+        data.forEach {
+            sut.append($0)
+        }
+        
+        //when
+        let removeResult: Int? = sut.removeFrist(of: 1)
+        let searchResult: Node<Int>? = sut.searchNode(at: 1)
+        
+        //then
+        XCTAssertEqual(removeResult, 1)
+        XCTAssertEqual(searchResult?.data, 2)
+    }
+    
+    func test_1부터_10까지의_정수로_이루어진_배열을_차례대로_append된_LinkedList에_10에_해당하는_값을_removeFirst한_경우_결과값은_10과_같고_LinkedList의_10번째를_searchNode한_결과값은_nil이다() {
+        //given
+        let data: [Int] = Array(1...10)
+        
+        data.forEach {
+            sut.append($0)
+        }
+        
+        //when
+        let removeResult: Int? = sut.removeFrist(of: 10)
+        let searchResult: Node<Int>? = sut.searchNode(at: 10)
+        
+        //then
+        XCTAssertEqual(removeResult, 10)
+        XCTAssertNil(searchResult)
+    }
+    
+    func test_1부터_10까지의_정수로_이루어진_배열을_차례대로_append된_LinkedList에_5에_해당하는_값을_removeFirst한_경우_결과값은_5와_같고_LinkedList의_5번째를_searchNode한_결과값의_data는_6과_같다() {
+        //given
+        let data: [Int] = Array(1...10)
+        
+        data.forEach {
+            sut.append($0)
+        }
+        
+        //when
+        let removeResult: Int? = sut.removeFrist(of: 5)
+        let searchResult: Node<Int>? = sut.searchNode(at: 5)
+        
+        //then
+        XCTAssertEqual(removeResult, 5)
+        XCTAssertEqual(searchResult?.data, 6)
     }
     
     func test_1부터_10까지의_정수로_이루어진_배열을_차례대로_append된_LinkedList를_removeAll한_경우_LinkedList의_isEmpty가_true이다() {


### PR DESCRIPTION
안녕하세요, 그린(@GREENOVER)🙇‍🙇‍🙇‍♀️!
[Som☁️](https://github.com/jsa0224), [Ayaan🦖](https://github.com/oneStar92), [Dragon🐉](https://github.com/FlameYG)입니다!
저희 Step 3 구현 완료하여 PR 보냅니다!😁
나름대로 비동기적 처리를 고민하여 구현해봤습니다...😵‍💫
부족한 부분이 많지만 좋은 리뷰 부탁드립니다!!!🙇🏻‍♂️


# 📍고민했던 부분 
- 무작위의 BankingServicce를 가진 상태의 고객들을 어떻게 분리할 것인가
  1. CustomerQueue를 loanQueue, depositQueue 2개로 만들어 고객들을 정렬
  2. CustomerQueue에서 BankingService에 맞는 가장 빠른 순서를 가진 고객을 dequeueFirst하는 메서드를 추가적으로 구현
  
   → Queue의 특성인 FIFO를 고려하여 1번이 더 적절하다고 판단하여 구현하였습니다. 

- `Completion` 사용
  - `DispatchQeueue`의 `global()`에서 async로 은행원이 업무를 처리한 후 다음 업무를 어떻게 처리해야할지 많은 고민을 했습니다.
      1. Delegate와 같은 패턴을 사용하여서 은행원이 업무가 끝나면 끝났음을 알리고 다음 고객을 전달받는 방식
      2. Completion으로 `@escaping` 클로저를 통해서 업무가 끝난 후 다음 작업을 이어서 수행하는 방식
  - Completion을 통해서 하나의 Task가 종료된 후 다음 Task를 이어서 수행하도록 구현하여 업무가 이어져서 처리되게 구현했습니다.

- `Semaphore` 사용
  - async로 처음에 구현했을 때, `dequeue`된 `Customer`가 여러 스레드에서 동시에 접근하여 Thread Unsafe한 오류가 있었습니다.
  - `Race condition`을 해결하면서 동시에 접근할 수 있는 스레드의 수를 제어해주는 `Semaphore`를 `CustomerQueue`에서 `dequeue`하는 시점에 사용해주었습니다. 

- `DispatchGroup`을 통한 `wait()`
  - deposit 담당과 loan 담당 은행원(3명)이 처리할 수 있는 고객 수는 각각 1명으로 한정되어 있기 때문에, `DispatchGroup`으로 구현하여 수행이 끝나기를 기다리는 메서드 `wait()`으로 구현했습니다. 


# 📍조언을 얻고 싶은 부분
- Completion
  ```swift
  private func entrustBankerService(of bankingService: BankingService) {
      guard let currentCustomer: Customer = requestCustomer(of: bankingService) else {
          return
      }
          
      banker.work(currentCustomer) {
          self.entrustBankerService(of: bankingService)
      }
  }
  ```
  - async에 해당 메소드를 호출해서 사용했습니다. 이러한 구조가 재귀함수의 구조를 사용하는 것인지 아니면 하나의 작업이 끝난 후 다음 작업이 이어져서 수행되는 것인지 궁금합니다.🤔
  - 이러한 구조가 아닌 다른 방법으로 해결할 수 있는지도 궁금합니다...🤔
