### PR TITLE
은행창구 매니저 [STEP 3] Gundy, jpush

### DIFF
--- a/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
+++ b/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
@@ -11,8 +11,8 @@
 		AC8E36662914B4D200C25FEA /* Bank.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC8E36642914B4D200C25FEA /* Bank.swift */; };
 		AC8E36682914B4FF00C25FEA /* BankProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC8E36672914B4FF00C25FEA /* BankProtocol.swift */; };
 		AC8E36692914B4FF00C25FEA /* BankProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC8E36672914B4FF00C25FEA /* BankProtocol.swift */; };
-		AC8E366B2914B55400C25FEA /* Banker.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC8E366A2914B55400C25FEA /* Banker.swift */; };
-		AC8E366C2914B55400C25FEA /* Banker.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC8E366A2914B55400C25FEA /* Banker.swift */; };
+		AC8E366B2914B55400C25FEA /* BankDesk.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC8E366A2914B55400C25FEA /* BankDesk.swift */; };
+		AC8E366C2914B55400C25FEA /* BankDesk.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC8E366A2914B55400C25FEA /* BankDesk.swift */; };
 		BF32254F2914A87E0097B1A6 /* BankCustomer.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF32254E2914A87E0097B1A6 /* BankCustomer.swift */; };
 		BF3225512914A8DB0097B1A6 /* BankCustomerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF3225502914A8DB0097B1A6 /* BankCustomerTests.swift */; };
 		BF3225532914A8F90097B1A6 /* BankCustomer.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF32254E2914A87E0097B1A6 /* BankCustomer.swift */; };
@@ -40,7 +40,7 @@
 /* Begin PBXFileReference section */
 		AC8E36642914B4D200C25FEA /* Bank.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Bank.swift; sourceTree = "<group>"; };
 		AC8E36672914B4FF00C25FEA /* BankProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BankProtocol.swift; sourceTree = "<group>"; };
-		AC8E366A2914B55400C25FEA /* Banker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Banker.swift; sourceTree = "<group>"; };
+		AC8E366A2914B55400C25FEA /* BankDesk.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BankDesk.swift; sourceTree = "<group>"; };
 		BF32254E2914A87E0097B1A6 /* BankCustomer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BankCustomer.swift; sourceTree = "<group>"; };
 		BF3225502914A8DB0097B1A6 /* BankCustomerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BankCustomerTests.swift; sourceTree = "<group>"; };
 		BF3225822919EC570097B1A6 /* CustomerType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomerType.swift; sourceTree = "<group>"; };
@@ -74,7 +74,7 @@
 		AC8E366D2914B5DC00C25FEA /* Bank */ = {
 			isa = PBXGroup;
 			children = (
-				AC8E366A2914B55400C25FEA /* Banker.swift */,
+				AC8E366A2914B55400C25FEA /* BankDesk.swift */,
 				AC8E36642914B4D200C25FEA /* Bank.swift */,
 				AC8E36672914B4FF00C25FEA /* BankProtocol.swift */,
 				BF32254E2914A87E0097B1A6 /* BankCustomer.swift */,
@@ -225,7 +225,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				AC8E366C2914B55400C25FEA /* Banker.swift in Sources */,
+				AC8E366C2914B55400C25FEA /* BankDesk.swift in Sources */,
 				BF3225512914A8DB0097B1A6 /* BankCustomerTests.swift in Sources */,
 				BFF51E0E2910DD62000E2EA3 /* BankManagerConsoleAppTests.swift in Sources */,
 				AC8E36662914B4D200C25FEA /* Bank.swift in Sources */,
@@ -242,7 +242,7 @@
 				AC8E36682914B4FF00C25FEA /* BankProtocol.swift in Sources */,
 				C7694E7A259C3EC00053667F /* main.swift in Sources */,
 				BF3225832919EC570097B1A6 /* CustomerType.swift in Sources */,
-				AC8E366B2914B55400C25FEA /* Banker.swift in Sources */,
+				AC8E366B2914B55400C25FEA /* BankDesk.swift in Sources */,
 				AC8E36652914B4D200C25FEA /* Bank.swift in Sources */,
 				C7D65D1B259C8190005510E0 /* BankManager.swift in Sources */,
 				BF32254F2914A87E0097B1A6 /* BankCustomer.swift in Sources */,

--- a/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,14 +1,16 @@
 {
-  "pins" : [
-    {
-      "identity" : "bankcustomerqueue",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/jjpush/BankCustomerQueue.git",
-      "state" : {
-        "branch" : "main",
-        "revision" : "99755b2e7d7074d976379596db750d7841100bb7"
+  "object": {
+    "pins": [
+      {
+        "package": "BankCustomerQueue",
+        "repositoryURL": "https://github.com/jjpush/BankCustomerQueue.git",
+        "state": {
+          "branch": "main",
+          "revision": "99755b2e7d7074d976379596db750d7841100bb7",
+          "version": null
+        }
       }
-    }
-  ],
-  "version" : 2
+    ]
+  },
+  "version": 1
 }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Bank/Bank.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Bank/Bank.swift
@@ -28,21 +28,26 @@ struct Bank: BankProtocol {
     
     private let constant: Constant = .init()
     private var depositDesk: BankDesk
+    private var loanDesk: BankDesk
+    
     private var customerQueue: BankCustomerQueue<BankCustomer>
     private var depositCustomerQueue: BankCustomerQueue<BankCustomer>
     private var loanCustomerQueue: BankCustomerQueue<BankCustomer>
+    
     private static var completedCustomerCount: Int = .zero
     private var totalWorkedTime: TimeInterval = .zero
+    
     private let group: DispatchGroup = .init()
     
-    init(depositBankerCount: Int) {
+    init(depositBankerCount: Int, loanBankerCount: Int) {
         self.depositDesk = BankDesk(banker: depositBankerCount)
+        self.loanDesk = BankDesk(banker: loanBankerCount)
+        
         self.customerQueue = .init()
         self.depositCustomerQueue = .init()
         self.loanCustomerQueue = .init()
         
-        arrangeCustomer()
-        separateCustomer()
+        configure()
     }
     
     private mutating func arrangeCustomer() {
@@ -74,12 +79,21 @@ struct Bank: BankProtocol {
             switch menu {
             case constant.openOption:
                 open()
+                configure()
             case constant.closeOption:
                 return
             default:
                 print(constant.invalidInput)
             }
         }
+    }
+    
+    private mutating func configure() {
+        arrangeCustomer()
+        separateCustomer()
+        
+        Self.completedCustomerCount = .zero
+        BankCustomer.resetCustomerNumber()
     }
     
     private func floatingMenu() {
@@ -89,6 +103,7 @@ struct Bank: BankProtocol {
     private mutating func open() {
         let startTime = Date()
         deposit()
+        
         group.wait()
         let endTime = Date()
         self.totalWorkedTime = endTime.timeIntervalSince(startTime)

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Bank/BankCustomer.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Bank/BankCustomer.swift
@@ -15,4 +15,8 @@ struct BankCustomer {
         self.waitingNumber = Self.customerNumber
         self.type = CustomerType.allCases.randomElement() ?? .deposit
     }
+    
+    static func resetCustomerNumber() {
+        Self.customerNumber = 0
+    }
 }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Bank/BankCustomer.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Bank/BankCustomer.swift
@@ -13,6 +13,6 @@ struct BankCustomer {
     init(customerType: CustomerType) {
         Self.customerNumber += 1
         self.waitingNumber = Self.customerNumber
-        self.type = customerType
+        self.type = CustomerType.allCases.randomElement() ?? .deposit
     }
 }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Bank/BankDesk.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Bank/BankDesk.swift
@@ -1,5 +1,5 @@
 //
-//  Banker.swift
+//  BankDesk.swift
 //  BankManagerConsoleApp
 //
 //  Created by Gundy, jpush on 2022/11/04.
@@ -7,13 +7,21 @@
 
 import Foundation
 
-struct Banker {
+struct BankDesk {
+    let banker: DispatchSemaphore
+    
+    init(banker: Int) {
+        self.banker = .init(value: banker)
+    }
+    
     func work(_ customer: BankCustomer) {
         let waitingNumber = customer.waitingNumber
         let workType = customer.type.description
         
+        banker.wait()
         print("\(waitingNumber)번 고객 \(workType)업무 시작")
         Thread.sleep(forTimeInterval: customer.type.wasteSeconds)
         print("\(waitingNumber)번 고객 \(workType)업무 완료")
+        banker.signal()
     }
 }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Bank/Banker.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Bank/Banker.swift
@@ -9,8 +9,11 @@ import Foundation
 
 struct Banker {
     func work(_ customer: BankCustomer) {
-        print("\(customer.waitingNumber)번 고객 업무 시작")
+        let waitingNumber = customer.waitingNumber
+        let workType = customer.type.description
+        
+        print("\(waitingNumber)번 고객 \(workType)업무 시작")
         Thread.sleep(forTimeInterval: customer.type.wasteSeconds)
-        print("\(customer.waitingNumber)번 고객 업무 완료")
+        print("\(waitingNumber)번 고객 \(workType)업무 완료")
     }
 }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Bank/CustomerType.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Bank/CustomerType.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-enum CustomerType {
+enum CustomerType: CaseIterable {
     case deposit
     case loan
     
@@ -17,6 +17,15 @@ enum CustomerType {
             return 0.7
         case .loan:
             return 1.1
+        }
+    }
+    
+    var description: String {
+        switch self {
+        case .deposit:
+            return "예금"
+        case .loan:
+            return "대출"
         }
     }
 }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/main.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/main.swift
@@ -7,6 +7,6 @@
 import Foundation
 import BankCustomerQueue
 
-var bank: Bank = Bank(depositBankerCount: 2)
+var bank: Bank = Bank(depositBankerCount: 2, loanBankerCount: 1)
 
 bank.startBusiness()

--- a/BankManagerConsoleApp/BankManagerConsoleApp/main.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/main.swift
@@ -7,8 +7,6 @@
 import Foundation
 import BankCustomerQueue
 
-var bank: Bank = Bank()
+var bank: Bank = Bank(depositBankerCount: 2)
 
 bank.startBusiness()
-
-

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@
     - POP
     - TDD
     - NameSpace
+    - Operation
+    - DispatchQueue
 
 ## 📆 타임라인
 
@@ -60,7 +62,26 @@
         - open, floatingMenu, work, close, init
     - 중첩타입으로 Constant 구현
 </details>
+ 
+<details>
+<summary>STEP 2 Feedback 반영</summary>
+
+221108
     
+- 내부 Constant 타입을 enum 에서 struct로 변경 및 CustomerType 추가
+- open 메서드의 네이밍 변경 및 기능을 쪼개서 분리
+</details>
+<details>
+    
+<summary>STEP 3</summary>
+
+221108
+    
+- 예금 업무를 처리하는 deposit() 메서드 구현
+- 업무 마감 후 초기화 시키는 configure 메서드 구현
+- 대출 업무를 처리하는 loan() 메서드 구현
+</details> 
+
 ## 👀 시각화된 프로젝트 구조
 
 ### TREE
@@ -70,8 +91,9 @@
 │   ├── Bank
 │   │   ├── Bank.swift
 │   │   ├── BankCustomer.swift
+│   │   ├── CustomerType.swift
 │   │   ├── BankProtocol.swift
-│   │   └── Banker.swift
+│   │   └── BankDesk.swift
 │   └── main.swift
 ├── BankManagerConsoleAppTests
 │   ├── BankCustomerTests.swift
@@ -86,29 +108,73 @@
         └── Queue.swift
 ```
 
+### 실행 로직
+![](https://i.imgur.com/TBmcoQz.png)
+
+CustomerQueue에 고객을 담고
+각 타입별로 deposit과 loan으로 나누어 준 뒤
+타입의 CustomerQueue에서 DispatchQueue.global.async로 Task를 실행해줍니다.
+
+각각의 DispatchQueue는 하나의 그룹에 넣어서 그룹이 다 끝날 때까지 기다린 후 업무 마감 메세지를 출력하도록 구성했습니다.
+
 ## 💻 실행 화면
 
-STEP2 실행화면
 
-![](https://i.imgur.com/Uv04ICE.gif)
+| 동기로 실행되는 화면 | 비동기로 실행되는 화면 |
+|:--:|:--:|
+|![](https://i.imgur.com/Uv04ICE.gif)|![](https://i.imgur.com/GbOgG0K.gif)|
+
 
 ## ❓ 트러블 슈팅
 
 ### Equatable
+<details>
+<summary>자세히</summary>
 Queue에서 꺼낸 Queueable 타입의 값을 Equatable을 채택해주어 비교할 수 있도록 하고 싶었습니다.
+
 ![](https://i.imgur.com/VoYAGwz.png)
 
 이부분을 해결하기 위하여 찾아보니 내부 요소인 Queueable 타입에 Equatable인 타입이 들어올 수 있도록 처리를 해 주었으나 잘 해결되지 않았고 직접적으로 Queue의 타입을 지정해주어서 출력되는 값이 String, Int 같은 Equatable 이 채택된 타입의 값을 받을 수 있도록 처리해서 해결해주었습니다.
 
 ![](https://i.imgur.com/C1wMhZ5.png)
+</details>
 
----
-        
 ### 오픈소스 제작
-STEP 1에서 구현한 부분을 오픈소스로 제작하기 위해 Swift Package Manager를 사용하였습니다. 오픈소스를 제작하고 나서 프로젝트에 적용하고 커밋을 하면 해당 커밋을 pull한 다른 사람들도 패키지가 적용된 상태로 바로 사용할 수 있을 줄 알았습니다. 
+<details>
+<summary>자세히</summary>
+STEP 1에서 구현한 제네릭 타입을 지원하는 Queue를 오픈소스로 제작하기 위해 Swift Package Manager를 사용하였습니다. 오픈소스를 제작하고 나서 프로젝트에 적용하고 커밋을 하면 해당 커밋을 pull한 다른 사람들도 패키지가 적용된 상태로 바로 사용할 수 있을 줄 알았습니다. 
 
 하지만 적용한 사람 이외에는 사용할 수도 없었고, 같은 패키지를 추가하여 사용할 수도 없었습니다. 이미 추가되어있는 패키지라서 추가할 수 없다는 멘트였습니다. 이 문제를 해결하기 위해 프로젝트 폴더도 뒤져봤지만 패키지는 프로젝트 폴더에 저장되지 않았고, 더 알아본 결과 Xcode 폴더 내부에서 발견할 수 있었습니다. 해당 파일을 삭제하는 것도 정답은 아니었는데, Xcode 프로젝트 상에서 해당 패키지를 resolve 하는 것으로 해결하였습니다.
-        
+</details>
+
+### DispatchGroup
+<details>
+<summary>자세히</summary>
+STEP 3에서 비동기 작업을 구현하면서 DispatchQueue를 활용했습니다. 이를 적용하면서 각각의 예금업무와 대출업무가 모두 마무리 된 이후에 업무 마감 안내문구를 출력해야하기 때문에 예금업무 대기열과 대출업무 대기열을 그룹으로 만들어 `wait()`을 사용하였습니다. 하지만 작업이 끝날 때까지 기다리는 경우도, 기다리지 않는 경우도 임의로 발생해 문제가 되었습니다. 저희가 그룹에 작업을 추가하기 위해 `enter()`와 `leave()` 메서드를 사용한 부분에서 문제가 된 것이라고 생각해, task를 추가할 때 group을 매개변수로 받아서 그룹에 추가하였습니다. 그렇게 해서 너무 빠른 속도로 코드가 진행돼 task가 제대로 수행되기 전에 다음 코드가 실행되는 것을 막았습니다.
+</details>
+    
+### @escaping 메서드의 캡처 리스트
+<details>
+<summary>자세히</summary>
+    
+![](https://i.imgur.com/ylgIeiL.png)
+
+비동기로 task를 그냥 보내주는 경우 
+`Escaping closure captures mutating 'self' parameter` 의 오류가 발생했습니다.
+
+escaping closure는 mutating 한 parameter를 캡처해야 했습니다.
+혹시 함수 바깥에서 실행되다보니 같은 프로퍼티에 접근할 경우 충돌이 발생해서 캡쳐를 해야하는 것일까? 싶었습니다.
+
+![](https://i.imgur.com/mtRCpbD.png)
+
+캡처를 해 주었으나 이번에는 캡처 리스트는 **캡처**되었기 때문에 변할 수 없는 `상수, let`이 되었습니다. 
+이것을 해결하기 위해서는 self의 타입이 class 가 되거나 프로퍼티가 외부에서 접근 가능한 타입 프로퍼티가 되어야 했습니다.
+
+class로 변경하지 않고 현 상태인 struct를 유지하며 수정하고 싶었기 때문에 타입프로퍼티로 변경해주었습니다.
+
+![](https://i.imgur.com/Hc4Uorq.png)
+</details>
+    
 ## 🔗 참고 링크
 
 - Swift Language Guide


### PR DESCRIPTION
@stevenkim18
안녕하세요 스티븐!
STEP3도 아주 재밌게 수행한 것 같습니다!
다른 한 쪽의 링크는 리드미에도 적혀있듯이 [Operation으로 구현](https://github.com/jjpush/ios-bank-manager/tree/step3-operation)을 참고해주세요!


# 고민했던 점

## 비동기 프로그래밍 구현 방식 선택

배우는 입장에서 다양한 방법을 체험해보는 것이 좋다고 생각했습니다. 그래서 기본이 되는 GCD의 DispatchQueue 방식부터 더욱 사용성이 좋아진 Operation, Async / Await 방식까지 체험을 해보고 싶었는데, 우선은 DispatchQueue과 Operation 방식으로 먼저 스텝을 수행해보았습니다. 개인적인 느낌으로는 DispatchQueue를 경험하고 Operation을 사용해보아서 그런지는 모르겠으나, Operation의 경우가 더욱 쉽게 사용할 수 있었던 것 같습니다.

## DispatchQueue의 로직 고민

DispatchQueue의 실행 로직을 고민해보았습니다.

![](https://i.imgur.com/lADFX0a.png)

CustomerQueue에 고객을 담고
각 타입별로 deposit과 loan으로 나누어 준 뒤
타입의 CustomerQueue에서 DispatchQueue.global.async로 Task를 실행해줍니다.

각각의 DispatchQueue는 하나의 그룹에 넣어서 그룹이 다 끝날 때까지 기다린 후 업무 마감 메세지를 출력하도록 구성했습니다.

## Operation의 로직 고민

DispatchQueue에서 비동기 프로세스 로직을 이미 경험해보았기 때문에 비슷한 기능을 수행하는 메서드로 대체하는 것을 주안점으로 삼았습니다.

![](https://i.imgur.com/pPUz7Zb.png)

다만 바뀌는 부분이 있다면 Operation 에는 group의 개념이 없는 것 같아서
각 queue를 기다려주는 부분을 연속으로 적어주었습니다.

```swift
deposit() // 예금 실행 메서드
loan() // 대출 실행 메서드

depositOperationQueue.waitUntilAllOperationsAreFinished()
loanOperationQueue.waitUntilAllOperationsAreFinished()

print("출력메세지")
```


## @escaping 메서드의 캡처 리스트

![](https://i.imgur.com/ylgIeiL.png)

비동기로 task를 그냥 보내주는 경우 
`Escaping closure captures mutating 'self' parameter` 의 오류가 발생했습니다.

escaping closure는 mutating 한 parameter를 캡처해야 했습니다.
혹시 함수 바깥에서 실행되다보니 같은 프로퍼티에 접근할 경우 충돌이 발생해서 캡쳐를 해야하는 것일까? 싶었습니다.

![](https://i.imgur.com/mtRCpbD.png)

캡처를 해 주었으나 이번에는 캡처 리스트는 **캡처**되었기 때문에 변할 수 없는 `상수, let`이 되었습니다. 
이것을 해결하기 위해서는 self의 타입이 class 가 되거나 프로퍼티가 외부에서 접근 가능한 타입 프로퍼티가 되어야 했습니다.

class로 변경하지 않고 현 상태인 struct를 유지하며 수정하고 싶었기 때문에 타입프로퍼티로 변경해주었습니다.

![](https://i.imgur.com/Hc4Uorq.png)


# 조언이 필요한 점

## DispatchQueue

### DispatchQueue를 선택하는 기준
사용해보니 Operation이 DispatchQueue보다는 체감상 사용하기 좋았다고 앞서 말씀드렸는데요! 그렇다보니 혹시 DispatchQueue도 분명 선택되는 기준이나 장점이 있을텐데 잘 모르겠습니다. 혹시 스티븐께서는 어떤 기준으로 DispatchQueue를 선택하고, Operation이나 다른 방법을 선택하시는지 알 수 있을까요?

## Operation

### addExecutionBlock(), completionBlock의 코드블록 실행 시점
BlockOperation의 경우 Operation의 동작이 끝나고 난 후에 `addExecutionBlock()`의 코드를 실행하고, Operation 및 관련된 executionBlock들이 모두 실행된 다음에 `completionBlock`의 코드가 실행되는 것으로 공부 했습니다.


![](https://i.imgur.com/zq0xnP8.png)

![](https://i.imgur.com/GewDlaM.png)

헌데 저희가 이를 적용하기 위해 

Operation에는 { 시작문구 출력과 sleep }, 
executionBlock에는 { 완료 문구 출력 }, 
completionBolck에는 { 완료 고객 수 증가 }

라는 코드들을 넣어주었는데, 같은 고객에 대해서 완료문구가 시작문구보다 먼저 출력되거나, 고객수 카운팅이 제대로 되지 않는 등의 문제가 발생하였습니다. 
논리적으로는 모두 순서에 맞게 실행이 되어야할 것 같은데, 그 이유를 모르겠습니다. 현재는 operation과 completionBlock만 사용하는 것으로 변경하여 문제들이 해결되었습니다. 이 코드들의 정확한 실행 시점이 궁금합니다!


### BlockOperation 의 재사용
분명 Operation의 DispatchQueue와는 다른 장점은 task의 객체화를 통한 재사용성에 있는 것으로 알고 있습니다. 하지만 이미 추가한 operation에 대하여 해당 인스턴스를 다시 추가하려고 하니 `operation is already enqueue on a queue`와 같은 에러가 발생합니다. 그래서 재사용을 하려고 했으나 재사용하지 못하고, 매번 새로운 인스턴스를 생성해주는 메서드를 통해 문제를 해결하였습니다. 재사용을 위한 특별한 방법이 필요했던 것일까요?

![](https://i.imgur.com/Z7kdIco.png)