### PR TITLE
은행 창구 매니저 [STEP 3] Rhode, sehong

### DIFF
--- a/BankManager.swift
+++ b/BankManager.swift
@@ -10,6 +10,6 @@ struct BankManager {
     func work(client: Client) {
         print("\(client.clientWaitingNumber)번 고객 \(client.bankingTypeText)업무 시작")
         Thread.sleep(forTimeInterval: client.bankingTime)
-        print("\(client.clientWaitingNumber)번 고객 \(client.bankingTypeText)업무 완료")
+        print("\(client.clientWaitingNumber)번 고객 \(client.bankingTypeText)업무 종료")
     }
 }

--- a/BankManager.swift
+++ b/BankManager.swift
@@ -7,9 +7,9 @@
 import Foundation
 
 struct BankManager {
-    func work(client: Int) {
-        print("\(client)번 업무 시작")
-        Thread.sleep(forTimeInterval: 0.7)
-        print("\(client)번 업무 완료")
+    func work(client: Client) {
+        print("\(client.clientWaitingNumber)번 고객 \(client.bankingType.rawValue)업무 시작")
+        Thread.sleep(forTimeInterval: client.bankingTime)
+        print("\(client.clientWaitingNumber)번 고객 \(client.bankingType.rawValue)업무 완료")
     }
 }

--- a/BankManager.swift
+++ b/BankManager.swift
@@ -8,8 +8,8 @@ import Foundation
 
 struct BankManager {
     func work(client: Client) {
-        print("\(client.clientWaitingNumber)번 고객 \(client.bankingText)업무 시작")
+        print("\(client.clientWaitingNumber)번 고객 \(client.description)업무 시작")
         Thread.sleep(forTimeInterval: client.bankingTime)
-        print("\(client.clientWaitingNumber)번 고객 \(client.bankingText)업무 종료")
+        print("\(client.clientWaitingNumber)번 고객 \(client.description)업무 종료")
     }
 }

--- a/BankManager.swift
+++ b/BankManager.swift
@@ -8,8 +8,8 @@ import Foundation
 
 struct BankManager {
     func work(client: Client) {
-        print("\(client.clientWaitingNumber)번 고객 \(client.bankingTypeText)업무 시작")
+        print("\(client.clientWaitingNumber)번 고객 \(client.bankingText)업무 시작")
         Thread.sleep(forTimeInterval: client.bankingTime)
-        print("\(client.clientWaitingNumber)번 고객 \(client.bankingTypeText)업무 종료")
+        print("\(client.clientWaitingNumber)번 고객 \(client.bankingText)업무 종료")
     }
 }

--- a/BankManager.swift
+++ b/BankManager.swift
@@ -8,8 +8,8 @@ import Foundation
 
 struct BankManager {
     func work(client: Client) {
-        print("\(client.clientWaitingNumber)번 고객 \(client.description)업무 시작")
+        print("\(client.clientWaitingNumber)번 고객 \(client)업무 시작")
         Thread.sleep(forTimeInterval: client.bankingTime)
-        print("\(client.clientWaitingNumber)번 고객 \(client.description)업무 종료")
+        print("\(client.clientWaitingNumber)번 고객 \(client)업무 종료")
     }
 }

--- a/BankManager.swift
+++ b/BankManager.swift
@@ -8,8 +8,8 @@ import Foundation
 
 struct BankManager {
     func work(client: Client) {
-        print("\(client.clientWaitingNumber)번 고객 \(client.bankingType.rawValue)업무 시작")
+        print("\(client.clientWaitingNumber)번 고객 \(client.bankingTypeText)업무 시작")
         Thread.sleep(forTimeInterval: client.bankingTime)
-        print("\(client.clientWaitingNumber)번 고객 \(client.bankingType.rawValue)업무 완료")
+        print("\(client.clientWaitingNumber)번 고객 \(client.bankingTypeText)업무 완료")
     }
 }

--- a/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
+++ b/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		D01A1B2F29B5C3CC0028B601 /* Queue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 367397A029B5B509007AF8FA /* Queue.swift */; };
 		D01A1B3029B5C3CF0028B601 /* BankManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7D65D1A259C8190005510E0 /* BankManager.swift */; };
 		D01A1B3129B5C3D20028B601 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7694E79259C3EC00053667F /* main.swift */; };
+		D0EB1EAC29BF01F100E2E9CA /* ClientWaitingLine.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0EB1EAB29BF01F100E2E9CA /* ClientWaitingLine.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -45,6 +46,7 @@
 		D01A1B2029B5B3DC0028B601 /* Node.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Node.swift; sourceTree = "<group>"; };
 		D01A1B2629B5C1E40028B601 /* BankQueueTest.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = BankQueueTest.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		D01A1B2829B5C1E40028B601 /* QueueTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QueueTest.swift; sourceTree = "<group>"; };
+		D0EB1EAB29BF01F100E2E9CA /* ClientWaitingLine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClientWaitingLine.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -99,6 +101,7 @@
 				367397CD29B8431A007AF8FA /* Bank.swift */,
 				C7D65D1A259C8190005510E0 /* BankManager.swift */,
 				367397CF29B8434B007AF8FA /* Client.swift */,
+				D0EB1EAB29BF01F100E2E9CA /* ClientWaitingLine.swift */,
 				C7694E79259C3EC00053667F /* main.swift */,
 				367397A229B5B676007AF8FA /* Queue */,
 			);
@@ -205,6 +208,7 @@
 				367397D029B8434B007AF8FA /* Client.swift in Sources */,
 				367397A129B5B509007AF8FA /* Queue.swift in Sources */,
 				D01A1B1F29B5AFC10028B601 /* LinkedList.swift in Sources */,
+				D0EB1EAC29BF01F100E2E9CA /* ClientWaitingLine.swift in Sources */,
 				367397CE29B8431A007AF8FA /* Bank.swift in Sources */,
 				C7D65D1B259C8190005510E0 /* BankManager.swift in Sources */,
 				D01A1B2129B5B3DC0028B601 /* Node.swift in Sources */,

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
@@ -46,49 +46,19 @@ struct Bank {
         }
     }
     
-    private mutating func manageClientQueue() -> (deposit: Queue<Client>, loan: Queue<Client>) {
-        var depositClientQueue = Queue<Client>()
-        var loanClientQueue = Queue<Client>()
-        
-        var clientArray: [Int] = []
+    private mutating func manageClientQueue() -> Queue<Client>  {
+        var clientQueue = Queue<Client>()
         clientCount = Int.random(in: 10...30)
         
-        (Int.zero..<clientCount).forEach {
-            clientArray.append($0 + 1)
-        }
-        
-        var loanArray: [Int] = []
-        let loanCount = Int.random(in: Int.zero...clientCount)
-        
-        while loanArray.count < loanCount {
-            let loanClientNumber = Int.random(in: 1...clientCount)
-            
-            if loanArray.contains(loanClientNumber) {
-                continue
-            } else {
-                loanArray.append(loanClientNumber)
+        for i in 1...clientCount {
+            Client.BankingType.allCases.randomElement().map {
+                clientQueue.enqueue(Client(clientWaitingNumber: i, bankingType: $0))
             }
+            
+            return clientQueue
         }
-        
-        loanArray = loanArray.sorted()
-        
-        for loanClientNumber in loanArray {
-            let loanClient = Client(clientWaitingNumber: loanClientNumber, bankingType: .loan)
-            loanClientQueue.enqueue(loanClient)
-        }
-        
-        clientArray.removeAll(where: {loanArray.contains($0)})
-        
-        for depositClientNumber in clientArray {
-            let depositClient = Client(clientWaitingNumber: depositClientNumber, bankingType: .deposit)
-            depositClientQueue.enqueue(depositClient)
-        }
-        
-        let clientTuple = (deposit: depositClientQueue, loan: loanClientQueue)
-        
-        return clientTuple
     }
-    
+        
     private mutating func distributeClient(depositManagerCount: Int, loanManagerCount: Int) {
         let clientLists = manageClientQueue()
         var depositClientList = clientLists.deposit

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
@@ -7,7 +7,7 @@
 import Foundation
 
 struct Bank {
-    var clientCount: Int = Int.zero
+    private var clientCount: Int = Int.zero
     
     private enum BankStatus: String {
         case open = "1"

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
@@ -9,6 +9,10 @@ import Foundation
 struct Bank {
     private var clientCount = 0
     
+    init(clientCount: Int) {
+        self.clientCount = clientCount
+    }
+    
     private enum BankStatus: String {
         case open = "1"
         case close = "2"
@@ -48,13 +52,11 @@ struct Bank {
     
     private mutating func manageClientQueue() -> Queue<Client> {
         var clientQueue = Queue<Client>()
-        let randomClientCount = Int.random(in: 10...30)
         
-        (0..<randomClientCount).forEach {
+        (0..<clientCount).forEach {
             let client = Client(clientWaitingNumber: $0 + 1)
             
             clientQueue.enqueue(client)
-            clientCount += 1
         }
         return clientQueue
     }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
@@ -56,8 +56,8 @@ struct Bank {
         clientCount = Int.random(in: 10...30)
         
         for i in 1...clientCount {
-            Client.BankingType.allCases.randomElement().map {
-                clientQueue.enqueue(Client(clientWaitingNumber: i, bankingType: $0))
+            Client.Banking.allCases.randomElement().map {
+                clientQueue.enqueue(Client(clientWaitingNumber: i, banking: $0))
             }
         }
         
@@ -70,7 +70,7 @@ struct Bank {
         let bankManager = BankManager()
         
         while let client = clientQueue.dequeue() {
-            switch client.bankingType {
+            switch client.banking {
             case .deposit:
                 depositQueue.async(group: group) { [self] in
                     depositSemaphore.wait()

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
@@ -7,7 +7,7 @@
 import Foundation
 
 struct Bank {
-    var clientCount: Int = 0
+    var clientCount: Int = Int.zero
     
     private enum BankStatus: String {
         case open = "1"
@@ -51,14 +51,14 @@ struct Bank {
         var loanClientQueue = Queue<Client>()
         
         var clientArray: [Int] = []
-        clientCount = Int.random(in: 5...10)
+        clientCount = Int.random(in: 10...30)
         
-        (0..<clientCount).forEach {
+        (Int.zero..<clientCount).forEach {
             clientArray.append($0 + 1)
         }
         
         var loanArray: [Int] = []
-        let loanCount = Int.random(in: 0...clientCount)
+        let loanCount = Int.random(in: Int.zero...clientCount)
         
         while loanArray.count < loanCount {
             let loanClientNumber = Int.random(in: 1...clientCount)
@@ -99,9 +99,9 @@ struct Bank {
         
         for _ in Int.zero..<depositManagerCount {
             DispatchQueue.global().async(group: group) {
-                semaphore.wait()
                 
                 while let client = depositClientList.dequeue() {
+                    semaphore.wait()
                     bankManager.work(client: client)
                     semaphore.signal()
                 }
@@ -109,9 +109,9 @@ struct Bank {
         }
         for _ in Int.zero..<loanManagerCount {
             DispatchQueue.global().async(group: group) {
-                semaphore.wait()
                 
                 while let client = loanClientList.dequeue() {
+                    semaphore.wait()
                     bankManager.work(client: client)
                     semaphore.signal()
                 }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
@@ -21,7 +21,9 @@ struct Bank {
     
     mutating func openBank() {
         displayBankMenu()
+        
         let bankStatus = readMenuNumber()
+        
         startWork(bankStatus)
     }
     

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
@@ -141,7 +141,7 @@ struct Bank {
     }
     
     private func completeManagingBank(count: Int, time: Double) {
-        let workingTime = String(format: "%.1f", time)
+        let workingTime = String(format: "%.2f", time)
         
         print("업무가 마감되었습니다. 오늘 업무를 처리한 고객은 총\(count)명이며, 총 업무시간은 \(workingTime)초 입니다.")
     }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
@@ -95,7 +95,7 @@ struct Bank {
         var loanClientList = clientLists.loan
         let bankManager = BankManager()
         let group = DispatchGroup()
-        let semaphore = DispatchSemaphore(value: 1)
+        let semaphore = DispatchSemaphore(value: 2)
         
         for _ in Int.zero..<depositManagerCount {
             DispatchQueue.global().async(group: group) {
@@ -111,9 +111,9 @@ struct Bank {
             DispatchQueue.global().async(group: group) {
                 
                 while let client = loanClientList.dequeue() {
-                    semaphore.wait()
+//                    semaphore.wait()
                     bankManager.work(client: client)
-                    semaphore.signal()
+//                    semaphore.signal()
                 }
             }
         }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
@@ -7,15 +7,7 @@
 import Foundation
 
 struct Bank {
-    var clientCount: Int
-    var clientArray: [Int]
-    var loanArray: [Int]
-    
-    init(clientCount: Int, clientArray: [Int], loanArray: [Int]) {
-        self.clientCount = clientCount
-        self.clientArray = clientArray
-        self.loanArray = loanArray
-    }
+    var clientCount: Int = 0
     
     private enum BankStatus: String {
         case open = "1"
@@ -57,6 +49,28 @@ struct Bank {
     private mutating func manageClientQueue() -> (deposit: Queue<Client>, loan: Queue<Client>) {
         var depositClientQueue = Queue<Client>()
         var loanClientQueue = Queue<Client>()
+        
+        var clientArray: [Int] = []
+        clientCount = Int.random(in: 5...10)
+        
+        (0..<clientCount).forEach {
+            clientArray.append($0 + 1)
+        }
+        
+        var loanArray: [Int] = []
+        let loanCount = Int.random(in: 0...clientCount)
+        
+        while loanArray.count < loanCount {
+            let loanClientNumber = Int.random(in: 1...clientCount)
+            
+            if loanArray.contains(loanClientNumber) {
+                continue
+            } else {
+                loanArray.append(loanClientNumber)
+            }
+        }
+        
+        loanArray = loanArray.sorted()
         
         for loanClientNumber in loanArray {
             let loanClient = Client(clientWaitingNumber: loanClientNumber, bankingType: .loan)

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
@@ -7,7 +7,7 @@
 import Foundation
 
 struct Bank {
-    private var clientCount: Int = Int.zero
+    private let clientWaitingLine = ClientWaitingLine()
     
     private let depositSemaphore = DispatchSemaphore(value: 2)
     private let depositQueue = DispatchQueue(label: "loan", attributes: .concurrent)
@@ -51,22 +51,9 @@ struct Bank {
         }
     }
     
-    private mutating func manageClientQueue() -> Queue<Client>  {
-        var clientQueue = Queue<Client>()
-        clientCount = Int.random(in: 10...30)
-        
-        for i in 1...clientCount {
-            Client.Banking.allCases.randomElement().map {
-                clientQueue.enqueue(Client(clientWaitingNumber: i, banking: $0))
-            }
-        }
-        
-        return clientQueue
-    }
-    
     private mutating func distributeClient() {
         let group = DispatchGroup()
-        var clientQueue = manageClientQueue()
+        var clientQueue = clientWaitingLine.manageClientQueue()
         let bankManager = BankManager()
         
         while let client = clientQueue.dequeue() {
@@ -94,7 +81,7 @@ struct Bank {
             distributeClient()
         }
         
-        completeManagingBank(count: clientCount, time: workTime)
+        completeManagingBank(count: clientWaitingLine.clientCount, time: workTime)
         openBank()
     }
     

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
@@ -34,9 +34,6 @@ struct Bank {
     private mutating func readMenuNumber() -> BankStatus? {
         guard let status = readLine(),
               let bankStatus = BankStatus(rawValue: status) else {
-            print(Constants.InvalidInputText)
-            openBank()
-            
             return nil
         }
         return bankStatus
@@ -49,8 +46,17 @@ struct Bank {
         case .close:
             return
         default:
-            return
+            print(Constants.InvalidInputText)
         }
+        openBank()
+    }
+    
+    private mutating func manageBank() {
+        let workTime = workTime {
+            distributeClient()
+        }
+        
+        completeManagingBank(count: clientWaitingLine.clientCount, time: workTime)
     }
     
     private mutating func distributeClient() {
@@ -76,15 +82,6 @@ struct Bank {
         }
         
         group.wait()
-    }
-    
-    private mutating func manageBank() {
-        let workTime = workTime {
-            distributeClient()
-        }
-        
-        completeManagingBank(count: clientWaitingLine.clientCount, time: workTime)
-        openBank()
     }
     
     private func workTime(workTimeHandler: () -> Void) -> TimeInterval {

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Bank.swift
@@ -48,9 +48,9 @@ struct Bank {
     
     private mutating func manageClientQueue() -> Queue<Client> {
         var clientQueue = Queue<Client>()
-        let randomClients = Int.random(in: 10...30)
+        let randomClientCount = Int.random(in: 10...30)
         
-        (0..<randomClients).forEach {
+        (0..<randomClientCount).forEach {
             let client = Client(clientWaitingNumber: $0 + 1)
             
             clientQueue.enqueue(client)

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Client.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Client.swift
@@ -5,15 +5,15 @@
 //
 
 struct Client {
-    enum BankingType: CaseIterable{
+    enum Banking: CaseIterable{
         case deposit
         case loan
     }
     
     let clientWaitingNumber: Int
-    let bankingType: BankingType
+    let banking: Banking
     var bankingTime: Double {
-        switch bankingType {
+        switch banking {
         case .deposit:
             return 0.7
         case .loan:
@@ -21,8 +21,8 @@ struct Client {
         }
     }
     
-    var bankingTypeText: String {
-        switch bankingType {
+    var bankingText: String {
+        switch banking {
         case .deposit:
             return "예금"
         case .loan:

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Client.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Client.swift
@@ -5,9 +5,9 @@
 //
 
 struct Client {
-    enum BankingType: String {
-        case deposit = "예금"
-        case loan = "대출"
+    enum BankingType {
+        case deposit
+        case loan
     }
     
     let clientWaitingNumber: Int
@@ -18,6 +18,15 @@ struct Client {
             return 0.7
         case .loan:
             return 1.1
+        }
+    }
+    
+    var bankingTypeText: String {
+        switch bankingType {
+        case .deposit:
+            return "예금"
+        case .loan:
+            return "대출"
         }
     }
 }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Client.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Client.swift
@@ -5,7 +5,7 @@
 //
 
 struct Client {
-    enum BankingType {
+    enum BankingType: CaseIterable{
         case deposit
         case loan
     }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Client.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Client.swift
@@ -5,5 +5,19 @@
 //
 
 struct Client {
+    enum BankingType: String {
+        case deposit = "예금"
+        case loan = "대출"
+    }
+    
     let clientWaitingNumber: Int
+    let bankingType: BankingType
+    var bankingTime: Double {
+        switch bankingType {
+        case .deposit:
+            return 0.7
+        case .loan:
+            return 1.1
+        }
+    }
 }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Client.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Client.swift
@@ -4,8 +4,8 @@
 //  Copyright © yagom academy. All rights reserved.
 //
 
-struct Client {
-    enum Banking: CaseIterable{
+struct Client: CustomStringConvertible {
+    enum Banking: CaseIterable {
         case deposit
         case loan
     }
@@ -21,7 +21,7 @@ struct Client {
         }
     }
     
-    var bankingText: String {
+    var description: String {
         switch banking {
         case .deposit:
             return "예금"

--- a/BankManagerConsoleApp/BankManagerConsoleApp/ClientWaitingLine.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/ClientWaitingLine.swift
@@ -1,0 +1,23 @@
+//
+//  ClientWaitingLine.swift
+//  BankManagerConsoleApp
+//
+//  Created by Jinah Park on 2023/03/13.
+//
+
+class ClientWaitingLine {
+    var clientCount = Int.zero
+    
+    func manageClientQueue() -> Queue<Client>  {
+        var clientQueue = Queue<Client>()
+        clientCount = Int.random(in: 1...5)
+        
+        for i in 1...clientCount {
+            Client.Banking.allCases.randomElement().map {
+                clientQueue.enqueue(Client(clientWaitingNumber: i, banking: $0))
+            }
+        }
+        
+        return clientQueue
+    }
+}

--- a/BankManagerConsoleApp/BankManagerConsoleApp/ClientWaitingLine.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/ClientWaitingLine.swift
@@ -1,8 +1,7 @@
 //
 //  ClientWaitingLine.swift
-//  BankManagerConsoleApp
-//
-//  Created by Jinah Park on 2023/03/13.
+//  Created by Rhode, sehong.
+//  Copyright © yagom academy. All rights reserved.
 //
 
 class ClientWaitingLine {
@@ -10,7 +9,7 @@ class ClientWaitingLine {
     
     func manageClientQueue() -> Queue<Client>  {
         var clientQueue = Queue<Client>()
-        clientCount = Int.random(in: 1...5)
+        clientCount = Int.random(in: 10...30)
         
         for i in 1...clientCount {
             Client.Banking.allCases.randomElement().map {

--- a/BankManagerConsoleApp/BankManagerConsoleApp/main.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/main.swift
@@ -6,6 +6,6 @@
 
 import Foundation
 
-var bank = Bank(clientCount: Int.random(in: 10...30))
+var bank = Bank()
 
 bank.openBank()

--- a/BankManagerConsoleApp/BankManagerConsoleApp/main.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/main.swift
@@ -6,6 +6,6 @@
 
 import Foundation
 
-var bank = Bank()
+var bank = Bank(clientCount: Int.random(in: 10...30))
 
 bank.openBank()

--- a/README.md
+++ b/README.md
@@ -1,6 +1,148 @@
-## iOS 커리어 스타터 캠프
+# 은행 창구 매니저🏦
 
-### 은행 매니저 프로젝트 저장소
+## 목차
+1. [소개](#1-소개)
+2. [팀원](#2-팀원)
+3. [타임라인](#3-타임라인)
+4. [프로젝트 구조](#4-프로젝트-구조)
+5. [실행화면(기능 설명)](#5-실행-화면기능-설명)
+6. [트러블슈팅](#6-트러블-슈팅)
+7. [참고링크](#7-참고-링크)
 
-- 이 저장소를 자신의 저장소로 fork하여 프로젝트를 진행합니다
+<br/>
+
+## 1. 소개
+ 은행에서 1명의 은행원이 10-30명 사이의 고객의 업무를 1:1로 처리해주는 콘솔앱 
+
+
+<br/>
+
+## 2. 팀원
+
+|⭐️Rhode| ⭐️Sehong |
+| :--------: | :-------: |
+|<img height="210px" src="https://i.imgur.com/XyDwGwe.jpg">| <img height="210px" src="https://i.imgur.com/64dvDJl.jpg"> |
+| Navigator / Driver | Navigator / Driver |
+
+
+
+</br>
+
+## 3. 타임라인
+### 프로젝트 진행 기간
+**23.03.06 (월) ~ 23.03.10 (금)** 
+
+|날짜|스텝| 타임라인 |
+| :-------: | :-------: | ------- |
+|03.06 (월) | STEP1 | BankQueue 구현 및 BankQueueTest 구현 |
+|03.07 (화) | STEP1 | BankQueue 리팩토링 |
+|03.08 (수) | STEP2 | Bank, Client, BankManager 구현 |
+|03.09 (목) | STEP2 | - |
+|03.10 (금) | STEP2 | Bank, Client, BankManager 리팩토링 |
+
+
+<br/>
+
+## 4. 프로젝트 구조
+### 폴더 구조
+
+````
+BankManagerConsoleApp
+│   ├── Bank.swift
+│   ├── Client.swift
+│   ├── Queue
+│   │   ├── LinkedList.swift
+│   │   ├── Node.swift
+│   │   └── Queue.swift
+│   └── main.swift
+└── QueueTest
+    └── QueueTest.swift
+````
+
+
+### 클래스 다이어그램
+
+<img height="600px" src="https://i.imgur.com/v8Tti2j.png">
+
+
+<br/>
+
+## 5. 실행 화면(기능 설명)
+![](https://i.imgur.com/Lw62WWD.gif)
+
+
+</br>
+
+## 6. 트러블 슈팅
+
+### 2. DispatchQueue.global().async가 실행되지 않았던 문제
+
+현재의 코드는 다음과 같습니다:
+
+```swift
+private mutating func distributeClient(bankManagerCount: Int) {
+    var clientList = managingClientQueue()
+    let bankManager = BankManager()
+    let group = DispatchGroup()
+    let semaphore = DispatchSemaphore(value: 1)
+    
+    for _ in Int.zero..<bankManagerCount {
+        DispatchQueue.global().async(group: group) {
+            semaphore.wait()
+            
+            while !clientList.isEmpty {
+                guard let client = clientList.dequeue()?.clientWaitingNumber else { return }
+                
+                bankManager.work(client: client)
+                semaphore.signal()
+            }
+        }
+    }
+    group.wait()
+}
+```
+원래는 코드에 `group.wait()`이 없었습니다. 그래서 `DispatchQueue.global().async(group: group)` 내부 코드가 실행되지 않았습니다. 비동기이기 때문에 업무를 던져주고 결과까지 기다리지 않는다는 것을 간과했었습니다. 그래서 `group.wait()` 코드를 삽입해주었습니다. 그 결과 해당 그룹의 모든 작업이 완료때까지 현재 스레드를 block 시킬 수 있었습니다.
+
+`wait()`의 정의는 다음과 같습니다:
+![](https://i.imgur.com/4Q4xCqb.png)
+
+이와 비슷한 기능으로는 `notify(queue:)`가 있는 것으로 알고 있습니다. `notify(queue:)`는 그룹으로 묶인 모든 작업이 끝났을 때 실행될 작업을 넘겨줍니다.
+
+
+
+
+
+
+
+### 2. 함수 실행 시간을 계산하는 workTime 메서드 구현
+
+
+은행원 n명이 단 하나의 업무를 수행하고 완료하는데 걸리는 시간은 0.7초 입니다. 해당 부분을 구현하기 위해서 단순히 작업 하나(손님 1명) 에 0.7을 곱하는 단순 계산을 선택하는 방식과 실제 작업시간을 계산하는 방식 중 어떤것을 사용할지 고민하였습니다.
+
+아래의 workTime 함수는 workTimeFunction이라는 매개변수를 가지는 클로저를 입력 받고, 해당 함수는 어떤 작업을 수행하는 함수를 의미합니다. 함수 내부에서는 먼저 작업 시작시간을 저장하고, 클로저를 호출하여 수행한 뒤 작업이 종료 되는 시간을 저장하고 있습니다. 이후 시작시간과 종료시간의 시간 차를 timeIntervalSince 메서드가 초단위로 계산하여 workTime을 반환해줍니다.
+
+```swift
+ private func workTime(workTimeFunction: () -> Void) -> TimeInterval {
+        let startTime = Date()
+        
+        workTimeFunction()
+        
+        let endTime = Date()
+        let workTime = endTime.timeIntervalSince(startTime)
+        
+        return workTime
+    }
+```
+
+
+
+
+
+## 7. 참고 링크
+
+> - [야곰닷넷 - 동시성프로그래밍](https://yagom.net/courses/%eb%8f%99%ec%8b%9c%ec%84%b1-%ed%94%84%eb%a1%9c%ea%b7%b8%eb%9e%98%eb%b0%8d-concurrency-programming/)
+> - [WWDC 2015 Protocol - Oriented Programming in Swift](https://developer.apple.com/videos/play/wwdc2016/720/)
+
+
+
 


### PR DESCRIPTION
@1Consumption
안녕하세요 올라프!⛄️⛄️⛄️⛄️ 
STEP3 PR 보냅니다.
다중처리하는 부분에 있어서 반복되는 코드가 생겨 어려움이 있었던 것 같습니다.
항상 바쁘신 와중에 리뷰해주셔서 감사합니다. 
이번에도 리뷰 잘 부탁드립니다.
감사합니다.⛄️



# 조언을 얻고 싶은 부분
## 1. manageClientQueue 메서드 client 생성자 분리하면서 발생하는 문제 

step2에서 손님 정보는 외부에서 생성자로 주입해줘도 좋을 것 같다는 조언을 얻어
```swift=
private mutating func manageClientQueue() -> Queue<Client> {
        var clientQueue = Queue<Client>()
        let randomClients = Int.random(in: 10...30)
    ....
```

수정후 아래와 같이 조금 더 직관적인 코드로 보기 좋게 수정되었습니다. 

```swift=

var bank = Bank(clientCount: Int.random(in: 10...30))

...

init(clientCount: Int) {
        self.clientCount = clientCount
    }

```

코드를 수정하고나서 무슨 문제인지ㅠ 고객의 수가 지정되어 업무를 마감하고 다시 은행 개점을 하면 같은 고객의 수가 반복되어 지정되는 문제가 발생하게 되었습니다. 해당 부분은 어떤식으로 해결해야할지 몰라서 원상태로 돌려뒀는데 원인을 알고싶습니다ㅠ


## 2. 업무는 동시적으로 처리되지만, 업무시간은 누계로 나오는 문제
업무는 동시적으로 처리가 되지만, 업무시간은 모든 업무의 누계로 나오는 문제가 발생하고 있습니다. 그러한 문제로 인하여 리팩토링을 하려고 하는데, 저희 코드 로직의 문제인지 아니면 `endTime.timeIntervalSince(startTime)` 코드의 문제인지 모르겠습니다. 

**다음은 저희가 겪고 있는 문제입니다**

이해를 돕기 위하여 고객의 수를 4명으로 정해보았습니다:

![](https://i.imgur.com/1pKZklN.png)

1번 고객은 대출업무를, 234번 고객은 예금 업무를 받습니다. 은행원은 A, B, C 세 명으로 A와 B는 예금 업무를, B는 대출업무를 처리합니다. 이 때 걸리는 시간은 다음과 같습니다:
 - A: 2번 고객(0.7초) -> 4번 고객(0.7초) => 1.4초
 - B: 3번 고객(0.7초) => 0.7초
 - C: 1번 고객(1.1초) => 1.1초
 - total: 1.4초

그런데, 저희의 코드는 총 3.21초를 나타내고 있습니다. 이는 1.4초와 0.7초와 1.1초를 더한 3.2초에 근사한 값입니다.

위와 같은 문제때문에 리팩토링을 하려고 합니다. 그런데, 무엇이 문제인지 파악할 수 없습니다.

콘솔창에는 2번->3번->1번->4번의 순서로 업무가 시작되고 종료되어 동시적으로 일을 처리하는 것처럼 보입니다. 그래서 저희의 코드가 동시적으로 업무를 처리하는 것에서 실패를 겪고 있는지 여부를 확인하기가 어렵습니다. 어떤 부분이 잘못 되었기에 업무시간이 누계로 나오는 것일까요? 올라프의 혜안을 나눠주시면 감사하겠습니다🥹🥲