### PR TITLE
은행 창구 매니저 [STEP2] 리지, 무리

### DIFF
--- a/BankManager.swift
+++ b/BankManager.swift
@@ -1,7 +1,38 @@
 //
 //  BankManager.swift
-//  Created by yagom.
+//  Created by 리지, 무리.
 //  Copyright © yagom academy. All rights reserved.
 //
 
 import Foundation
+
+struct BankManager {
+    private var bank = Bank()
+    
+    mutating private func openBank() {
+        bank.lineUpClient()
+        bank.doTask()
+        startBankApp()
+    }
+    
+    mutating func startBankApp() {
+        let open = "1"
+        let close = "2"
+        let noticeMenu = "1 : 은행 개점 \n2 : 종료 \n입력 : "
+        let inputError = "입력이 잘못되었습니다."
+        
+        print(noticeMenu, terminator: "")
+        
+        guard let input = readLine() else { return }
+        
+        switch input {
+        case open:
+            openBank()
+        case close:
+            return
+        default:
+            print(inputError)
+            startBankApp()
+        }
+    }
+}

--- a/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
+++ b/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		4B56954529B5ECF700366C7A /* Queue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B56954429B5ECF700366C7A /* Queue.swift */; };
 		4B56954729B5FE7B00366C7A /* Queue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B56954429B5ECF700366C7A /* Queue.swift */; };
+		4BF70BC129B842320060E794 /* Client.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BF70BC029B842320060E794 /* Client.swift */; };
 		C7694E7A259C3EC00053667F /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7694E79259C3EC00053667F /* main.swift */; };
 		C7D65D1B259C8190005510E0 /* BankManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7D65D1A259C8190005510E0 /* BankManager.swift */; };
 		FB580D7929B5DEE8003E95B5 /* Node.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB580D7829B5DEE8003E95B5 /* Node.swift */; };
@@ -36,6 +37,7 @@
 
 /* Begin PBXFileReference section */
 		4B56954429B5ECF700366C7A /* Queue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Queue.swift; sourceTree = "<group>"; };
+		4BF70BC029B842320060E794 /* Client.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Client.swift; sourceTree = "<group>"; };
 		C7694E76259C3EC00053667F /* BankManagerConsoleApp */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = BankManagerConsoleApp; sourceTree = BUILT_PRODUCTS_DIR; };
 		C7694E79259C3EC00053667F /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
 		C7D65D1A259C8190005510E0 /* BankManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = BankManager.swift; path = ../../BankManager.swift; sourceTree = "<group>"; };
@@ -116,6 +118,7 @@
 				FB580D7A29B5DEF0003E95B5 /* LinkedList.swift */,
 				FB580D7829B5DEE8003E95B5 /* Node.swift */,
 				4B56954429B5ECF700366C7A /* Queue.swift */,
+				4BF70BC029B842320060E794 /* Client.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -246,6 +249,7 @@
 			files = (
 				4B56954529B5ECF700366C7A /* Queue.swift in Sources */,
 				FB580D7929B5DEE8003E95B5 /* Node.swift in Sources */,
+				4BF70BC129B842320060E794 /* Client.swift in Sources */,
 				C7694E7A259C3EC00053667F /* main.swift in Sources */,
 				FB580D9529B5E19F003E95B5 /* LinkedList.swift in Sources */,
 				C7D65D1B259C8190005510E0 /* BankManager.swift in Sources */,

--- a/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
+++ b/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		4BF70BC129B842320060E794 /* Client.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BF70BC029B842320060E794 /* Client.swift */; };
 		C7694E7A259C3EC00053667F /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7694E79259C3EC00053667F /* main.swift */; };
 		C7D65D1B259C8190005510E0 /* BankManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7D65D1A259C8190005510E0 /* BankManager.swift */; };
+		FB33C7BB29B842BE00F2C3A2 /* BankClerk.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB33C7BA29B842BE00F2C3A2 /* BankClerk.swift */; };
 		FB580D7929B5DEE8003E95B5 /* Node.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB580D7829B5DEE8003E95B5 /* Node.swift */; };
 		FB580D8329B5DF11003E95B5 /* LinkedListTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB580D8229B5DF11003E95B5 /* LinkedListTest.swift */; };
 		FB580D8729B5E030003E95B5 /* LinkedList.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB580D7A29B5DEF0003E95B5 /* LinkedList.swift */; };
@@ -41,6 +42,7 @@
 		C7694E76259C3EC00053667F /* BankManagerConsoleApp */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = BankManagerConsoleApp; sourceTree = BUILT_PRODUCTS_DIR; };
 		C7694E79259C3EC00053667F /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
 		C7D65D1A259C8190005510E0 /* BankManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = BankManager.swift; path = ../../BankManager.swift; sourceTree = "<group>"; };
+		FB33C7BA29B842BE00F2C3A2 /* BankClerk.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BankClerk.swift; sourceTree = "<group>"; };
 		FB580D7829B5DEE8003E95B5 /* Node.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Node.swift; sourceTree = "<group>"; };
 		FB580D7A29B5DEF0003E95B5 /* LinkedList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkedList.swift; sourceTree = "<group>"; };
 		FB580D8029B5DF11003E95B5 /* LinkedListTest.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = LinkedListTest.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -119,6 +121,7 @@
 				FB580D7829B5DEE8003E95B5 /* Node.swift */,
 				4B56954429B5ECF700366C7A /* Queue.swift */,
 				4BF70BC029B842320060E794 /* Client.swift */,
+				FB33C7BA29B842BE00F2C3A2 /* BankClerk.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -248,6 +251,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				4B56954529B5ECF700366C7A /* Queue.swift in Sources */,
+				FB33C7BB29B842BE00F2C3A2 /* BankClerk.swift in Sources */,
 				FB580D7929B5DEE8003E95B5 /* Node.swift in Sources */,
 				4BF70BC129B842320060E794 /* Client.swift in Sources */,
 				C7694E7A259C3EC00053667F /* main.swift in Sources */,

--- a/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
+++ b/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		4B56954529B5ECF700366C7A /* Queue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B56954429B5ECF700366C7A /* Queue.swift */; };
 		4B56954729B5FE7B00366C7A /* Queue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B56954429B5ECF700366C7A /* Queue.swift */; };
 		4BF70BC129B842320060E794 /* Client.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BF70BC029B842320060E794 /* Client.swift */; };
+		4BF70BC329B8435A0060E794 /* Bank.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BF70BC229B8435A0060E794 /* Bank.swift */; };
 		C7694E7A259C3EC00053667F /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7694E79259C3EC00053667F /* main.swift */; };
 		C7D65D1B259C8190005510E0 /* BankManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7D65D1A259C8190005510E0 /* BankManager.swift */; };
 		FB33C7BB29B842BE00F2C3A2 /* BankClerk.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB33C7BA29B842BE00F2C3A2 /* BankClerk.swift */; };
@@ -39,6 +40,7 @@
 /* Begin PBXFileReference section */
 		4B56954429B5ECF700366C7A /* Queue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Queue.swift; sourceTree = "<group>"; };
 		4BF70BC029B842320060E794 /* Client.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Client.swift; sourceTree = "<group>"; };
+		4BF70BC229B8435A0060E794 /* Bank.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Bank.swift; sourceTree = "<group>"; };
 		C7694E76259C3EC00053667F /* BankManagerConsoleApp */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = BankManagerConsoleApp; sourceTree = BUILT_PRODUCTS_DIR; };
 		C7694E79259C3EC00053667F /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
 		C7D65D1A259C8190005510E0 /* BankManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = BankManager.swift; path = ../../BankManager.swift; sourceTree = "<group>"; };
@@ -122,6 +124,7 @@
 				4B56954429B5ECF700366C7A /* Queue.swift */,
 				4BF70BC029B842320060E794 /* Client.swift */,
 				FB33C7BA29B842BE00F2C3A2 /* BankClerk.swift */,
+				4BF70BC229B8435A0060E794 /* Bank.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -251,6 +254,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				4B56954529B5ECF700366C7A /* Queue.swift in Sources */,
+				4BF70BC329B8435A0060E794 /* Bank.swift in Sources */,
 				FB33C7BB29B842BE00F2C3A2 /* BankClerk.swift in Sources */,
 				FB580D7929B5DEE8003E95B5 /* Node.swift in Sources */,
 				4BF70BC129B842320060E794 /* Client.swift in Sources */,

--- a/BankManagerConsoleApp/BankManagerConsoleApp/main.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/main.swift
@@ -1,7 +1,9 @@
 //
 //  BankManagerConsoleApp - main.swift
-//  Created by yagom. 
+//  Created by 리지, 무리
 //  Copyright © yagom academy. All rights reserved.
 // 
 
-import Foundation
+var bankManger = BankManager()
+bankManger.startBankApp()
+

--- a/BankManagerConsoleApp/Model/Bank.swift
+++ b/BankManagerConsoleApp/Model/Bank.swift
@@ -1,0 +1,22 @@
+//
+//  Bank.swift
+//  BankManagerConsoleApp
+//
+//  Created by 리지, 무리 on 2023/03/08.
+//
+
+import Foundation
+
+struct Bank {
+    var waitingLine = Queue<Client>()
+    var todayClient: Int = 10
+    var BankClerkCount: Int = 1
+
+    mutating func lineUpClient() {
+        todayClient = Int.random(in: 10...30)
+        for number in 1...todayClient {
+            let currentClient = Client(number: number)
+            waitingLine.enqueue(currentClient)
+        }
+    }
+}

--- a/BankManagerConsoleApp/Model/Bank.swift
+++ b/BankManagerConsoleApp/Model/Bank.swift
@@ -30,7 +30,7 @@ struct Bank {
         }
         
         let timeOfTask = CFAbsoluteTimeGetCurrent() - startTime
-        let totalTime = String(format: "%.2f", floor(timeOfTask))
+        let totalTime = String(format: "%.2f", timeOfTask)
         let success = "업무가 마감되었습니다. 오늘 업무를 처리한 고객은 총 \(clientCount)명이며, 총 업무시간은 \(totalTime)초입니다."
         print(success)
     }

--- a/BankManagerConsoleApp/Model/Bank.swift
+++ b/BankManagerConsoleApp/Model/Bank.swift
@@ -11,6 +11,7 @@ struct Bank {
     var waitingLine = Queue<Client>()
     var todayClient: Int = 10
     var BankClerkCount: Int = 1
+    var bankClerk = BankClerk()
 
     mutating func lineUpClient() {
         todayClient = Int.random(in: 10...30)
@@ -18,5 +19,19 @@ struct Bank {
             let currentClient = Client(number: number)
             waitingLine.enqueue(currentClient)
         }
+    }
+    
+    mutating func doTask() {
+        let startTime = CFAbsoluteTimeGetCurrent()
+        
+        for _ in 1...waitingLine.count {
+            guard let currentClient = waitingLine.dequeue() else { return }
+            bankClerk.service(to: currentClient)
+        }
+        
+        let timeOfTask = CFAbsoluteTimeGetCurrent() - startTime
+        let totalTime = String(format: "%.2f", floor(timeOfTask))
+        let success = "업무가 마감되었습니다. 오늘 업무를 처리한 고객은 총 \(todayClient)명이며, 총 업무시간은 \(totalTime)초입니다."
+        print(success)
     }
 }

--- a/BankManagerConsoleApp/Model/Bank.swift
+++ b/BankManagerConsoleApp/Model/Bank.swift
@@ -9,13 +9,13 @@ import Foundation
 
 struct Bank {
     var waitingLine = Queue<Client>()
-    var todayClient: Int = 10
+    var clientCount: Int = 10
     var BankClerkCount: Int = 1
     var bankClerk = BankClerk()
 
     mutating func lineUpClient() {
-        todayClient = Int.random(in: 10...30)
-        for number in 1...todayClient {
+        clientCount = Int.random(in: 10...30)
+        for number in 1...clientCount {
             let currentClient = Client(number: number)
             waitingLine.enqueue(currentClient)
         }
@@ -31,7 +31,7 @@ struct Bank {
         
         let timeOfTask = CFAbsoluteTimeGetCurrent() - startTime
         let totalTime = String(format: "%.2f", floor(timeOfTask))
-        let success = "업무가 마감되었습니다. 오늘 업무를 처리한 고객은 총 \(todayClient)명이며, 총 업무시간은 \(totalTime)초입니다."
+        let success = "업무가 마감되었습니다. 오늘 업무를 처리한 고객은 총 \(clientCount)명이며, 총 업무시간은 \(totalTime)초입니다."
         print(success)
     }
 }

--- a/BankManagerConsoleApp/Model/Bank.swift
+++ b/BankManagerConsoleApp/Model/Bank.swift
@@ -8,10 +8,10 @@
 import Foundation
 
 struct Bank {
-    var waitingLine = Queue<Client>()
-    var clientCount: Int = 10
-    var BankClerkCount: Int = 1
-    var bankClerk = BankClerk()
+    private var waitingLine = Queue<Client>()
+    private var clientCount: Int = 10
+    private var BankClerkCount: Int = 1
+    private var bankClerk = BankClerk()
 
     mutating func lineUpClient() {
         clientCount = Int.random(in: 10...30)

--- a/BankManagerConsoleApp/Model/BankClerk.swift
+++ b/BankManagerConsoleApp/Model/BankClerk.swift
@@ -1,0 +1,19 @@
+//
+//  BankClerk.swift
+//  BankManagerConsoleApp
+//
+//  Created by 리지, 무리 on 2023/03/08.
+//
+
+import Foundation
+
+struct BankClerk {
+    mutating func service(to client: Client) {
+        let start = "\(client.number)번 고객 업무 시작"
+        let end = "\(client.number)번 고객 업무 완료"
+        
+        print(start)
+        usleep(700000)
+        print(end)
+    }
+}

--- a/BankManagerConsoleApp/Model/Client.swift
+++ b/BankManagerConsoleApp/Model/Client.swift
@@ -6,5 +6,5 @@
 //
 
 struct Client {
-    var number: Int
+    private(set) var number: Int
 }

--- a/BankManagerConsoleApp/Model/Client.swift
+++ b/BankManagerConsoleApp/Model/Client.swift
@@ -1,0 +1,10 @@
+//
+//  Client.swift
+//  BankManagerConsoleApp
+//
+//  Created by 리지, 무리 on 2023/03/08.
+//
+
+struct Client {
+    var number: Int
+}

--- a/BankManagerConsoleApp/Model/LinkedList.swift
+++ b/BankManagerConsoleApp/Model/LinkedList.swift
@@ -8,6 +8,7 @@
 struct LinkedList<T> {
     private(set) var head: Node<T>?
     private(set) var tail: Node<T>?
+    var count: Int = 0
     var isEmpty: Bool {
         return head == nil
     }
@@ -19,17 +20,20 @@ struct LinkedList<T> {
         guard !isEmpty else {
             self.head = Node(data: data)
             self.tail = head
+            count += 1
             
             return
         }
         
         tail?.next = Node(data: data)
         self.tail = tail?.next
+        count += 1
     }
     
     mutating func removeFirst() -> T? {
         guard let node = head else { return nil }
         self.head = head?.next
+        count -= 1
         
         return node.data
     }
@@ -37,5 +41,6 @@ struct LinkedList<T> {
     mutating func removeAll() {
         self.head = nil
         self.tail = nil
+        count = 0
     }
 }

--- a/BankManagerConsoleApp/Model/Queue.swift
+++ b/BankManagerConsoleApp/Model/Queue.swift
@@ -7,6 +7,9 @@
 
 struct Queue<T> {
     private var list = LinkedList<T>()
+    var count: Int {
+        return list.count
+    }
     var isEmpty: Bool {
         return list.isEmpty
     }


### PR DESCRIPTION
@uuu1101 
안녕하세요 태태! 리지 무리입니다! 
STEP2 PR 보냅니다! 코멘트 기다리고있겠습니당😊

## 고민했던 부분
### 1️⃣ client 타입 구현시 랜덤숫자를 어디서 적용할지
- 처음에 구현한 방법은 client 객체에서 random 숫자를 10..30까지 부여하는 방법을 적용시켰습니다. 그렇게 할 경우 Bank에서 받는 client는 모두 10-30 사이 수의 고객만 오게 된다고 생각하여 고객의 수를 지정하는 것을 Bank타입의 `lineUpClient()` 메서드에서 하도록 구현하였습니다.
Client는 번호표를 가진다는 의미로 `number`변수만 가지도록 구현했습니다.

```swift
// 수정 전 Client.swift 
struct Client {
    var number: Int = Int.random(in: 10...30)
}

// 수정 후 Bank.swift
mutating func lineUpClient() {
    clientCount = Int.random(in: 10...30)
    for number in 1...clientCount {
        let currentClient = Client(number: number)
        waitingLine.enqueue(currentClient)
       }
}
```

### 2️⃣ 매직리터럴, 매직넘버 처리
- 이번 프로젝트에서 print문이나 사용자 입력받기에서 사용되는 숫자를 사용하는 일이 많았고 매직리터럴, 매직넘버 사용을 자제하려고 노력하였습니다.
처음 고민한 부분은 enum을 만들어 namespace를 적용해볼까? 고민하였는데, 저희가 생각했을 때 특정 부분에서만 사용되어 enum으로 따로 만드는 것은 불필요하다고 결론을 내렸습니다.
따라서 사용되는 부분에서 상수로 선언하여 처리하도록 구현하였습니다!


## 조언을 얻고싶은 부분
### 1️⃣ 은행원이 업무를 처리하는 시간을 측정하는 법
> 각 고객의 업무를 처리하는 데 걸리는 시간은 0.7초입니다.
- 프로젝트 요구사항에 위와같은 부분이 있었습니다. 
은행원은 한 고객의 업무를 0.7초간 봐야하며 이를 구현하기위해 `usleep`을 사용했습니다. 그리고 은행원이 업무 시작하는 시간을 `startTime`변수에 담은 후 업무 처리가 완료된 시점을 측정하여 업무에 걸린 총 시간을 측정하였습니다.
- 하지만 요구사항의 예시에서는 10명의 고객을 처리하는데 걸린 시간이 7.00초로 저희가 진행 한 방법으로는 약간의 오차(7.03, 7.04)가 생기게 되었습니다. 10명을 기준으로 floor를 사용하여 7.00을 나타내는 방법을 사용했는데 이 방법을 사용하니 11명을 처리했을때도 7.00의 시간이 걸린다고 나오게되었습니다. 오차가 너무 크다고 생각하여 floor를 사용하지 않는 방법으로 구현하였습니다.
- 7.03, 7.04가 아닌 7.00인 위의 요구사항을 맞추기 위해 은행원의 업무시간을 0.7초로 정해준 뒤 고객의 수를 곱하여 출력하는 방법과 저희가 선택한 방법중에 어떤게 더 적절한 것 같은지 태태의 의견을 듣고싶습니다!
