### PR TITLE
은행창구매니저 [STEP 2] brody, christy, harry

### DIFF
--- a/BankManager.swift
+++ b/BankManager.swift
@@ -18,7 +18,10 @@ struct BankManager {
             switch userInput {
             case "1":
                 let bank = Bank(bankersCount: 1)
-                bank.open()
+                let numberOfCustomer = Int.random(in: 10...30)
+                
+                bank.receive(of: numberOfCustomer)
+                bank.startBusiness()
             case "2":
                 isSelectedOpen = false
             default:

--- a/BankManager.swift
+++ b/BankManager.swift
@@ -1,7 +1,33 @@
 //
 //  BankManager.swift
-//  Created by yagom.
+//  Created by brody, christy, harry.
 //  Copyright © yagom academy. All rights reserved.
 //
 
-import Foundation
+struct BankManager {
+    func start() {
+        var isSelectedOpen = true
+        
+        while isSelectedOpen {
+            print("1 : 은행개점")
+            print("2 : 종료")
+            print("입력 : ", terminator: "")
+            
+            guard let userInput = readLine() else { continue }
+            
+            switch userInput {
+            case "1":
+                let bank = Bank(bankersCount: 1)
+                bank.open()
+            case "2":
+                isSelectedOpen = false
+            default:
+                print()
+                
+                continue
+            }
+        }
+    }
+}
+
+

--- a/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
+++ b/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
@@ -15,6 +15,9 @@
 		62CCAB0729B60407007240F8 /* BankManagerQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A57F99A29B5DF7500289E97 /* BankManagerQueue.swift */; };
 		62CCAB0829B60446007240F8 /* LinkedList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7FA2498229B5B4890064270A /* LinkedList.swift */; };
 		62CCAB0929B60479007240F8 /* Node.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6257D2DF29B5B177002D0818 /* Node.swift */; };
+		7F23169A29B724BF00B5DC7B /* Bank.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F23169929B724BF00B5DC7B /* Bank.swift */; };
+		7F23169C29B7254900B5DC7B /* Banker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F23169B29B7254900B5DC7B /* Banker.swift */; };
+		7F23169E29B7255700B5DC7B /* Customer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F23169D29B7255700B5DC7B /* Customer.swift */; };
 		7FA2498329B5B48A0064270A /* LinkedList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7FA2498229B5B4890064270A /* LinkedList.swift */; };
 		7FA249AC29B5C0720064270A /* LinkedListTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7FA249AB29B5C0720064270A /* LinkedListTests.swift */; };
 		C7694E7A259C3EC00053667F /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7694E79259C3EC00053667F /* main.swift */; };
@@ -38,6 +41,9 @@
 		4A57F9A029B5DF8A00289E97 /* BankManagerQueueTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = BankManagerQueueTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		4A57F9A229B5DF8A00289E97 /* BankManagerQueueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BankManagerQueueTests.swift; sourceTree = "<group>"; };
 		6257D2DF29B5B177002D0818 /* Node.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Node.swift; sourceTree = "<group>"; };
+		7F23169929B724BF00B5DC7B /* Bank.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Bank.swift; sourceTree = "<group>"; };
+		7F23169B29B7254900B5DC7B /* Banker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Banker.swift; sourceTree = "<group>"; };
+		7F23169D29B7255700B5DC7B /* Customer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Customer.swift; sourceTree = "<group>"; };
 		7FA2498229B5B4890064270A /* LinkedList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkedList.swift; sourceTree = "<group>"; };
 		7FA249A929B5C0710064270A /* LinkedListTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = LinkedListTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		7FA249AB29B5C0720064270A /* LinkedListTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkedListTests.swift; sourceTree = "<group>"; };
@@ -115,6 +121,9 @@
 				6257D2DF29B5B177002D0818 /* Node.swift */,
 				7FA2498229B5B4890064270A /* LinkedList.swift */,
 				4A57F99A29B5DF7500289E97 /* BankManagerQueue.swift */,
+				7F23169929B724BF00B5DC7B /* Bank.swift */,
+				7F23169B29B7254900B5DC7B /* Banker.swift */,
+				7F23169D29B7255700B5DC7B /* Customer.swift */,
 			);
 			path = BankManagerConsoleApp;
 			sourceTree = "<group>";
@@ -256,9 +265,12 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				7F23169C29B7254900B5DC7B /* Banker.swift in Sources */,
 				7FA2498329B5B48A0064270A /* LinkedList.swift in Sources */,
 				4A57F99B29B5DF7500289E97 /* BankManagerQueue.swift in Sources */,
+				7F23169E29B7255700B5DC7B /* Customer.swift in Sources */,
 				6257D2E029B5B177002D0818 /* Node.swift in Sources */,
+				7F23169A29B724BF00B5DC7B /* Bank.swift in Sources */,
 				C7694E7A259C3EC00053667F /* main.swift in Sources */,
 				C7D65D1B259C8190005510E0 /* BankManager.swift in Sources */,
 			);

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
@@ -9,7 +9,18 @@ struct Bank {
     private let bankers: [Banker]
     private var customerQueue: BankManagerQueue<Customer> = BankManagerQueue()
     
-    init(bankers: [Banker]) {
-        self.bankers = bankers
+    init(bankersCount: Int) {
+        self.bankers = .init(repeating: Banker(), count: bankersCount)
+        
+        let numberOfCustomer = Int.random(in: 10...30)
+        
+        for waitingNumber in 1...numberOfCustomer {
+            let customer = Customer(waitingNumber: waitingNumber)
+            customerQueue.enqueue(customer)
+        }
+    }
+    
+    func startWork() {
+        
     }
 }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
@@ -29,7 +29,7 @@ struct Bank {
         while customerQueue.isEmpty == false {
             guard let currentCustomer = customerQueue.dequeue() else { return }
             
-            bankers[0].work(customer: currentCustomer)
+            bankers[0].work(for: currentCustomer)
             completedJobCount += 1
         }
         let durationTime = CFAbsoluteTimeGetCurrent() - startTime

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
@@ -4,6 +4,7 @@
 //
 //  Created by brody, christy, harry on 2023/03/07.
 //
+
 import Foundation
 
 struct Bank {
@@ -13,7 +14,7 @@ struct Bank {
     init(bankersCount: Int) {
         self.bankers = .init(repeating: Banker(), count: bankersCount)
         
-        let numberOfCustomer = Int.random(in: 10...10)
+        let numberOfCustomer = Int.random(in: 10...30)
         
         for waitingNumber in 1...numberOfCustomer {
             let customer = Customer(waitingNumber: waitingNumber)
@@ -24,16 +25,19 @@ struct Bank {
     func open() {
         var completedJobCount = 0
         let startTime = CFAbsoluteTimeGetCurrent()
+        
         while customerQueue.isEmpty == false {
             guard let currentCustomer = customerQueue.dequeue() else { return }
+            
             bankers[0].work(customer: currentCustomer)
             completedJobCount += 1
         }
         let durationTime = CFAbsoluteTimeGetCurrent() - startTime
-        close(completedJobCount, durationTime)
+        
+        close(count: completedJobCount, time: durationTime)
     }
     
-    private func close(_ completedJobCount: Int, _ durationTime: CFAbsoluteTime) {
+    private func close(count completedJobCount: Int, time durationTime: CFAbsoluteTime) {
         let formattedTime = String(format: "%.2f", durationTime)
         print("업무가 마감되었습니다. 오늘 업무를 처리한 고객은 총 \(completedJobCount)명이며, 총 업무시간은 \(formattedTime)초입니다.\n")
     }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
@@ -4,6 +4,7 @@
 //
 //  Created by brody, christy, harry on 2023/03/07.
 //
+import Foundation
 
 struct Bank {
     private let bankers: [Banker]
@@ -20,7 +21,21 @@ struct Bank {
         }
     }
     
-    func startWork() {
-        
+    func open() {
+        var completedJobCount = 0.0
+        let startTime = CFAbsoluteTimeGetCurrent()
+        while customerQueue.isEmpty == false {
+            guard let currentCustomer = customerQueue.dequeue() else { return }
+            bankers[0].work(customer: currentCustomer)
+            completedJobCount += 1
+        }
+        let durationTime = CFAbsoluteTimeGetCurrent() - startTime
+        close(completedJobCount, durationTime)
     }
+    
+    private func close(_ completedJobCount: Double, _ durationTime: CFAbsoluteTime) {
+        let formattedTime = String(format: "%.2f", durationTime)
+        print("업무가 마감되었습니다. 오늘 업무를 처리한 고객은 총 \(completedJobCount)명이며, 총 업무시간은 \(formattedTime)초입니다.")
+    }
+    
 }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
@@ -1,0 +1,15 @@
+//
+//  Bank.swift
+//  BankManagerConsoleApp
+//
+//  Created by brody, christy, harry on 2023/03/07.
+//
+
+struct Bank {
+    private let bankers: [Banker]
+    private var customerQueue: BankManagerQueue<Customer> = BankManagerQueue()
+    
+    init(bankers: [Banker]) {
+        self.bankers = bankers
+    }
+}

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
@@ -13,7 +13,7 @@ struct Bank {
     init(bankersCount: Int) {
         self.bankers = .init(repeating: Banker(), count: bankersCount)
         
-        let numberOfCustomer = Int.random(in: 10...30)
+        let numberOfCustomer = Int.random(in: 10...10)
         
         for waitingNumber in 1...numberOfCustomer {
             let customer = Customer(waitingNumber: waitingNumber)
@@ -22,7 +22,7 @@ struct Bank {
     }
     
     func open() {
-        var completedJobCount = 0.0
+        var completedJobCount = 0
         let startTime = CFAbsoluteTimeGetCurrent()
         while customerQueue.isEmpty == false {
             guard let currentCustomer = customerQueue.dequeue() else { return }
@@ -33,9 +33,8 @@ struct Bank {
         close(completedJobCount, durationTime)
     }
     
-    private func close(_ completedJobCount: Double, _ durationTime: CFAbsoluteTime) {
+    private func close(_ completedJobCount: Int, _ durationTime: CFAbsoluteTime) {
         let formattedTime = String(format: "%.2f", durationTime)
-        print("업무가 마감되었습니다. 오늘 업무를 처리한 고객은 총 \(completedJobCount)명이며, 총 업무시간은 \(formattedTime)초입니다.")
+        print("업무가 마감되었습니다. 오늘 업무를 처리한 고객은 총 \(completedJobCount)명이며, 총 업무시간은 \(formattedTime)초입니다.\n")
     }
-    
 }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
@@ -9,20 +9,20 @@ import Foundation
 
 struct Bank {
     private let bankers: [Banker]
-    private var customerQueue: BankManagerQueue<Customer> = BankManagerQueue()
+    private let customerQueue: BankManagerQueue<Customer> = BankManagerQueue()
     
     init(bankersCount: Int) {
         self.bankers = .init(repeating: Banker(), count: bankersCount)
-        
-        let numberOfCustomer = Int.random(in: 10...30)
-        
+    }
+    
+    func receive(of numberOfCustomer: Int) {
         for waitingNumber in 1...numberOfCustomer {
             let customer = Customer(waitingNumber: waitingNumber)
             customerQueue.enqueue(customer)
         }
     }
     
-    func open() {
+    func startBusiness() {
         var completedJobCount = 0
         let startTime = CFAbsoluteTimeGetCurrent()
         
@@ -34,10 +34,10 @@ struct Bank {
         }
         let durationTime = CFAbsoluteTimeGetCurrent() - startTime
         
-        close(count: completedJobCount, time: durationTime)
+        endBusiness(count: completedJobCount, time: durationTime)
     }
     
-    private func close(count completedJobCount: Int, time durationTime: CFAbsoluteTime) {
+    private func endBusiness(count completedJobCount: Int, time durationTime: CFAbsoluteTime) {
         let formattedTime = String(format: "%.2f", durationTime)
         print("업무가 마감되었습니다. 오늘 업무를 처리한 고객은 총 \(completedJobCount)명이며, 총 업무시간은 \(formattedTime)초입니다.\n")
     }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/BankManagerQueue.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/BankManagerQueue.swift
@@ -6,7 +6,7 @@
 //
 
 struct BankManagerQueue<T> {
-    private let linkedList: LinkedList<T> = LinkedList()
+    private var linkedList: LinkedList<T>
     
     var peek: T? {
         linkedList.head?.value
@@ -14,6 +14,10 @@ struct BankManagerQueue<T> {
     
     var isEmpty: Bool {
         linkedList.head == nil ? true : false
+    }
+    
+    init(linkedList: LinkedList<T> = LinkedList()) {
+        self.linkedList = linkedList
     }
     
     func enqueue(_ value: T) {

--- a/BankManagerConsoleApp/BankManagerConsoleApp/BankManagerQueue.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/BankManagerQueue.swift
@@ -6,7 +6,7 @@
 //
 
 struct BankManagerQueue<T> {
-    private var linkedList: LinkedList<T>
+    private let linkedList: LinkedList<T>
     
     var peek: T? {
         linkedList.head?.value

--- a/BankManagerConsoleApp/BankManagerConsoleApp/BankManagerQueue.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/BankManagerQueue.swift
@@ -6,7 +6,7 @@
 //
 
 struct BankManagerQueue<T> {
-    private let linkedList: LinkedList<T>
+    private let linkedList: LinkedList<T> = LinkedList()
     
     var peek: T? {
         linkedList.head?.value
@@ -14,10 +14,6 @@ struct BankManagerQueue<T> {
     
     var isEmpty: Bool {
         linkedList.head == nil ? true : false
-    }
-    
-    init(linkedList: LinkedList<T>) {
-        self.linkedList = linkedList
     }
     
     func enqueue(_ value: T) {

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Banker.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Banker.swift
@@ -4,7 +4,12 @@
 //
 //  Created by brody, christy, harry on 2023/03/07.
 //
+import Foundation
 
 struct Banker {
-    
+    func work(customer: Customer) {
+        print("\(customer.waitingNumber)번 고객 업무 시작")
+        Thread.sleep(forTimeInterval: customer.consultingTime)
+        print("\(customer.waitingNumber)번 고객 업무 완료")
+    }
 }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Banker.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Banker.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 struct Banker {
-    func work(customer: Customer) {
+    func work(for customer: Customer) {
         print("\(customer.waitingNumber)번 고객 업무 시작")
         Thread.sleep(forTimeInterval: customer.consultingTime)
         print("\(customer.waitingNumber)번 고객 업무 완료")

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Banker.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Banker.swift
@@ -4,6 +4,7 @@
 //
 //  Created by brody, christy, harry on 2023/03/07.
 //
+
 import Foundation
 
 struct Banker {

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Banker.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Banker.swift
@@ -1,0 +1,10 @@
+//
+//  Banker.swift
+//  BankManagerConsoleApp
+//
+//  Created by brody, christy, harry on 2023/03/07.
+//
+
+struct Banker {
+    
+}

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Customer.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Customer.swift
@@ -1,0 +1,10 @@
+//
+//  Customer.swift
+//  BankManagerConsoleApp
+//
+//  Created by brody, christy, harry on 2023/03/07.
+//
+
+struct Customer {
+    
+}

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Customer.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Customer.swift
@@ -7,4 +7,5 @@
 
 struct Customer {
     let waitingNumber: Int
+    let consultingTime: Double = 0.7
 }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Customer.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Customer.swift
@@ -6,5 +6,5 @@
 //
 
 struct Customer {
-    
+    let waitingNumber: Int
 }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/LinkedList.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/LinkedList.swift
@@ -4,6 +4,7 @@
 //
 //  Created by brody, christy, harry on 2023/03/06.
 //
+
 import Foundation
 
 final class LinkedList<T> {

--- a/BankManagerConsoleApp/BankManagerConsoleApp/main.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/main.swift
@@ -5,3 +5,5 @@
 // 
 
 import Foundation
+
+

--- a/BankManagerConsoleApp/BankManagerConsoleApp/main.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/main.swift
@@ -4,26 +4,5 @@
 //  Copyright © yagom academy. All rights reserved.
 // 
 
-import Foundation
-
-var isSelectedOpen = true
-
-while isSelectedOpen {
-    print("1 : 은행개점")
-    print("2 : 종료")
-    print("입력 : ", terminator: "")
-    guard let userInput = readLine() else {
-        continue
-    }
-    
-    switch userInput {
-    case "1":
-        let bank = Bank(bankersCount: 1)
-        bank.open()
-    case "2":
-        isSelectedOpen = false
-    default:
-        print()
-        continue
-    }
-}
+let bankManager = BankManager()
+bankManager.start()

--- a/BankManagerConsoleApp/BankManagerConsoleApp/main.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/main.swift
@@ -6,4 +6,24 @@
 
 import Foundation
 
+var isSelectedOpen = true
 
+while isSelectedOpen {
+    print("1 : 은행개점")
+    print("2 : 종료")
+    print("입력 : ", terminator: "")
+    guard let userInput = readLine() else {
+        continue
+    }
+    
+    switch userInput {
+    case "1":
+        let bank = Bank(bankersCount: 1)
+        bank.open()
+    case "2":
+        isSelectedOpen = false
+    default:
+        print()
+        continue
+    }
+}


### PR DESCRIPTION
@forestjae
 
안녕하세요 숲재!
은행창구 매니저의 두번째 PR을 보내게 된 브로디, 해리, 크리스티입니다.
이번에도 잘 부탁드리겠습니다!😄

## 고민한 점

### 업무시간 계산하기
큐의 모든 업무가 끝나면 업무를 처리한 고객수와 총 업무시간을 출력해주는 기능이 있었습니다.
업무시간을 **고객의 수 * 0.7** 로 계산을 해서 단순히 출력을 시켜주는 것이 좋을까? 아니면 실제로 업무를 처리를 하는 것을 측정을 하는 것이 좋을까? 고민을 했습니다.

- 결론
    - **고객의 수 * 0.7**의 계산식은 실제 업무처리 시간이 아닌 예측을 하는 것이라 생각했습니다.
    - 따라서 Core Foundation의 `CFAbsoluteTimeGetCurrent()`를 사용해서 시작시간을 구하였습니다.
    - 업무 처리가 끝나는 시간에서 이전에 시작시간을 빼주어 총 소요시간을 측정했습니다.

<br>

### BankManager와 Bank의 역할분리
처음에는 은행이 문을열고 닫는 것이라고 생각해서 `BankManager`를 사용하지 않고 `Bank`파일에 은행에 관련된 기능을 담고, main파일에서 은행을 열지말지를 정하는 코드를 작성했습니다.

하지만 `main`파일 내에서 은행을 말지열지를 정하는 것보다 `BankManager`가 이 행동에 대해 책임을 지는 것이 좋다고 생각했습니다. 
따라서 `BankManager`객체에서 `Bank`의 인스턴스를 소유해, 사용자의 입력에 따라 `Bank`를 열지 말지 선택할 수 있게 만들었습니다.

<br>