### PR TITLE
은행 창구 매니저[STEP3] 리지, 무리

### DIFF
--- a/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
+++ b/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		C7694E7A259C3EC00053667F /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7694E79259C3EC00053667F /* main.swift */; };
 		C7D65D1B259C8190005510E0 /* BankManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7D65D1A259C8190005510E0 /* BankManager.swift */; };
 		FB33C7BB29B842BE00F2C3A2 /* BankClerk.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB33C7BA29B842BE00F2C3A2 /* BankClerk.swift */; };
+		FB33C7BD29B9B7C800F2C3A2 /* Task.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB33C7BC29B9B7C800F2C3A2 /* Task.swift */; };
 		FB580D7929B5DEE8003E95B5 /* Node.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB580D7829B5DEE8003E95B5 /* Node.swift */; };
 		FB580D8329B5DF11003E95B5 /* LinkedListTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB580D8229B5DF11003E95B5 /* LinkedListTest.swift */; };
 		FB580D8729B5E030003E95B5 /* LinkedList.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB580D7A29B5DEF0003E95B5 /* LinkedList.swift */; };
@@ -45,6 +46,7 @@
 		C7694E79259C3EC00053667F /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
 		C7D65D1A259C8190005510E0 /* BankManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = BankManager.swift; path = ../../BankManager.swift; sourceTree = "<group>"; };
 		FB33C7BA29B842BE00F2C3A2 /* BankClerk.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BankClerk.swift; sourceTree = "<group>"; };
+		FB33C7BC29B9B7C800F2C3A2 /* Task.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Task.swift; sourceTree = "<group>"; };
 		FB580D7829B5DEE8003E95B5 /* Node.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Node.swift; sourceTree = "<group>"; };
 		FB580D7A29B5DEF0003E95B5 /* LinkedList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkedList.swift; sourceTree = "<group>"; };
 		FB580D8029B5DF11003E95B5 /* LinkedListTest.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = LinkedListTest.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -125,6 +127,7 @@
 				4BF70BC029B842320060E794 /* Client.swift */,
 				FB33C7BA29B842BE00F2C3A2 /* BankClerk.swift */,
 				4BF70BC229B8435A0060E794 /* Bank.swift */,
+				FB33C7BC29B9B7C800F2C3A2 /* Task.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -260,6 +263,7 @@
 				4BF70BC129B842320060E794 /* Client.swift in Sources */,
 				C7694E7A259C3EC00053667F /* main.swift in Sources */,
 				FB580D9529B5E19F003E95B5 /* LinkedList.swift in Sources */,
+				FB33C7BD29B9B7C800F2C3A2 /* Task.swift in Sources */,
 				C7D65D1B259C8190005510E0 /* BankManager.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/BankManagerConsoleApp/Model/Bank.swift
+++ b/BankManagerConsoleApp/Model/Bank.swift
@@ -18,7 +18,7 @@ struct Bank {
     
     mutating func manageTodayTask() {
         lineUpClient()
-        let totalTime = checkTaskTime()
+        let totalTime = calculateTaskTime()
         notifyTaskCompletion(totalTime)
     }
     
@@ -32,7 +32,7 @@ struct Bank {
         }
     }
     
-    mutating func checkTaskTime() -> String {
+    mutating func calculateTaskTime() -> String {
         let startTime = CFAbsoluteTimeGetCurrent()
         
         doTask()

--- a/BankManagerConsoleApp/Model/Bank.swift
+++ b/BankManagerConsoleApp/Model/Bank.swift
@@ -64,9 +64,10 @@ struct Bank {
             loanBankClerk.signal()
         }
         
-        if currentClient.purposeOfVisit == .deposit {
+        switch currentClient.purposeOfVisit {
+        case .deposit:
             DispatchQueue.global().async(group: group, execute: depositService)
-        } else {
+        case .loan:
             DispatchQueue.global().async(group: group, execute: loanService)
         }
     }

--- a/BankManagerConsoleApp/Model/Bank.swift
+++ b/BankManagerConsoleApp/Model/Bank.swift
@@ -22,7 +22,7 @@ struct Bank {
         notifyTaskCompletion(totalTime)
     }
     
-    mutating func lineUpClient() {
+    mutating private func lineUpClient() {
         clientCount = Int.random(in: 10...30)
         
         for number in 1...clientCount {
@@ -32,7 +32,7 @@ struct Bank {
         }
     }
     
-    mutating func calculateTaskTime() -> String {
+    mutating private func calculateTaskTime() -> String {
         let startTime = CFAbsoluteTimeGetCurrent()
         
         doTask()
@@ -43,7 +43,7 @@ struct Bank {
         return totalTime
     }
 
-    mutating func doTask() {
+    mutating private func doTask() {
         for _ in 1...waitingLine.count {
             guard let currentClient = waitingLine.dequeue() else { return }
             assignToBankClerk(currentClient)
@@ -72,7 +72,7 @@ struct Bank {
         }
     }
     
-    mutating func notifyTaskCompletion(_ totalTime: String) {
+    private func notifyTaskCompletion(_ totalTime: String) {
         let success = "업무가 마감되었습니다. 오늘 업무를 처리한 고객은 총 \(clientCount)명이며, 총 업무시간은 \(totalTime)초입니다."
         print(success)
     }

--- a/BankManagerConsoleApp/Model/Bank.swift
+++ b/BankManagerConsoleApp/Model/Bank.swift
@@ -12,6 +12,7 @@ struct Bank {
     private var clientCount: Int = 10
     private var BankClerkCount: Int = 1
     private var bankClerk = BankClerk()
+    private let typeOfTask: [Task] = [.deposit, .loan]
 
     mutating func manageTodayTask() {
         lineUpClient()
@@ -22,9 +23,11 @@ struct Bank {
     mutating func lineUpClient() {
         clientCount = Int.random(in: 10...30)
         for number in 1...clientCount {
-            let currentClient = Client(waitingNumber: number)
+            guard let type = typeOfTask.randomElement() else { return }
+            let currentClient = Client(waitingNumber: number, purposeOfVisit: type)
             waitingLine.enqueue(currentClient)
         }
+   
     }
 
     mutating func doTask() {
@@ -46,4 +49,5 @@ struct Bank {
         let success = "업무가 마감되었습니다. 오늘 업무를 처리한 고객은 총 \(clientCount)명이며, 총 업무시간은 \(totalTime)초입니다."
         print(success)
     }
+    
 }

--- a/BankManagerConsoleApp/Model/BankClerk.swift
+++ b/BankManagerConsoleApp/Model/BankClerk.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 struct BankClerk {
-    mutating func service(to client: Client) {
+    func service(to client: Client) {
         let start = "\(client.waitingNumber)번 고객 \(client.purposeOfVisit.rawValue)업무 시작"
         let end = "\(client.waitingNumber)번 고객 \(client.purposeOfVisit.rawValue)업무 완료"
         

--- a/BankManagerConsoleApp/Model/BankClerk.swift
+++ b/BankManagerConsoleApp/Model/BankClerk.swift
@@ -9,11 +9,16 @@ import Foundation
 
 struct BankClerk {
     mutating func service(to client: Client) {
-        let start = "\(client.waitingNumber)번 고객 업무 시작"
-        let end = "\(client.waitingNumber)번 고객 업무 완료"
+        let start = "\(client.waitingNumber)번 고객 \(client.purposeOfVisit.rawValue)업무 시작"
+        let end = "\(client.waitingNumber)번 고객 \(client.purposeOfVisit.rawValue)업무 완료"
         
         print(start)
-        usleep(700000)
+        switch client.purposeOfVisit {
+        case .loan:
+            usleep(1100000)
+        case .deposit:
+            usleep(700000)
+        }
         print(end)
     }
 }

--- a/BankManagerConsoleApp/Model/Client.swift
+++ b/BankManagerConsoleApp/Model/Client.swift
@@ -7,4 +7,5 @@
 
 struct Client {
     private(set) var waitingNumber: Int
+    private(set) var purposeOfVisit: Task
 }

--- a/BankManagerConsoleApp/Model/Task.swift
+++ b/BankManagerConsoleApp/Model/Task.swift
@@ -1,0 +1,12 @@
+//
+//  Task.swift
+//  BankManagerConsoleApp
+//
+//  Created by 리지, 무리 on 2023/03/09.
+//
+
+enum Task: String {
+    case deposit = "예금"
+    case loan = "대출"
+}
+

--- a/README.md
+++ b/README.md
@@ -1,6 +1,195 @@
-## iOS 커리어 스타터 캠프
+# 은행창구 매니저
+> 은행을 방문한 고객들의 업무를 여러명의 은행원이 처리하도록 만든 콘솔앱입니다.
+>
+> 프로젝트 기간: 2023.03.06 - 2023.03.17
+> 
 
-### 은행 매니저 프로젝트 저장소
+## 팀원
+| 무리 | 리지 |
+| :--------: |  :--------: | 
+| <Img src = "https://i.imgur.com/RoWuqsN.jpg" width="200" height="200"/>      |<Img src ="https://user-images.githubusercontent.com/114971172/221088543-6f6a8d09-7081-4e61-a54a-77849a102af8.png" width="200" height="200"/>
+| [Github Profile](https://github.com/parkmuri) |[Github Profile](https://github.com/yijiye)
 
-- 이 저장소를 자신의 저장소로 fork하여 프로젝트를 진행합니다
+## 목차
+1. [타임라인](#타임라인)
+2. [프로젝트 구조](#프로젝트-구조)
+3. [실행화면](#실행화면) 
+4. [트러블 슈팅](#트러블-슈팅) 
+5. [핵심경험](#핵심경험)
+6. [참고 링크](#참고-링크)
 
+
+# 타임라인 
+- 2023.03.06 : LinkedList를 이용하여 Queue 구현, UnitTest 
+- 2023.03.07 : Bank, Client 구현
+- 2023.03.08 : BankClerk 구현, Bank, Client refactoring
+- 2023.03.09 : DispathQueue 적용
+- 2023.03.10 : refactoring, README.md 작성
+
+
+<br/>
+
+# 프로젝트 구조
+<details>
+    <summary><big>UML</big></big></summary>
+
+<img src="https://i.imgur.com/iztFWFI.png" width="1000">
+
+</details>
+
+<br/>
+
+
+# 실행화면
+<img src="https://i.imgur.com/jF0aH41.gif">
+
+
+# 트러블 슈팅
+## 1️⃣ STEP3의 요구사항 중 `세 명의 은행원`에 대한 해석
+> 은행에는 3명의 은행원이 근무합니다(예금담당 2명, 대출담당 1명)
+
+- 은행에는 은행원이 세 명 근무하도록 안내되어있었습니다. `BankClerk`타입을 구현 해 놓은 후라서 "세 개의 global 스레드 안에 각각 BankClerk 인스턴스를 만들어주면 되지 않을까?" 생각을 했습니다. 
+- 저희가 만들어 놓은 로직에서는 은행원이 직접 손님들의 대기열을 dequeue하지 않고, 은행 내부에서 dequeue한 손님들을 목적(대출 or 예금)에 따라 은행원에게 보내주도록 구현해놓았습니다. 
+이 상태에서 위 처럼 생각 후 비동기 스레드를 구현하니 예금목적 손님들은 예금을 담당하는 두 명의 은행원 스레드를 돌게되는 등의 오류가 발생했습니다.
+- BankClerk의 인스턴스로 은행원의 실체를 만드는 것이 아니라, 은행원을 하나의 스레드로 생각 하고 서비스를 제공하는 BankClerk의 인스턴스 한개를 전역변수로 구현하였습니다. 그리고 **접근하는 스레드의 수 (=은행원)** 를 `Semaphore`로 제한함으로써 총 3명의 은행원이 일을 처리하도록 구현하였습니다.
+```swift
+// Bank.swift
+private var bankClerk = BankClerk()
+private let loanBankClerk = DispatchSemaphore(value: 1)
+private let depositBankClerks = DispatchSemaphore(value: 2)
+
+private func dispatchQueue(_ currentClient: Client) {
+    let depositService = DispatchWorkItem() {
+        depositBankClerks.wait()
+        bankClerk.service(to: currentClient)
+        depositBankClerks.signal()
+    }
+    let loanService = DispatchWorkItem() {
+        loanBankClerk.wait()
+        bankClerk.service(to: currentClient)
+        loanBankClerk.signal()
+    }
+
+    if currentClient.purposeOfVisit == .deposit {
+            DispatchQueue.global().async(execute: depositService)
+    } else {
+        DispatchQueue.global().async(execute: loanService)
+    }
+}
+```
+
+## 2️⃣ 스레드 실행 순서 고민
+- 은행원을 스레드로 생각하여 `DispatchQueue.global().async` 로 3명의 은행원에서 고객들을 비동기적으로 처리하도록 구현하였는데, 메인스레드가 아닌 다른 스레드에서 작업을 처리하여 작업이 끝나기 전에 메인스레드에 있는 `notifyTaskCompletion` 메서드가 실행되어 함수 내부의 print문이 출력되는 오류가 있었습니다.
+실행 순서 문제를 해결하고자 `DispatchGroup`을 전역상수로 두고`DispatchQueue.global().async`를 group로 묶어준 후 `group.wait()` 메서드를 사용하였습니다. 이때, 시간을 계산하고 print문이 출력되어야 하므로 doTask() 일이 끝나는 곳에서 `group.wait()`메서드를 실행하였습니다.
+
+```swift
+// Bank.swift
+private let group = DispatchGroup
+
+mutating func doTask() {
+    for _ in 1...waitingLine.count {
+        guard let currentClient = waitingLine.dequeue() else { return }
+        dispatchQueue(currentClient)
+    }
+
+    group.wait()
+}
+
+private func dispatchQueue(_ currentClient: Client) { 
+    // ...
+    if currentClient.purposeOfVisit == .deposit {
+        DispatchQueue.global().async(group: group, execute: depositService)
+    } else {
+        DispatchQueue.global().async(group: group, execute: loanService)
+    }
+}
+```
+
+# 핵심경험
+
+<details>
+    <summary><big>✅ LinkedList를 이용한 Queue 구현</big></summary>
+    
+### removeAll() 구현
+- `removeAll()` 의 기능은 enqueue된 값을 모두 삭제하는 것이라 생각하였습니다. 처음 생각한 점은 값을 하나씩 삭제를 해줘야하나? 고민하였는데, 연결리스트의 특성상 노드가 다음 값의 주소값과 연결되어 있으므로 head와 tail을 nil로 변환하면 가르키는 주소값이 사라지게 되고 결국 swift의 ARC가 자동으로 메모리를 해제한다는 점을 고려하여 다음과 같이 구현하였습니다.
+    
+```swift
+ mutating func removeAll() {
+    self.head = nil
+    self.tail = nil
+    count = 0
+}
+```
+    
+### append 구현
+- 처음 appen 구현시 조건문을 if로 사용하여 return 을 구현하지 않아 append 기능에 문제가 있었습니다. 
+    
+수정 전 코드
+```swift
+ mutating func append(_ data: T) {
+    if isEmpty {
+        self.head = Node(data: data)
+        self.tail = head
+        count += 1
+    }
+```
+- 비어있을 때, head에 새로운 Node를 주고 Node가 head이자 tail이 되도록 한 후 코드를 빠져나오도록 return 값을 주면서 빠른 종료를 위해 guard문으로 변경하였습니다.
+    
+수정 후 코드
+```swift
+ mutating func append(_ data: T) {
+    guard !isEmpty else {
+        self.head = Node(data: data)
+        self.tail = head
+        count += 1
+    
+        return
+    }
+```
+    
+### count 추가
+- step2를 진행하면서 count의 기능이 필요하다 생각하여 count를 추가하였습니다. 그러나 LinkedList를 swift에서 기본으로 제공하는 타입이 아니므로 count를 세는 것을 직접 구현해야 했습니다. 따라서 enqueue 되면서 count를 하나씩 증가하고, dequeue 될 때 count가 하나씩 감소하며 removeAll 하면 count가 다시 0이 되도록 직접 구현하였습니다.
+</details>
+
+
+<details>
+    <summary><big>✅ 시간 측정</big></summary>
+    
+- 은행원 1명이 1명의 고객을 처리하는데 걸리는 시간 조건이 있었고, 그 시간을 측정하여 하루동안 일한 시간을 print 하는 미션이 있었습니다. 저희는 그 시간을 측정하기 위해 `usleep()`을 사용하여 정해진 시간만큼 일을 처리하고 그 합을 `CFAbsoluteTimeGetCurrent()` 메서드를 이용하여 해결하였습니다.
+```swift
+mutating func checkTaskTime() -> String {
+        let startTime = CFAbsoluteTimeGetCurrent()
+        
+        doTask()
+        
+        let timeOfTask = CFAbsoluteTimeGetCurrent() - startTime
+        let totalTime = String(format: "%.2f", timeOfTask)
+        
+        return totalTime
+    }
+```
+    
+추가적으로 같은 기능을 하는 Thread.sleep()과 sleep()에 대해 좀 더 찾아보았습니다.
+    
+```swift
+// sleep
+static func sleep(_ duration: UInt64) async
+
+// Thread.sleep
+@_unavailableFromAsync(message: "Use Task.sleep(until:clock:) instead.") 
+class func sleep(forTimeInterval ti: TimeInterval)
+```
+- 두 메서드 모두 정해진 시간만큼 업무 수행을 중지 시키는 메서드로 가장 큰 차이로는 static 타입 메서드인 것과 class 타입 메서드 인 점이 있습니다.
+Thread.sleep()이 Foundation FrameWork의 Thread class에 정의된 메서드로, swift에 더 최적화되어 있으나 기능적으로 차이는 없다는 것을 알게되었습니다.
+    
+</details>
+
+<br/>
+
+# 참고 링크
+- [AppleDeveloper : sleep(forTimeInterval:)](https://developer.apple.com/documentation/foundation/thread/1413673-sleep)
+- [AppleDeveloper : DispatchQueue](https://developer.apple.com/documentation/dispatch/dispatchqueue/)
+- [AppleDeveloper : global()](https://developer.apple.com/documentation/dispatch/dispatchqueue/2300077-global)
+- [AppleDeveloper : wait()](https://developer.apple.com/documentation/dispatch/dispatchworkitem/2016085-wait)
+- [AppleDeveloper : DispatchGroup](https://developer.apple.com/documentation/dispatch/dispatchgroup)
+- [야곰닷넷 - 동시성 프로그래밍](https://yagom.net/courses/%eb%8f%99%ec%8b%9c%ec%84%b1-%ed%94%84%eb%a1%9c%ea%b7%b8%eb%9e%98%eb%b0%8d-concurrency-programming/)


### PR DESCRIPTION
@uuu1101
안녕하세요 태태~! 드디어 STEP3 PR을 보내네요...!
뭔가 이번 스텝 진행하면서 초반에 했던 생각이 다 바뀌는 바람에 많이 헤맨 것 같아요...🥲
그럼 리뷰 기다리고있겠습니다😊!

---
## 고민했던 부분

### 1️⃣ 은행원이 누구일까?
> 은행에는 3명의 은행원이 근무합니다(예금담당 2명, 대출담당 1명)
- 은행에는 은행원이 세 명 근무하도록 안내되어있었습니다. `BankClerk`타입을 구현 해 놓은 후라서 "세 개의 global 스레드 안에 각각 BankClerk 인스턴스를 만들어주면 되지 않을까?" 생각을 했습니다. 

#### `BankClerk()` 인스턴스로 생각했을 때 (문제발생)
- 저희가 처음 생각한 부분은 은행이 은행원에게 대기줄에 있는 손님들을 async로 줄세워주고, 손님들을 받은 은행원들은 동기적으로 일을 처리한다고 생각했습니다.
그래서 은행이 client의 watingLine에서 dequeue하여 bankClerk에게 전달하는 행위자체를 `DispatchQueue.global().async { }` 로 구현하였습니다. 
그리고 client를 전달받은 `BankClerk()`이 3명이 존재하므로 3개의 `DispatchWorkItem`안에 `BankClerk()` 인스턴스를 각각 만들어주었고, client의 방문 목적에 따라 if문을 통하여 deposit/loan으로 나뉘어 세 개의 스레드 중 해당 업무를 처리하는 `BankClerk()`이 존재하는 스레드로 보내주었습니다.
- 위와같이 생각하고 구현을 한 결과, 다음과 같은 문제들이 발생했습니다.
    1. deposit 목적의 client는 두 개의 스레드를 거쳐서 중복으로 출력된다.
    2. 세 개의 스레드 안에 존재하는 `BankClerk()`들이 동기적으로 일을 하지 못한다.
    
```swift
private func dispatchQueue(_ currentClient: Client) {
    DispatchQueue.global().async { // 은행원에게 고객을 주는 과정이라고 생각
        let depositServiceA = DispatchWorkItem() { //은행원이 고객을 담당하여 업무를 처리하는 과정이라고 생각하여 총 3명의 은행원을 직접 구현
            let bankClerk = BankClerk()
            bankClerk.service(to: currentClient)
        }
        let depositServiceB = DispatchWorkItem() {
            let bankClerk = BankClerk()
            bankClerk.service(to: currentClient)
        }
        let loanService = DispatchWorkItem() {
            let bankClerk = BankClerk()
            bankClerk.service(to: currentClient)
        }

        if currentClient.purposeOfVisit == .deposit {
            DispatchQueue.global().sync(execute: depositServiceA)
            DispatchQueue.global().sync(execute: depositServiceB)
        } else {
            DispatchQueue.global().sync(execute: loanService)
            }
}
    
```

#### `Thread` 로 생각했을 때 (해결방법)
- 인스턴스로 직접 만들어서 구현하니 위와같은 문제가 발생하여 BankClerk의 인스턴스로 은행원의 실체를 만드는 것이 아니라, 은행원을 하나의 스레드로 생각 하고 서비스를 제공하는 BankClerk의 인스턴스 한개를 전역변수로 구현하였습니다. 그리고 **접근하는 스레드의 수 (=은행원)** 를 `Semaphore`로 제한함으로써 총 3명의 은행원이 일을 처리하도록 구현하였습니다.
```swift
// Bank.swift
private var bankClerk = BankClerk()
private let loanBankClerk = DispatchSemaphore(value: 1)
private let depositBankClerks = DispatchSemaphore(value: 2)

private func dispatchQueue(_ currentClient: Client) {
    let depositService = DispatchWorkItem() {
        depositBankClerks.wait()
        bankClerk.service(to: currentClient)
        depositBankClerks.signal()
    }
    let loanService = DispatchWorkItem() {
        loanBankClerk.wait()
        bankClerk.service(to: currentClient)
        loanBankClerk.signal()
    }

    if currentClient.purposeOfVisit == .deposit {
            DispatchQueue.global().async(execute: depositService)
    } else {
        DispatchQueue.global().async(execute: loanService)
    }
}
```

### 2️⃣ 스레드 실행 순서

- 은행원을 스레드로 생각하여 `DispatchQueue.global().async` 로 3명의 은행원에서 고객들을 비동기적으로 처리하도록 구현하였는데, 메인스레드가 아닌 다른 스레드에서 작업을 처리하여 작업이 끝나기 전에 메인스레드에 있는 `notifyTaskCompletion` 메서드가 실행되어 함수 내부의 print문이 출력되는 오류가 있었습니다.
실행 순서 문제를 해결하고자 `DispatchGroup`을 전역상수로 두고`DispatchQueue.global().async`를 group로 묶어준 후 `group.wait()` 메서드를 사용하였습니다. 이때, 시간을 계산하고 print문이 출력되어야 하므로 doTask() 일이 끝나는 곳에서 `group.wait()`메서드를 실행하였습니다.

```swift
// Bank.swift
private let group = DispatchGroup

mutating func doTask() {
    for _ in 1...waitingLine.count {
        guard let currentClient = waitingLine.dequeue() else { return }
        dispatchQueue(currentClient)
    }

    group.wait()
}

private func dispatchQueue(_ currentClient: Client) { 
    // ...
    if currentClient.purposeOfVisit == .deposit {
        DispatchQueue.global().async(group: group, execute: depositService)
    } else {
        DispatchQueue.global().async(group: group, execute: loanService)
    }
}
```
