### PR TITLE
은행 창구 매니저 [STEP 2] 토털이, Aaron

### DIFF
--- a/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
+++ b/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		0A7203BB34A9EFA265346E8A /* Pods_BankManagerConsoleApp.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C1EDE8B7325A8ACDA67E5206 /* Pods_BankManagerConsoleApp.framework */; };
 		11123008290FCE7500C60709 /* LinkedList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11123007290FCE7500C60709 /* LinkedList.swift */; };
 		3C381581290FEA160061D86A /* Node.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C381580290FEA160061D86A /* Node.swift */; };
+		3C56C1CB2913D6D100EAB605 /* Bank.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C56C1CA2913D6D100EAB605 /* Bank.swift */; };
 		3C9D9F53290FF0390099E7C3 /* BankManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7D65D1A259C8190005510E0 /* BankManager.swift */; };
 		3C9D9F54290FF03E0099E7C3 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7694E79259C3EC00053667F /* main.swift */; };
 		3C9D9F55290FF0400099E7C3 /* LinkedList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11123007290FCE7500C60709 /* LinkedList.swift */; };
@@ -38,6 +39,7 @@
 		22FDC1883CC7AFCCED248F1A /* Pods-BankManagerConsoleApp.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BankManagerConsoleApp.release.xcconfig"; path = "Target Support Files/Pods-BankManagerConsoleApp/Pods-BankManagerConsoleApp.release.xcconfig"; sourceTree = "<group>"; };
 		3C38157F290FCB250061D86A /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
 		3C381580290FEA160061D86A /* Node.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Node.swift; sourceTree = "<group>"; };
+		3C56C1CA2913D6D100EAB605 /* Bank.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Bank.swift; sourceTree = "<group>"; };
 		3CC80D4B290FEC3800D7B7C1 /* Queue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Queue.swift; sourceTree = "<group>"; };
 		3CC80D51290FEF3300D7B7C1 /* CustomerQueueTest.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CustomerQueueTest.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		3CC80D53290FEF3300D7B7C1 /* CustomerQueueTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomerQueueTest.swift; sourceTree = "<group>"; };
@@ -121,6 +123,7 @@
 				11123007290FCE7500C60709 /* LinkedList.swift */,
 				3CC80D4B290FEC3800D7B7C1 /* Queue.swift */,
 				3C381580290FEA160061D86A /* Node.swift */,
+				3C56C1CA2913D6D100EAB605 /* Bank.swift */,
 			);
 			path = BankManagerConsoleApp;
 			sourceTree = "<group>";
@@ -273,6 +276,7 @@
 				11123008290FCE7500C60709 /* LinkedList.swift in Sources */,
 				C7694E7A259C3EC00053667F /* main.swift in Sources */,
 				3CC80D4C290FEC3800D7B7C1 /* Queue.swift in Sources */,
+				3C56C1CB2913D6D100EAB605 /* Bank.swift in Sources */,
 				C7D65D1B259C8190005510E0 /* BankManager.swift in Sources */,
 				3C381581290FEA160061D86A /* Node.swift in Sources */,
 			);

--- a/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
+++ b/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		0A7203BB34A9EFA265346E8A /* Pods_BankManagerConsoleApp.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C1EDE8B7325A8ACDA67E5206 /* Pods_BankManagerConsoleApp.framework */; };
 		11123008290FCE7500C60709 /* LinkedList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11123007290FCE7500C60709 /* LinkedList.swift */; };
+		1135DB342913F187008AD820 /* CFAbsoluteTime+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1135DB332913F187008AD820 /* CFAbsoluteTime+.swift */; };
 		11C9A5FB2913DF7D00E90A8A /* Customer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11C9A5FA2913DF7D00E90A8A /* Customer.swift */; };
 		11C9A5FD2913DFA300E90A8A /* BankClerk.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11C9A5FC2913DFA300E90A8A /* BankClerk.swift */; };
 		3C381581290FEA160061D86A /* Node.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C381580290FEA160061D86A /* Node.swift */; };
@@ -38,6 +39,7 @@
 
 /* Begin PBXFileReference section */
 		11123007290FCE7500C60709 /* LinkedList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkedList.swift; sourceTree = "<group>"; };
+		1135DB332913F187008AD820 /* CFAbsoluteTime+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CFAbsoluteTime+.swift"; sourceTree = "<group>"; };
 		11C9A5FA2913DF7D00E90A8A /* Customer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Customer.swift; sourceTree = "<group>"; };
 		11C9A5FC2913DFA300E90A8A /* BankClerk.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BankClerk.swift; sourceTree = "<group>"; };
 		22FDC1883CC7AFCCED248F1A /* Pods-BankManagerConsoleApp.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BankManagerConsoleApp.release.xcconfig"; path = "Target Support Files/Pods-BankManagerConsoleApp/Pods-BankManagerConsoleApp.release.xcconfig"; sourceTree = "<group>"; };
@@ -73,6 +75,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		1135DB322913F169008AD820 /* Common */ = {
+			isa = PBXGroup;
+			children = (
+				1135DB332913F187008AD820 /* CFAbsoluteTime+.swift */,
+			);
+			path = Common;
+			sourceTree = "<group>";
+		};
 		1D64B39B58EA4FE7A62993E1 /* Pods */ = {
 			isa = PBXGroup;
 			children = (
@@ -122,6 +132,7 @@
 		C7694E78259C3EC00053667F /* BankManagerConsoleApp */ = {
 			isa = PBXGroup;
 			children = (
+				1135DB322913F169008AD820 /* Common */,
 				C7D65D1A259C8190005510E0 /* BankManager.swift */,
 				C7694E79259C3EC00053667F /* main.swift */,
 				11123007290FCE7500C60709 /* LinkedList.swift */,
@@ -283,6 +294,7 @@
 				11C9A5FB2913DF7D00E90A8A /* Customer.swift in Sources */,
 				C7694E7A259C3EC00053667F /* main.swift in Sources */,
 				3CC80D4C290FEC3800D7B7C1 /* Queue.swift in Sources */,
+				1135DB342913F187008AD820 /* CFAbsoluteTime+.swift in Sources */,
 				3C56C1CB2913D6D100EAB605 /* Bank.swift in Sources */,
 				C7D65D1B259C8190005510E0 /* BankManager.swift in Sources */,
 				3C381581290FEA160061D86A /* Node.swift in Sources */,

--- a/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
+++ b/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
@@ -9,6 +9,8 @@
 /* Begin PBXBuildFile section */
 		0A7203BB34A9EFA265346E8A /* Pods_BankManagerConsoleApp.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C1EDE8B7325A8ACDA67E5206 /* Pods_BankManagerConsoleApp.framework */; };
 		11123008290FCE7500C60709 /* LinkedList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11123007290FCE7500C60709 /* LinkedList.swift */; };
+		11C9A5FB2913DF7D00E90A8A /* Customer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11C9A5FA2913DF7D00E90A8A /* Customer.swift */; };
+		11C9A5FD2913DFA300E90A8A /* BankClerk.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11C9A5FC2913DFA300E90A8A /* BankClerk.swift */; };
 		3C381581290FEA160061D86A /* Node.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C381580290FEA160061D86A /* Node.swift */; };
 		3C56C1CB2913D6D100EAB605 /* Bank.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C56C1CA2913D6D100EAB605 /* Bank.swift */; };
 		3C9D9F53290FF0390099E7C3 /* BankManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7D65D1A259C8190005510E0 /* BankManager.swift */; };
@@ -36,6 +38,8 @@
 
 /* Begin PBXFileReference section */
 		11123007290FCE7500C60709 /* LinkedList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkedList.swift; sourceTree = "<group>"; };
+		11C9A5FA2913DF7D00E90A8A /* Customer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Customer.swift; sourceTree = "<group>"; };
+		11C9A5FC2913DFA300E90A8A /* BankClerk.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BankClerk.swift; sourceTree = "<group>"; };
 		22FDC1883CC7AFCCED248F1A /* Pods-BankManagerConsoleApp.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BankManagerConsoleApp.release.xcconfig"; path = "Target Support Files/Pods-BankManagerConsoleApp/Pods-BankManagerConsoleApp.release.xcconfig"; sourceTree = "<group>"; };
 		3C38157F290FCB250061D86A /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
 		3C381580290FEA160061D86A /* Node.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Node.swift; sourceTree = "<group>"; };
@@ -124,6 +128,8 @@
 				3CC80D4B290FEC3800D7B7C1 /* Queue.swift */,
 				3C381580290FEA160061D86A /* Node.swift */,
 				3C56C1CA2913D6D100EAB605 /* Bank.swift */,
+				11C9A5FA2913DF7D00E90A8A /* Customer.swift */,
+				11C9A5FC2913DFA300E90A8A /* BankClerk.swift */,
 			);
 			path = BankManagerConsoleApp;
 			sourceTree = "<group>";
@@ -274,11 +280,13 @@
 			buildActionMask = 2147483647;
 			files = (
 				11123008290FCE7500C60709 /* LinkedList.swift in Sources */,
+				11C9A5FB2913DF7D00E90A8A /* Customer.swift in Sources */,
 				C7694E7A259C3EC00053667F /* main.swift in Sources */,
 				3CC80D4C290FEC3800D7B7C1 /* Queue.swift in Sources */,
 				3C56C1CB2913D6D100EAB605 /* Bank.swift in Sources */,
 				C7D65D1B259C8190005510E0 /* BankManager.swift in Sources */,
 				3C381581290FEA160061D86A /* Node.swift in Sources */,
+				11C9A5FD2913DFA300E90A8A /* BankClerk.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
@@ -13,7 +13,7 @@ struct Bank {
     func open() {
         setupRandomCustomerQueue()
         startBankJob()
-        menu()
+        start()
     }
     
     func setupRandomCustomerQueue() {
@@ -44,10 +44,13 @@ struct Bank {
     
     func close() {}
     
-    func menu() {
+    func printMenu() {
         print("1: 은행 개점")
         print("2: 종료")
-        
+    }
+    
+    func start() {
+        printMenu()
         let menuNumber = readLine()
         switch menuNumber {
         case "1":
@@ -55,7 +58,7 @@ struct Bank {
         case "2":
             close()
         default:
-            menu()
+            start()
         }
     }
 }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
@@ -7,8 +7,13 @@
 import Foundation
 
 struct Bank {
-    let clerk = BankClerk()
+    let clerks: [BankClerk]
     let customerQueue = Queue<Customer>()
+    var customerCount: Int = 0
+    
+    init(clerkCount: Int) {
+        self.clerks = Array(repeating: BankClerk(), count: clerkCount)
+    }
     
     func open() {
         startBankJob()
@@ -16,22 +21,17 @@ struct Bank {
     
     func startBankJob() {
         let startTime = CFAbsoluteTimeGetCurrent()
-        let customerCount = manageCustomer()
+        manageCustomer()
         let endTime = CFAbsoluteTimeGetCurrent()
         let timeInterval = endTime - startTime
         
         print("업무가 마감되었습니다. 오늘 업무를 처리한 고객은 총 \(customerCount)명이며, 총 업무시간은 \(timeInterval.formattedNumber)초입니다.")
     }
     
-    func manageCustomer() -> Int {
-        var customerCount = 0
+    func manageCustomer() {
         while let customer = customerQueue.dequeue() {
-            clerk.work(for: customer)
-            
-            customerCount += 1
+            clerks.first?.work(for: customer)
         }
-        
-        return customerCount
     }
     
     func close() {}

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
@@ -24,20 +24,22 @@ struct Bank {
     
     func startBankJob() {
         let startTime = CFAbsoluteTimeGetCurrent()
+        var customerCount = manageCustomer()
+        let endTime = CFAbsoluteTimeGetCurrent()
+        let timeInterval = endTime - startTime
+        
+        print("업무가 마감되었습니다. 오늘 업무를 처리한 고객은 총 \(customerCount)명이며, 총 업무시간은 \(timeInterval.formattedNumber)초입니다.")
+    }
+    
+    func manageCustomer() -> Int {
         var customerCount = 0
         while let customer = customerQueue.dequeue() {
             clerk.work(for: customer)
             
             customerCount += 1
         }
-        let endTime = CFAbsoluteTimeGetCurrent()
-        let timeInterval = endTime - startTime
         
-        guard let formattedTime = timeInterval.formattedNumber else {
-            return
-        }
-        
-        print("업무가 마감되었습니다. 오늘 업무를 처리한 고객은 총 \(customerCount)명이며, 총 업무시간은 \(formattedTime)초입니다.")
+        return customerCount
     }
     
     func close() {}

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
@@ -1,0 +1,30 @@
+//
+//  Bank.swift
+//  BankManagerConsoleApp
+//
+//  Created by Aaron, tottale on 11/3/22.
+//
+
+struct Bank {
+    
+    struct BankClerk {}
+    let clerk = BankClerk()
+    
+    func open() {}
+    
+    func close() {}
+    
+    func menu() {
+        print("1: 은행 개점")
+        print("2: 종료")
+        let menuNumber = readLine()
+        switch menuNumber {
+        case "1":
+            open()
+        case "2":
+            close()
+        default:
+            menu()
+        }
+    }
+}

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
@@ -4,16 +4,37 @@
 //
 //  Created by Aaron, tottale on 11/3/22.
 //
+import Foundation
 
 struct Bank {
     let clerk = BankClerk()
     let customerQueue = Queue<Customer>()
     
     func open() {
+        setupRandomCustomerQueue()
+        startBankJob()
+        menu()
+    }
+    
+    func setupRandomCustomerQueue() {
         Array(repeating: 0, count: Int.random(in: 10...30)).enumerated().forEach { index, number in
             customerQueue.enqueue(Customer(number: index+1))
         }
     }
+    
+    func startBankJob() {
+        let startTime = CFAbsoluteTimeGetCurrent()
+        var customerCount = 0
+        while let customer = customerQueue.dequeue() {
+            clerk.work(for: customer)
+            usleep(useconds_t(700000))
+            customerCount += 1
+        }
+        let endTime = CFAbsoluteTimeGetCurrent()
+        let timeInterval = endTime - startTime
+        print("업무가 마감되었습니다. 오늘 업무를 처리한 고객은 총 \(customerCount)명이며, 총 업무시간은 \(timeInterval)초입니다.")
+    }
+    
     func close() {}
     
     func menu() {

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
@@ -32,7 +32,12 @@ struct Bank {
         }
         let endTime = CFAbsoluteTimeGetCurrent()
         let timeInterval = endTime - startTime
-        print("업무가 마감되었습니다. 오늘 업무를 처리한 고객은 총 \(customerCount)명이며, 총 업무시간은 \(timeInterval)초입니다.")
+        
+        guard let formattedTime = timeInterval.formattedNumber else {
+            return
+        }
+        
+        print("업무가 마감되었습니다. 오늘 업무를 처리한 고객은 총 \(customerCount)명이며, 총 업무시간은 \(formattedTime)초입니다.")
     }
     
     func close() {}

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
@@ -11,20 +11,12 @@ struct Bank {
     let customerQueue = Queue<Customer>()
     
     func open() {
-        setupRandomCustomerQueue()
         startBankJob()
-        start()
-    }
-    
-    func setupRandomCustomerQueue() {
-        Array(repeating: 0, count: Int.random(in: 10...30)).enumerated().forEach { index, number in
-            customerQueue.enqueue(Customer(number: index+1))
-        }
     }
     
     func startBankJob() {
         let startTime = CFAbsoluteTimeGetCurrent()
-        var customerCount = manageCustomer()
+        let customerCount = manageCustomer()
         let endTime = CFAbsoluteTimeGetCurrent()
         let timeInterval = endTime - startTime
         
@@ -44,21 +36,4 @@ struct Bank {
     
     func close() {}
     
-    func printMenu() {
-        print("1: 은행 개점")
-        print("2: 종료")
-    }
-    
-    func start() {
-        printMenu()
-        let menuNumber = readLine()
-        switch menuNumber {
-        case "1":
-            open()
-        case "2":
-            close()
-        default:
-            start()
-        }
-    }
 }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
@@ -6,17 +6,20 @@
 //
 
 struct Bank {
-    
-    struct BankClerk {}
     let clerk = BankClerk()
+    let customerQueue = Queue<Customer>()
     
-    func open() {}
-    
+    func open() {
+        Array(repeating: 0, count: Int.random(in: 10...30)).enumerated().forEach { index, number in
+            customerQueue.enqueue(Customer(number: index+1))
+        }
+    }
     func close() {}
     
     func menu() {
         print("1: 은행 개점")
         print("2: 종료")
+        
         let menuNumber = readLine()
         switch menuNumber {
         case "1":

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
@@ -27,7 +27,7 @@ struct Bank {
         var customerCount = 0
         while let customer = customerQueue.dequeue() {
             clerk.work(for: customer)
-            usleep(useconds_t(700000))
+            
             customerCount += 1
         }
         let endTime = CFAbsoluteTimeGetCurrent()

--- a/BankManagerConsoleApp/BankManagerConsoleApp/BankClerk.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/BankClerk.swift
@@ -4,4 +4,11 @@
 //
 //  Created by Aaron, ttotale on 2022/11/03.
 //
-struct BankClerk {}
+import Foundation
+
+struct BankClerk {
+    
+    func work(for customer: Customer) {
+        print("\(customer.number)번 고객 업무 시작")
+    }
+}

--- a/BankManagerConsoleApp/BankManagerConsoleApp/BankClerk.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/BankClerk.swift
@@ -10,5 +10,7 @@ struct BankClerk {
     
     func work(for customer: Customer) {
         print("\(customer.number)번 고객 업무 시작")
+        usleep(useconds_t(700000))
+        print("\(customer.number)번 고객 업무 완료")
     }
 }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/BankClerk.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/BankClerk.swift
@@ -7,7 +7,6 @@
 import Foundation
 
 struct BankClerk {
-    
     func work(for customer: Customer) {
         print("\(customer.number)번 고객 업무 시작")
         usleep(useconds_t(700000))

--- a/BankManagerConsoleApp/BankManagerConsoleApp/BankClerk.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/BankClerk.swift
@@ -1,0 +1,7 @@
+//
+//  BankClerk.swift
+//  BankManagerConsoleApp
+//
+//  Created by Aaron, ttotale on 2022/11/03.
+//
+struct BankClerk {}

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Common/CFAbsoluteTime+.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Common/CFAbsoluteTime+.swift
@@ -8,12 +8,12 @@
 import Foundation
 
 extension CFAbsoluteTime {
-    var formattedNumber: String? {
+    var formattedNumber: String {
         let numberFormatter = NumberFormatter()
         
         numberFormatter.roundingMode = .floor
         numberFormatter.maximumSignificantDigits = 4
         
-        return numberFormatter.string(for: self)
+        return numberFormatter.string(for: self) ?? ""
     }
 }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Common/CFAbsoluteTime+.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Common/CFAbsoluteTime+.swift
@@ -1,0 +1,19 @@
+//
+//  CFAbsoluteTime+.swift
+//  BankManagerConsoleApp
+//
+//  Created by Aaron, ttotale on 2022/11/03.
+//
+
+import Foundation
+
+extension CFAbsoluteTime {
+    var formattedNumber: String? {
+        let numberFormatter = NumberFormatter()
+        
+        numberFormatter.roundingMode = .floor
+        numberFormatter.maximumSignificantDigits = 4
+        
+        return numberFormatter.string(for: self)
+    }
+}

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Customer.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Customer.swift
@@ -1,0 +1,10 @@
+//
+//  Customer.swift
+//  BankManagerConsoleApp
+//
+//  Created by Aaron, ttotale on 2022/11/03.
+//
+
+struct Customer {
+    var number: Int
+}

--- a/BankManagerConsoleApp/BankManagerConsoleApp/LinkedList.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/LinkedList.swift
@@ -18,13 +18,13 @@ final class LinkedList<T> {
     }
     
     func push(_ node: Node<T>) {
-        tail?.next = node
-        tail = node
-        
         if isEmpty {
             head = node
-            return
+        } else {
+            tail?.next = node
         }
+    
+        tail = node
     }
     
     func pop() -> Node<T>? {

--- a/BankManagerConsoleApp/BankManagerConsoleApp/main.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/main.swift
@@ -7,4 +7,30 @@
 import Foundation
 
 let bank = Bank()
-bank.start()
+start()
+
+func printMenu() {
+    print("1: 은행 개점")
+    print("2: 종료")
+    print("입력: ", terminator: "")
+}
+
+func start() {
+    printMenu()
+    let menuNumber = readLine()
+    switch menuNumber {
+    case "1":
+        setupRandomCustomerQueue()
+        bank.open()
+    case "2":
+        bank.close()
+    default:
+        start()
+    }
+}
+
+func setupRandomCustomerQueue() {
+    Array(repeating: 0, count: Int.random(in: 10...30)).enumerated().forEach { index, number in
+        bank.customerQueue.enqueue(Customer(number: index+1))
+    }
+}

--- a/BankManagerConsoleApp/BankManagerConsoleApp/main.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/main.swift
@@ -6,7 +6,7 @@
 
 import Foundation
 
-let bank = Bank()
+var bank: Bank = Bank(clerkCount: 1)
 start()
 
 func printMenu() {
@@ -30,7 +30,9 @@ func start() {
 }
 
 func setupRandomCustomerQueue() {
-    Array(repeating: 0, count: Int.random(in: 10...30)).enumerated().forEach { index, number in
+    let randomNumber = Int.random(in: 10...30)
+    bank.customerCount = randomNumber
+    Array(repeating: 0, count: randomNumber).enumerated().forEach { index, number in
         bank.customerQueue.enqueue(Customer(number: index+1))
     }
 }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/main.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/main.swift
@@ -5,3 +5,6 @@
 // 
 
 import Foundation
+
+let bank = Bank()
+bank.menu()

--- a/BankManagerConsoleApp/BankManagerConsoleApp/main.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/main.swift
@@ -7,4 +7,4 @@
 import Foundation
 
 let bank = Bank()
-bank.menu()
+bank.start()

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@
 |<img src="https://i.imgur.com/vE9Xqbh.gif" width="300px">|<img src="https://i.imgur.com/68Y8ozn.gif" width="300px">| -->
 > <img src="https://i.imgur.com/HZ4T4NK.gif" width="600px">
 
-## 🎯 트러블 슈팅 및 고민****
+## 🎯 트러블 슈팅 및 고민
 ### `push 메서드 로직`
 ```swift!
 class LinkedList<T> {

--- a/README.md
+++ b/README.md
@@ -1,6 +1,136 @@
-## iOS 커리어 스타터 캠프
+# 🏦Ios Bank Manager🏦
 
-### 은행 매니저 프로젝트 저장소
+## 🗒︎목차
+1. [소개](#-소개)
+2. [개발환경 및 라이브러리](#-개발환경-및-라이브러리)
+3. [팀원](#-팀원)
+4. [타임라인](#-타임라인)
+5. [파일구조](#-파일구조)<!-- 6. [UML](#-UML) -->
+6. [실행화면](#-실행-화면)
+7. [트러블 슈팅 및 고민](#-트러블-슈팅-및-고민)
+8. [참고링크](#-참고-링크)
 
-- 이 저장소를 자신의 저장소로 fork하여 프로젝트를 진행합니다
 
+## 👋 소개
+[Aaron](https://github.com/hashswim), [Tottale](https://github.com/tottalE)의 은행 창구 매니저 프로젝트입니다.
+
+
+## 💻 개발환경 및 라이브러리
+[![swift](https://img.shields.io/badge/swift-5.6-orange)]()
+[![xcode](https://img.shields.io/badge/Xcode-13.4.1-blue)]()
+
+![]()
+
+## 🧑 팀원
+|<img src = "https://i.imgur.com/I8UdM0C.png" width=200 height=170>|<img src = "https://i.imgur.com/ZykY6Vn.png" width=200 height=170> 
+|:--:|:--:|
+|[Aaron](https://github.com/hashswim)|[Tottale](https://github.com/tottalE)|
+ 
+
+## 🕖 타임라인
+### 2022.10.31
+- cocoapods `swiftlint` setting
+- `Linked List`, `Node`, `Queue` 클래스 생성 및 기본 구현 정의
+- `Linked List`의 `Push`, , `Clear`, `RemoveAll`, `Peek`, `isEmpty` 기능 메서드 구현
+- `Queue`의 `Enqueue`, `Dequeue`, `Clear`, `Peek`, `isEmpty` 기능 메서드 구현
+- `Queue` 클래스에 대한 유닛 테스트 진행
+
+### 2022.11.3
+- 네이밍 수정
+- `Bank`, `Customer`, `BankClerk` 클래스 정의
+-  고객 대기열 큐 타입 구현
+-  콘솔 메시지 출력 구현
+-  `usleep`을 통한 루프문 처리 구현
+
+
+## 💾 파일구조
+```
+└── BankManagerConsoleApp/
+    ├── common
+    │    └──CFAbsoluteTime+
+    |
+    ├── Appdelegate
+    ├── SceneDelegate
+    ├── Model
+    │   ├── BankManager
+    │   ├── LinkedList
+    │   ├── Queue
+    │   ├── Node
+    │   ├── Bank
+    │   ├── Customer
+    │   └── BankClerk
+    │
+    ├── View/
+    │   └── Main
+    └── Controller/
+```
+
+<!-- ## 📊 UML
+ > ![](https://i.imgur.com/55fQ8ms.png)
+ -->
+
+## 💻 실행 화면
+
+<!-- |일반 화면|다이나믹 타입 적용화면|
+|:----:|:----:|
+|<img src="https://i.imgur.com/vE9Xqbh.gif" width="300px">|<img src="https://i.imgur.com/68Y8ozn.gif" width="300px">| -->
+> <img src="https://i.imgur.com/HZ4T4NK.gif" width="600px">
+
+## 🎯 트러블 슈팅 및 고민****
+### `push 메서드 로직`
+```swift!
+class LinkedList<T> {
+    ...
+    
+    func push() {      
+        if self.isEmpty {
+            self.head = node
+            self.tail = node
+            return
+        }
+
+        self.tail?.next = node
+        self.tail = node
+    }
+    ...
+}
+
+```
+- `self.tail = node` 의 중복을 없애기 위해
+[다음](https://github.com/yagom-academy/ios-bank-manager/pull/214/commits/eba1e9f052f874584e140a9d039c101a3243da00)과 같이 수정 했으나 코드의 가독성과 직관성이 떨어져 아래와 같이 수정함
+
+```swift!
+class LinkedList<T> {
+    ...
+    
+    func push() {      
+        if self.isEmpty {
+            self.head = node
+        } else {
+            self.tail?.next = node
+        }
+        self.tail = node
+    ...
+}
+
+```
+
+
+### delay 구현
+```swift
+struct BankClerk {
+        
+    func work(for customer: Customer) {
+        print("\(customer.number)번 고객 업무 시작")
+        usleep(useconds_t(700000))
+        print("\(customer.number)번 고객 업무 완료")
+    }
+}
+```
+
+- `Timer`, `asyncAfter`, `DispatchSourceTimer` 등의 방법을 고려했지만 Step 2의 요구사항에만 맞도록 `usleep`을 사용하여 구현
+
+## 📚 참고 링크
+
+[Swift 지연실행 실험 - NSTimer, asyncAfter, DispatchSourceTimer
+](https://es1015.tistory.com/405) <br>


### PR DESCRIPTION
@junbangg
안녕하세요!
반갑습니다 알라딘:) 이번 스탭도 잘 부탁드리겠습니다! 💪🏽

## 개발한 내용
- 고객, 은행, 은행원 타입 구현
- 은행 내에 `open()`, `close()`, `menu()` 구현
- 은행에서 10~30사이의 랜덤한 명수의 손님들을 생성
- 은행에서 은행원이 손님들을 처리하도록 로직 구현
- `CFAbsoluteTimeGetCurrent()` 을 사용하여 시작 및 종료 시간을 측정해서 완료시에 보여주도록 함
- `CFAbsoluteTime`의 extension으로 fomat된 2자리 소수점의 string을 반환하도록 구현


## 고민한 점

### 1. 은행 업무 처리시간 sleep 메서드 사용
스위프트의 런타임 시간 지연방법중 `sleep()`메서드를 사용해 진행했지만 `Duration`타입의 파라미터에서 1초 미만의 시간을 설정하는데 어려움을 겪었습니다.

 Dispatch group을 사용하는 방법과 Timer를 사용하는 방법등 여러 방법을 사용해보다 
`usleep()` 메서드를 사용해 구현했습니다.

```swift
func work(for customer: Customer) {
        print("\(customer.number)번 고객 업무 시작")
        usleep(useconds_t(700000))
        print("\(customer.number)번 고객 업무 완료")
    }
```




### 2. DispatchQueue의 사용

- `DispatchQueue.main.asyncAfter()`을 사용하려 했지만 제대로 동작하지 않았고, DispatchGroup을 사용하여 이렇게 구현을 할 수 있는데, 불필요하다고 생각이 되어 일단 `usleep()`으로 구현을 해 주었습니다.
```swift
func work(for customer: Customer) {
    let group = DispatchGroup()
    group.enter()
    DispatchQueue.global().asyncAfter(deadline: .now() + 0.7) {
        print("\(customer.number)번 고객 업무 시작")
        group.leave()
    }
    group.wait()
}
```