### PR TITLE
은행창구 매니저 [STEP 3] Baem, Bella

### DIFF
--- a/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
+++ b/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		F60C035E2910ED800095E27E /* Node.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6DA96E22910BA1D00A67D80 /* Node.swift */; };
 		F60C035F2910EE020095E27E /* Node.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6DA96E22910BA1D00A67D80 /* Node.swift */; };
 		FC3A50B8291252F100490EF3 /* Customer.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC3A50B7291252F100490EF3 /* Customer.swift */; };
+		FC5713D82919270F0087A624 /* BankManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC5713D72919270F0087A624 /* BankManager.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -45,6 +46,7 @@
 		F605C7392918FEEE00E390F7 /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
 		F6DA96E22910BA1D00A67D80 /* Node.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Node.swift; sourceTree = "<group>"; };
 		FC3A50B7291252F100490EF3 /* Customer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Customer.swift; sourceTree = "<group>"; };
+		FC5713D72919270F0087A624 /* BankManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BankManager.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -121,6 +123,7 @@
 				0436C25A2912396C009266DE /* Bank.swift */,
 				FC3A50B7291252F100490EF3 /* Customer.swift */,
 				04D1B65B2919188700244A5F /* Task.swift */,
+				FC5713D72919270F0087A624 /* BankManager.swift */,
 			);
 			path = BankManagerConsoleApp;
 			sourceTree = "<group>";
@@ -269,6 +272,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				C7694E7A259C3EC00053667F /* main.swift in Sources */,
+				FC5713D82919270F0087A624 /* BankManager.swift in Sources */,
 				043E7B7D2910BB3D008E8F1A /* LinkedList.swift in Sources */,
 				0436C25B2912396C009266DE /* Bank.swift in Sources */,
 				FC3A50B8291252F100490EF3 /* Customer.swift in Sources */,

--- a/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
+++ b/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		0436C25B2912396C009266DE /* Bank.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0436C25A2912396C009266DE /* Bank.swift */; };
 		043E7B7D2910BB3D008E8F1A /* LinkedList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 043E7B7C2910BB3D008E8F1A /* LinkedList.swift */; };
 		043E7B9B2910CAD6008E8F1A /* LinkedListTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 043E7B9A2910CAD6008E8F1A /* LinkedListTests.swift */; };
+		04D1B65C2919188700244A5F /* Task.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04D1B65B2919188700244A5F /* Task.swift */; };
 		C7694E7A259C3EC00053667F /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7694E79259C3EC00053667F /* main.swift */; };
 		E58661CE012328C9D2F319F0 /* Pods_BankManagerConsoleApp.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 743D125E074CDE7564544C56 /* Pods_BankManagerConsoleApp.framework */; };
 		F60C035D2910ED6D0095E27E /* LinkedList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 043E7B7C2910BB3D008E8F1A /* LinkedList.swift */; };
@@ -35,6 +36,7 @@
 		043E7B7C2910BB3D008E8F1A /* LinkedList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkedList.swift; sourceTree = "<group>"; };
 		043E7B982910CAD6008E8F1A /* LinkedListTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = LinkedListTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		043E7B9A2910CAD6008E8F1A /* LinkedListTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkedListTests.swift; sourceTree = "<group>"; };
+		04D1B65B2919188700244A5F /* Task.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Task.swift; sourceTree = "<group>"; };
 		743D125E074CDE7564544C56 /* Pods_BankManagerConsoleApp.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_BankManagerConsoleApp.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		87120C213D4EA7799480A956 /* Pods-BankManagerConsoleApp.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BankManagerConsoleApp.release.xcconfig"; path = "Target Support Files/Pods-BankManagerConsoleApp/Pods-BankManagerConsoleApp.release.xcconfig"; sourceTree = "<group>"; };
 		C7694E76259C3EC00053667F /* BankManagerConsoleApp */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = BankManagerConsoleApp; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -118,6 +120,7 @@
 				043E7B7C2910BB3D008E8F1A /* LinkedList.swift */,
 				0436C25A2912396C009266DE /* Bank.swift */,
 				FC3A50B7291252F100490EF3 /* Customer.swift */,
+				04D1B65B2919188700244A5F /* Task.swift */,
 			);
 			path = BankManagerConsoleApp;
 			sourceTree = "<group>";
@@ -269,6 +272,7 @@
 				043E7B7D2910BB3D008E8F1A /* LinkedList.swift in Sources */,
 				0436C25B2912396C009266DE /* Bank.swift in Sources */,
 				FC3A50B8291252F100490EF3 /* Customer.swift in Sources */,
+				04D1B65C2919188700244A5F /* Task.swift in Sources */,
 				F60C035F2910EE020095E27E /* Node.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
@@ -7,7 +7,9 @@ import Foundation
 struct Bank {
     private let manager = BankManager()
     private var lineOfCustomer = LinkedList<Customer>()
-    let group = DispatchGroup()
+    private let group = DispatchGroup()
+    private let loanFront = 1
+    private let depositFront = 2
     
     mutating func selectMenu() {
         print(" 1 : 은행개점\n 2 : 종료\n입력 :", terminator: " ")
@@ -50,8 +52,8 @@ struct Bank {
     }
     
     private mutating func startTask() {
-        let loanSemaphore = DispatchSemaphore(value: 1)
-        let depoSemaphore = DispatchSemaphore(value: 2)
+        let loanSemaphore = DispatchSemaphore(value: loanFront)
+        let depoSemaphore = DispatchSemaphore(value: depositFront)
         
         while lineOfCustomer.isEmpty == false {
             guard let currentCustomer = lineOfCustomer.dequeue() else { break }
@@ -63,6 +65,7 @@ struct Bank {
                     manager.task(customer: currentCustomer)
                     manager.addDepositTime()
                     depoSemaphore.signal()
+                    manager.addCustomer()
                 }
             case .loan:
                 DispatchQueue.global().async(group: group) { [self] in
@@ -70,9 +73,9 @@ struct Bank {
                     manager.task(customer: currentCustomer)
                     manager.addLoanTime()
                     loanSemaphore.signal()
+                    manager.addCustomer()
                 }
             }
-            manager.addCustomer()
         }
     }
     

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
@@ -35,7 +35,7 @@ struct Bank {
         let totalCustomer = Int.random(in: 10...30)
         
         listUpCustomer(totalCustomer)
-//        startTask()
+        startTask()
         selectMenu()
     }
     
@@ -54,22 +54,7 @@ struct Bank {
         Int.random(in: 1...2) == 1 ? .deposit : .loan
     }
     
-//    mutating private func startTask() {
-//        taskTime = 0
-//        processedCustomer = 0
-//
-//        while lineOfCustomer.isEmpty == false {
-//            guard let currentCustomer = lineOfCustomer.dequeue() else {
-//                break
-//            }
-//            print("\(currentCustomer.waitingNumber)번 고객 업무 시작")
-//            taskTime += 0.7
-//            usleep(70_000)
-//            processedCustomer += 1
-//            print("\(currentCustomer.waitingNumber)번 고객 업무 종료")
-//        }
-//
-//        taskTime = round(taskTime * 100)/100
-//        print("업무가 마감되었습니다. 오늘 업무를 처리한 고객은 총 \(processedCustomer)명이며, 총 업무시간은 \(taskTime)초입니다.")
-//    }
+    func startTask() {
+        
+    }
 }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
@@ -5,9 +5,8 @@
 import Foundation
 
 struct Bank {
-    private let manager: [BankManager]
-    private var lineOfDepositCustomer = LinkedList<Customer>()
-    private var lineOfLoanCustomer = LinkedList<Customer>()
+    private let manager = BankManager()
+    private var lineOfCustomer = LinkedList<Customer>()
     private var processedCustomer: Int = 0
     private var taskTime: Double = 0
     
@@ -41,12 +40,7 @@ struct Bank {
     
     mutating private func listUpCustomer(_ customerCount: Int) {
         for customerIndex in 1...customerCount {
-            switch randomTask() {
-            case .deposit:
-                lineOfDepositCustomer.enqueue(value: Customer(waitingNumber: customerIndex, purposeOfServie: .deposit))
-            case .loan:
-                lineOfLoanCustomer.enqueue(value: Customer(waitingNumber: customerIndex, purposeOfServie: .loan))
-            }
+            lineOfCustomer.enqueue(value: Customer(waitingNumber: customerIndex, purposeOfServie: randomTask()))
         }
     }
     

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
@@ -60,22 +60,20 @@ struct Bank {
             
             switch currentCustomer.purposeOfServie {
             case .deposit:
-                DispatchQueue.global().async(group: group) { [self] in
-                    depoSemaphore.wait()
-                    manager.task(customer: currentCustomer)
-                    manager.addDepositTime()
-                    depoSemaphore.signal()
-                    manager.addCustomer()
-                }
+                dispatchTask(of: currentCustomer, using: depoSemaphore)
             case .loan:
-                DispatchQueue.global().async(group: group) { [self] in
-                    loanSemaphore.wait()
-                    manager.task(customer: currentCustomer)
-                    manager.addLoanTime()
-                    loanSemaphore.signal()
-                    manager.addCustomer()
-                }
+                dispatchTask(of: currentCustomer, using: loanSemaphore)
             }
+        }
+    }
+    
+    private func dispatchTask(of currentCustomer: Customer, using semaphore: DispatchSemaphore) {
+        DispatchQueue.global().async(group: group) { [self] in
+            semaphore.wait()
+            manager.task(customer: currentCustomer)
+            manager.addLoanTime()
+            semaphore.signal()
+            manager.addCustomer()
         }
     }
     

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
@@ -8,8 +8,8 @@ struct Bank {
     private let manager = BankManager()
     private var lineOfCustomer = LinkedList<Customer>()
     private let taskingGroup = DispatchGroup()
-    private let loanFront = 1
-    private let depositFront = 2
+    private let loanFront = Task.loan.front
+    private let depositFront = Task.deposit.front
     
     mutating func selectMenu() {
         print(" 1 : 은행개점\n 2 : 종료\n입력 :", terminator: " ")

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
@@ -44,11 +44,31 @@ struct Bank {
         }
     }
     
-    func randomTask() -> Task {
+    private func randomTask() -> Task {
         Int.random(in: 1...2) == 1 ? .deposit : .loan
     }
     
-    func startTask() {
+    private mutating func startTask() {
+        let loanSemaphore = DispatchSemaphore(value: 1)
+        let depoSemaphore = DispatchSemaphore(value: 2)
         
+        while lineOfCustomer.isEmpty == false {
+            guard let currentCustomer = lineOfCustomer.dequeue() else { break }
+            
+            switch currentCustomer.purposeOfServie {
+            case .deposit:
+                DispatchQueue.global().async { [self] in
+                    depoSemaphore.wait()
+                    manager.task(customer: currentCustomer)
+                    depoSemaphore.signal()
+                }
+            case .loan:
+                DispatchQueue.global().async { [self] in
+                    loanSemaphore.wait()
+                    manager.task(customer: currentCustomer)
+                    loanSemaphore.signal()
+                }
+            }
+        }
     }
 }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
@@ -7,7 +7,7 @@ import Foundation
 struct Bank {
     private let manager = BankManager()
     private var lineOfCustomer = LinkedList<Customer>()
-    private let group = DispatchGroup()
+    private let taskingGroup = DispatchGroup()
     private let loanFront = 1
     private let depositFront = 2
     
@@ -36,14 +36,14 @@ struct Bank {
         
         listUpCustomer(totalCustomer)
         startTask()
-        group.wait()
+        taskingGroup.wait()
         taskEnd()
         selectMenu()
     }
     
     mutating private func listUpCustomer(_ customerCount: Int) {
         for customerIndex in 1...customerCount {
-            lineOfCustomer.enqueue(value: Customer(waitingNumber: customerIndex, purposeOfServie: randomTask()))
+            lineOfCustomer.enqueue(value: Customer(waitingNumber: customerIndex, purposeOfService: randomTask()))
         }
     }
     
@@ -58,7 +58,7 @@ struct Bank {
         while lineOfCustomer.isEmpty == false {
             guard let currentCustomer = lineOfCustomer.dequeue() else { break }
             
-            switch currentCustomer.purposeOfServie {
+            switch currentCustomer.purposeOfService {
             case .deposit:
                 dispatchTask(of: currentCustomer, using: depoSemaphore)
             case .loan:
@@ -68,7 +68,7 @@ struct Bank {
     }
     
     private func dispatchTask(of currentCustomer: Customer, using semaphore: DispatchSemaphore) {
-        DispatchQueue.global().async(group: group) {
+        DispatchQueue.global().async(group: taskingGroup) {
             semaphore.wait()
             manager.task(customer: currentCustomer)
             manager.addLoanTime()

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
@@ -68,7 +68,7 @@ struct Bank {
     }
     
     private func dispatchTask(of currentCustomer: Customer, using semaphore: DispatchSemaphore) {
-        DispatchQueue.global().async(group: group) { [self] in
+        DispatchQueue.global().async(group: group) {
             semaphore.wait()
             manager.task(customer: currentCustomer)
             manager.addLoanTime()

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
@@ -5,8 +5,9 @@
 import Foundation
 
 struct Bank {
-    private let manager: Int = 1
-    private var lineOfCustomer = LinkedList<Customer>()
+    private let manager: [BankManager]
+    private var lineOfDepositCustomer = LinkedList<Customer>()
+    private var lineOfLoanCustomer = LinkedList<Customer>()
     private var processedCustomer: Int = 0
     private var taskTime: Double = 0
     
@@ -34,33 +35,41 @@ struct Bank {
         let totalCustomer = Int.random(in: 10...30)
         
         listUpCustomer(totalCustomer)
-        startTask()
+//        startTask()
         selectMenu()
     }
     
     mutating private func listUpCustomer(_ customerCount: Int) {
         for customerIndex in 1...customerCount {
-//            lineOfCustomer.enqueue(value: Customer(waitingNumber: customerIndex))
+            switch randomTask() {
+            case .deposit:
+                lineOfDepositCustomer.enqueue(value: Customer(waitingNumber: customerIndex, purposeOfServie: .deposit))
+            case .loan:
+                lineOfLoanCustomer.enqueue(value: Customer(waitingNumber: customerIndex, purposeOfServie: .loan))
+            }
         }
     }
     
-    mutating private func startTask() {
-        taskTime = 0
-        processedCustomer = 0
-        
-        while lineOfCustomer.isEmpty == false {
-            guard let currentCustomer = lineOfCustomer.dequeue() else {
-                break
-            }
-
-            print("\(currentCustomer.waitingNumber)번 고객 업무 시작")
-            taskTime += 0.7
-            usleep(70_000)
-            processedCustomer += 1
-            print("\(currentCustomer.waitingNumber)번 고객 업무 종료")
-        }
-        
-        taskTime = round(taskTime * 100)/100
-        print("업무가 마감되었습니다. 오늘 업무를 처리한 고객은 총 \(processedCustomer)명이며, 총 업무시간은 \(taskTime)초입니다.")
+    func randomTask() -> Task {
+        Int.random(in: 1...2) == 1 ? .deposit : .loan
     }
+    
+//    mutating private func startTask() {
+//        taskTime = 0
+//        processedCustomer = 0
+//
+//        while lineOfCustomer.isEmpty == false {
+//            guard let currentCustomer = lineOfCustomer.dequeue() else {
+//                break
+//            }
+//            print("\(currentCustomer.waitingNumber)번 고객 업무 시작")
+//            taskTime += 0.7
+//            usleep(70_000)
+//            processedCustomer += 1
+//            print("\(currentCustomer.waitingNumber)번 고객 업무 종료")
+//        }
+//
+//        taskTime = round(taskTime * 100)/100
+//        print("업무가 마감되었습니다. 오늘 업무를 처리한 고객은 총 \(processedCustomer)명이며, 총 업무시간은 \(taskTime)초입니다.")
+//    }
 }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
@@ -77,7 +77,9 @@ struct Bank {
     }
     
     func taskEnd() {
-        let time = manager.depositTimer > manager.loanTimer ? manager.depositTimer : manager.loanTimer
-        print("업무가 마감되었습니다. 오늘 업무를 처리한 고객은 총 \(manager.processedCustomer)명이며, 총 업무시간은 \(time)초입니다.")
+        var taskTime = manager.depositTimer > manager.loanTimer ? manager.depositTimer : manager.loanTimer
+        taskTime = Double(round(taskTime * 100) / 100)
+        print("업무가 마감되었습니다. 오늘 업무를 처리한 고객은 총 \(manager.processedCustomer)명이며, 총 업무시간은 \(taskTime)초입니다.")
+        manager.managerClear()
     }
 }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
@@ -7,8 +7,6 @@ import Foundation
 struct Bank {
     private let manager = BankManager()
     private var lineOfCustomer = LinkedList<Customer>()
-    private var processedCustomer: Int = 0
-    private var taskTime: Double = 0
     
     mutating func selectMenu() {
         print(" 1 : 은행개점\n 2 : 종료\n입력 :", terminator: " ")
@@ -60,12 +58,14 @@ struct Bank {
                 DispatchQueue.global().async { [self] in
                     depoSemaphore.wait()
                     manager.task(customer: currentCustomer)
+                    manager.addDepositTime()
                     depoSemaphore.signal()
                 }
             case .loan:
                 DispatchQueue.global().async { [self] in
                     loanSemaphore.wait()
                     manager.task(customer: currentCustomer)
+                    manager.addLoanTime()
                     loanSemaphore.signal()
                 }
             }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
@@ -40,7 +40,7 @@ struct Bank {
     
     mutating private func listUpCustomer(_ customerCount: Int) {
         for customerIndex in 1...customerCount {
-            lineOfCustomer.enqueue(value: Customer(waitingNumber: customerIndex))
+//            lineOfCustomer.enqueue(value: Customer(waitingNumber: customerIndex))
         }
     }
     

--- a/BankManagerConsoleApp/BankManagerConsoleApp/BankManager.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/BankManager.swift
@@ -14,10 +14,10 @@ class BankManager {
     private var loanTimer: TimeInterval = 0
     private var processedCustomer: Int = 0
     
-    func startTask(_ lineOfCustomer1: LinkedList<Customer>) {
+    func startTask(_ customerList: LinkedList<Customer>) {
         let loanSemaphore = DispatchSemaphore(value: loanFront)
         let depoSemaphore = DispatchSemaphore(value: depositFront)
-        var lineOfCustomer = lineOfCustomer1
+        var lineOfCustomer = customerList
         
         while lineOfCustomer.isEmpty == false {
             guard let currentCustomer = lineOfCustomer.dequeue() else { break }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/BankManager.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/BankManager.swift
@@ -4,7 +4,18 @@
 //  Copyright © yagom academy. All rights reserved.
 //
 
+import Foundation
+
 struct BankManager {
-    let nickName: String
-    let task: Task
+    func task(customer: Customer) {
+        print("\(customer.waitingNumber)번 고객 \(customer.purposeOfServie.rawValue)업무 시작")
+        
+        switch customer.purposeOfServie {
+        case .deposit:
+            usleep(700000)
+        case .loan:
+            usleep(1100000)
+        }
+        print("\(customer.waitingNumber)번 고객 \(customer.purposeOfServie.rawValue)업무 종료")
+    }
 }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/BankManager.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/BankManager.swift
@@ -36,7 +36,12 @@ class BankManager {
         DispatchQueue.global().async(group: taskingGroup) {
             semaphore.wait()
             self.task(customer: currentCustomer)
-            self.addLoanTime()
+            switch currentCustomer.purposeOfService {
+            case .deposit:
+                self.addDepositTime()
+            case .loan:
+                self.addLoanTime()
+            }
             semaphore.signal()
             self.addCustomer()
         }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/BankManager.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/BankManager.swift
@@ -7,11 +7,42 @@
 import Foundation
 
 class BankManager {
-    var depositTimer: Double = 0
-    var loanTimer: Double = 0
-    var processedCustomer: Int = 0
+    private let taskingGroup = DispatchGroup()
+    private let loanFront = Task.loan.front
+    private let depositFront = Task.deposit.front
+    private var depositTimer: TimeInterval = 0
+    private var loanTimer: TimeInterval = 0
+    private var processedCustomer: Int = 0
     
-    func task(customer: Customer) {
+    func startTask(_ lineOfCustomer1: LinkedList<Customer>) {
+        let loanSemaphore = DispatchSemaphore(value: loanFront)
+        let depoSemaphore = DispatchSemaphore(value: depositFront)
+        var lineOfCustomer = lineOfCustomer1
+        
+        while lineOfCustomer.isEmpty == false {
+            guard let currentCustomer = lineOfCustomer.dequeue() else { break }
+            
+            switch currentCustomer.purposeOfService {
+            case .deposit:
+                dispatchTask(of: currentCustomer, using: depoSemaphore)
+            case .loan:
+                dispatchTask(of: currentCustomer, using: loanSemaphore)
+            }
+        }
+        taskingGroup.wait()
+    }
+    
+    private func dispatchTask(of currentCustomer: Customer, using semaphore: DispatchSemaphore) {
+        DispatchQueue.global().async(group: taskingGroup) {
+            semaphore.wait()
+            self.task(customer: currentCustomer)
+            self.addLoanTime()
+            semaphore.signal()
+            self.addCustomer()
+        }
+    }
+    
+    private func task(customer: Customer) {
         print("\(customer.waitingNumber)번 고객 \(customer.purposeOfService.rawValue)업무 시작")
         
         switch customer.purposeOfService {
@@ -23,21 +54,28 @@ class BankManager {
         print("\(customer.waitingNumber)번 고객 \(customer.purposeOfService.rawValue)업무 종료")
     }
     
-    func addDepositTime () {
+    func endTask() {
+        var taskTime = depositTimer > loanTimer ? depositTimer : loanTimer
+        taskTime = Double(round(taskTime * 100) / 100)
+        print("업무가 마감되었습니다. 오늘 업무를 처리한 고객은 총 \(processedCustomer)명이며, 총 업무시간은 \(taskTime)초입니다.")
+        managerClear()
+    }
+    
+    private func addDepositTime () {
         depositTimer += 0.7
     }
     
-    func addLoanTime() {
+    private func addLoanTime() {
         loanTimer += 1.1
     }
     
-    func addCustomer() {
+    private func addCustomer() {
         processedCustomer += 1
     }
     
-    func managerClear() {
+    private func managerClear() {
         depositTimer = 0
         loanTimer = 0
-        processedCustomer = 0 
+        processedCustomer = 0
     }
 }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/BankManager.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/BankManager.swift
@@ -28,7 +28,7 @@ class BankManager {
     }
     
     func addLoanTime() {
-        LoanTimer += 1.1
+        loanTimer += 1.1
     }
     
     func addCustomer() {
@@ -40,6 +40,4 @@ class BankManager {
         loanTimer = 0
         processedCustomer = 0 
     }
-    
-    
 }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/BankManager.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/BankManager.swift
@@ -12,15 +12,15 @@ class BankManager {
     var processedCustomer: Int = 0
     
     func task(customer: Customer) {
-        print("\(customer.waitingNumber)번 고객 \(customer.purposeOfServie.rawValue)업무 시작")
+        print("\(customer.waitingNumber)번 고객 \(customer.purposeOfService.rawValue)업무 시작")
         
-        switch customer.purposeOfServie {
+        switch customer.purposeOfService {
         case .deposit:
-            usleep(700000)
+            usleep(700_000)
         case .loan:
-            usleep(1100000)
+            usleep(1_100_000)
         }
-        print("\(customer.waitingNumber)번 고객 \(customer.purposeOfServie.rawValue)업무 종료")
+        print("\(customer.waitingNumber)번 고객 \(customer.purposeOfService.rawValue)업무 종료")
     }
     
     func addDepositTime () {

--- a/BankManagerConsoleApp/BankManagerConsoleApp/BankManager.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/BankManager.swift
@@ -6,7 +6,11 @@
 
 import Foundation
 
-struct BankManager {
+class BankManager {
+    var depositTimer: Double = 0
+    var loanTimer: Double = 0
+    var processedCustomer: Int = 0
+    
     func task(customer: Customer) {
         print("\(customer.waitingNumber)번 고객 \(customer.purposeOfServie.rawValue)업무 시작")
         
@@ -18,4 +22,24 @@ struct BankManager {
         }
         print("\(customer.waitingNumber)번 고객 \(customer.purposeOfServie.rawValue)업무 종료")
     }
+    
+    func addDepositTime () {
+        depositTimer += 0.7
+    }
+    
+    func addLoanTime() {
+        LoanTimer += 1.1
+    }
+    
+    func addCustomer() {
+        processedCustomer += 1
+    }
+    
+    func managerClear() {
+        depositTimer = 0
+        loanTimer = 0
+        processedCustomer = 0 
+    }
+    
+    
 }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/BankManager.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/BankManager.swift
@@ -1,0 +1,10 @@
+//
+//  BankManager.swift
+//  Created by yagom.
+//  Copyright © yagom academy. All rights reserved.
+//
+
+struct BankManager {
+    let nickName: String
+    let task: Task
+}

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Customer.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Customer.swift
@@ -4,5 +4,5 @@
 
 struct Customer {
     let waitingNumber: Int
-    let purposeOfServie: Task
+    let purposeOfService: Task
 }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Customer.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Customer.swift
@@ -4,4 +4,5 @@
 
 struct Customer {
     let waitingNumber: Int
+    let purposeOfServie: Task
 }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Task.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Task.swift
@@ -2,7 +2,7 @@
 //  BankManagerConsoleApp
 //  Created by Baem & Bella on 2022/11/07.
 
-enum Task {
-    case deposit
-    case loan
+enum Task: String {
+    case deposit = "예금"
+    case loan = "대출"
 }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Task.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Task.swift
@@ -1,0 +1,8 @@
+//  Task.swift
+//  BankManagerConsoleApp
+//  Created by Baem & Bella on 2022/11/07.
+
+enum Task {
+    case deposit
+    case loan
+}

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Task.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Task.swift
@@ -5,4 +5,13 @@
 enum Task: String {
     case deposit = "예금"
     case loan = "대출"
+    
+    var front: Int {
+        switch self {
+        case .deposit:
+            return 2
+        case .loan:
+            return 1
+        }
+    }
 }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/main.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/main.swift
@@ -2,3 +2,6 @@
 //  Created by Baem & Bella on 2022/11/02.
 //  Copyright © yagom academy. All rights reserved.
 
+var bank = Bank()
+
+bank.selectMenu()

--- a/BankManagerConsoleApp/BankManagerConsoleApp/main.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/main.swift
@@ -2,8 +2,3 @@
 //  Created by Baem & Bella on 2022/11/02.
 //  Copyright © yagom academy. All rights reserved.
 
-import Foundation
-
-var bank: Bank = Bank()
-
-bank.selectMenu()

--- a/BankManagerConsoleApp/Pods/Pods.xcodeproj/project.pbxproj
+++ b/BankManagerConsoleApp/Pods/Pods.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 			dependencies = (
 			);
 			name = SwiftLint;
+			productName = SwiftLint;
 		};
 /* End PBXAggregateTarget section */
 
@@ -45,7 +46,7 @@
 		7CEDD4CE6542936F0A14C08C753CDD0A /* Pods-BankManagerConsoleApp-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-BankManagerConsoleApp-acknowledgements.markdown"; sourceTree = "<group>"; };
 		7EAB1DA481EDDC005A251D3A5E6BE4CD /* SwiftLint.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = SwiftLint.release.xcconfig; sourceTree = "<group>"; };
 		8F480A25914524A43FF97634FA26163E /* Pods-BankManagerConsoleApp-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-BankManagerConsoleApp-umbrella.h"; sourceTree = "<group>"; };
-		9D940727FF8FB9C785EB98E56350EF41 /* Podfile */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; indentWidth = 2; lastKnownFileType = text; name = Podfile; path = ../Podfile; sourceTree = SOURCE_ROOT; tabWidth = 2; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
+		9D940727FF8FB9C785EB98E56350EF41 /* Podfile */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; indentWidth = 2; name = Podfile; path = ../Podfile; sourceTree = SOURCE_ROOT; tabWidth = 2; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
 		C1430F003D39D9906881A6AC724B7931 /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk/System/Library/Frameworks/Cocoa.framework; sourceTree = DEVELOPER_DIR; };
 		C5096E91B57DDCA493CCFA3F4713FA30 /* Pods-BankManagerConsoleApp-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-BankManagerConsoleApp-acknowledgements.plist"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -120,7 +121,6 @@
 			children = (
 				7FDA596DBE0337ACDFE55A210D54EF26 /* Support Files */,
 			);
-			name = SwiftLint;
 			path = SwiftLint;
 			sourceTree = "<group>";
 		};


### PR DESCRIPTION
@uuu1101 
안녕하세요 태태! 🙌🏼
은행창구 매니저 [STEP 3] p.r을 보냅니다! 잘 부탁드립니다! 🙆🏻‍♀️🙆🏻‍♂️ 

### [고민했던 점]
#### 동기 비동기 사용
- 예금 업무와 대출 업무를 `DispatchQueue.global().sync` 로 보내게 될 경우에, 예금 업무와 대출 업무가 동시에 처리되지 않고 하나씩 처리되어 프로젝트의 요구사항과 맞지 않다고 생각되어, `async`로 처리하게 되었습니다. 

#### DispatchSemaphore 사용
- 예금과 대출 업무를 `global.async` 를 이용하여 보낼 경우에, 랜덤하게 생성한 고객 수 만큼(필요한 만큼) 쓰레드를 생성하게 되었습니다. 이를 해결하기 위해, `DispatchSemaphore`와 `SerialQueue` 두 가지 방법 중에 고민하게 되었으며 예금 업무와 대출 업무의 쓰레드의 개수를 DispatchSemaphore의 value 를 이용하여 지정해주게 되었습니다. 

#### 큐의 사용
- 처음 `예금 큐` `대출 큐` 를 따로 만들어서 사용하고자 하였습니다. 그러나, Bank 타입 내부에 예금 매니저 2명과 대출 매니저 1명을 생성했고, 예금 매니저에게 예금 큐에 들어있는 고객을 처리하도록 구현해보았으나 구현에 실패하게 되었습니다.🥲
그래서, 일단은 구현에 목적을 두고 고객대기열을 단일 큐로 만들었으며 고객을 enqueue() 할 때에 예금과 대출 업무를 랜덤하게 넣어주게 되었습니다. 

### [조언이 필요한 점]

#### 뱅크매니저
- 앞서 큐의 사용에서 기재한 내용과 이어지는 부분입니다. `BankManger` 를 은행원이라 생각 한 후 예금처리하는 은행원 2명, 대출 처리하는 은행원 1명이라 생각하고 `Bank` 타입을 은행 창구라고 생각해서 은행원들을 처리해주는 곳에 따라 넣어주고자 하였습니다. 
하지만 너무 방대한 생각이여서, 결국은 하나의 고객대기열에 각각의 업무에 따라 쓰레드가 접근하도록 하였으며 접근할 수 있는 스레드의 개수를 `Semaphore`를 사용해서 예금과 대출 업무를 처리하도록 구현하였습니다.

``` swift
mutating private func startTask() {
    ...

    
        while lineOfLoanCustomer.isEmpty == false {
            guard let currentCustomer = lineOfLoanCustomer.dequeue() else { break }
            DispatchQueue.global().sync {
                loan1.task(customer: currentCustomer)
            }
        }
        while lineOfDepositCustomer.isEmpty == false {
            guard let currentCustomer = lineOfDepositCustomer.dequeue() else { break }
            DispatchQueue.global().sync {
                depo1.task(customer: currentCustomer)
            }
        }
// 위에서 이미 lineOfDepositCustomer가 비어있는 상태라, 아래 코드가 실행되지 않음!!🥲
        while lineOfDepositCustomer.isEmpty == false {
            guard let currentCustomer = lineOfDepositCustomer.dequeue() else { break }
            DispatchQueue.global().sync {
                depo2.task(customer: currentCustomer)
            }
    ...
        }
```

#### Struct, class로 변경 (클로저 캡쳐)
- `struct Bankmanager` 의 타입이 Struct일 때, `Bank`의 DispatchQueue 에서 사용하면 불변하는 값이기 때문에 변경 할 수 없다라는 클로저 캡처와 관련된 오류가 발생 하였습니다. 아래 사진 첨부했습니다!

![](https://i.imgur.com/2CUCsq8.png)

- 고민해보며 캡쳐드리스트를 이용하여 오류를 해결해보고자 하였으나 해결되지 않았고, 어떻게 해야할지 몰라 타입 자체를 struct -> class로 변경하여 오류를 해결 했습니다.