### PR TITLE
은행창구 매니저 [STEP 1] yyss99(와이), 비모

### DIFF
--- a/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
+++ b/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		0A0F9C512A5BF74100AF5569 /* Node.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A0F9C502A5BF74100AF5569 /* Node.swift */; };
 		C7694E7A259C3EC00053667F /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7694E79259C3EC00053667F /* main.swift */; };
 		C7D65D1B259C8190005510E0 /* BankManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7D65D1A259C8190005510E0 /* BankManager.swift */; };
+		CB4ABCE22A5BF9FD00CC0097 /* LinkedList.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB4ABCE12A5BF9FD00CC0097 /* LinkedList.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -29,6 +30,7 @@
 		C7694E76259C3EC00053667F /* BankManagerConsoleApp */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = BankManagerConsoleApp; sourceTree = BUILT_PRODUCTS_DIR; };
 		C7694E79259C3EC00053667F /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
 		C7D65D1A259C8190005510E0 /* BankManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = BankManager.swift; path = ../../BankManager.swift; sourceTree = "<group>"; };
+		CB4ABCE12A5BF9FD00CC0097 /* LinkedList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkedList.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -64,6 +66,7 @@
 				C7D65D1A259C8190005510E0 /* BankManager.swift */,
 				C7694E79259C3EC00053667F /* main.swift */,
 				0A0F9C502A5BF74100AF5569 /* Node.swift */,
+				CB4ABCE12A5BF9FD00CC0097 /* LinkedList.swift */,
 			);
 			path = BankManagerConsoleApp;
 			sourceTree = "<group>";
@@ -127,6 +130,7 @@
 			files = (
 				0A0F9C512A5BF74100AF5569 /* Node.swift in Sources */,
 				C7694E7A259C3EC00053667F /* main.swift in Sources */,
+				CB4ABCE22A5BF9FD00CC0097 /* LinkedList.swift in Sources */,
 				C7D65D1B259C8190005510E0 /* BankManager.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
+++ b/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
@@ -12,6 +12,10 @@
 		C7694E7A259C3EC00053667F /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7694E79259C3EC00053667F /* main.swift */; };
 		C7D65D1B259C8190005510E0 /* BankManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7D65D1A259C8190005510E0 /* BankManager.swift */; };
 		CB4ABCE22A5BF9FD00CC0097 /* LinkedList.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB4ABCE12A5BF9FD00CC0097 /* LinkedList.swift */; };
+		CBFA091E2A5C28CD00901699 /* CustomerWaitingQueueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBFA091D2A5C28CD00901699 /* CustomerWaitingQueueTests.swift */; };
+		CBFA09232A5C295F00901699 /* CustomerWaitingQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A0F9C522A5C106500AF5569 /* CustomerWaitingQueue.swift */; };
+		CBFA09242A5C296100901699 /* LinkedList.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB4ABCE12A5BF9FD00CC0097 /* LinkedList.swift */; };
+		CBFA09252A5C296400901699 /* Node.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A0F9C502A5BF74100AF5569 /* Node.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -33,10 +37,20 @@
 		C7694E79259C3EC00053667F /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
 		C7D65D1A259C8190005510E0 /* BankManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = BankManager.swift; path = ../../BankManager.swift; sourceTree = "<group>"; };
 		CB4ABCE12A5BF9FD00CC0097 /* LinkedList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkedList.swift; sourceTree = "<group>"; };
+		CBFA091B2A5C28CD00901699 /* BankManagerConsoleAppTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = BankManagerConsoleAppTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		CBFA091D2A5C28CD00901699 /* CustomerWaitingQueueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomerWaitingQueueTests.swift; sourceTree = "<group>"; };
+		CBFA09222A5C28FE00901699 /* BankManagerConsoleApp.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = BankManagerConsoleApp.xctestplan; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
 		C7694E73259C3EC00053667F /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		CBFA09182A5C28CD00901699 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -49,7 +63,9 @@
 		C7694E6D259C3EC00053667F = {
 			isa = PBXGroup;
 			children = (
+				CBFA09222A5C28FE00901699 /* BankManagerConsoleApp.xctestplan */,
 				C7694E78259C3EC00053667F /* BankManagerConsoleApp */,
+				CBFA091C2A5C28CD00901699 /* BankManagerConsoleAppTests */,
 				C7694E77259C3EC00053667F /* Products */,
 			);
 			sourceTree = "<group>";
@@ -58,6 +74,7 @@
 			isa = PBXGroup;
 			children = (
 				C7694E76259C3EC00053667F /* BankManagerConsoleApp */,
+				CBFA091B2A5C28CD00901699 /* BankManagerConsoleAppTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -72,6 +89,14 @@
 				0A0F9C522A5C106500AF5569 /* CustomerWaitingQueue.swift */,
 			);
 			path = BankManagerConsoleApp;
+			sourceTree = "<group>";
+		};
+		CBFA091C2A5C28CD00901699 /* BankManagerConsoleAppTests */ = {
+			isa = PBXGroup;
+			children = (
+				CBFA091D2A5C28CD00901699 /* CustomerWaitingQueueTests.swift */,
+			);
+			path = BankManagerConsoleAppTests;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -94,17 +119,37 @@
 			productReference = C7694E76259C3EC00053667F /* BankManagerConsoleApp */;
 			productType = "com.apple.product-type.tool";
 		};
+		CBFA091A2A5C28CD00901699 /* BankManagerConsoleAppTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = CBFA09212A5C28CD00901699 /* Build configuration list for PBXNativeTarget "BankManagerConsoleAppTests" */;
+			buildPhases = (
+				CBFA09172A5C28CD00901699 /* Sources */,
+				CBFA09182A5C28CD00901699 /* Frameworks */,
+				CBFA09192A5C28CD00901699 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = BankManagerConsoleAppTests;
+			productName = BankManagerConsoleAppTests;
+			productReference = CBFA091B2A5C28CD00901699 /* BankManagerConsoleAppTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
 		C7694E6E259C3EC00053667F /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastSwiftUpdateCheck = 1210;
+				LastSwiftUpdateCheck = 1430;
 				LastUpgradeCheck = 1210;
 				TargetAttributes = {
 					C7694E75259C3EC00053667F = {
 						CreatedOnToolsVersion = 12.1;
+					};
+					CBFA091A2A5C28CD00901699 = {
+						CreatedOnToolsVersion = 14.3.1;
 					};
 				};
 			};
@@ -122,9 +167,20 @@
 			projectRoot = "";
 			targets = (
 				C7694E75259C3EC00053667F /* BankManagerConsoleApp */,
+				CBFA091A2A5C28CD00901699 /* BankManagerConsoleAppTests */,
 			);
 		};
 /* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		CBFA09192A5C28CD00901699 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		C7694E72259C3EC00053667F /* Sources */ = {
@@ -136,6 +192,17 @@
 				CB4ABCE22A5BF9FD00CC0097 /* LinkedList.swift in Sources */,
 				0A0F9C532A5C106500AF5569 /* CustomerWaitingQueue.swift in Sources */,
 				C7D65D1B259C8190005510E0 /* BankManager.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		CBFA09172A5C28CD00901699 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				CBFA09242A5C296100901699 /* LinkedList.swift in Sources */,
+				CBFA091E2A5C28CD00901699 /* CustomerWaitingQueueTests.swift in Sources */,
+				CBFA09232A5C295F00901699 /* CustomerWaitingQueue.swift in Sources */,
+				CBFA09252A5C296400901699 /* Node.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -275,6 +342,46 @@
 			};
 			name = Release;
 		};
+		CBFA091F2A5C28CD00901699 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				MACOSX_DEPLOYMENT_TARGET = 13.3;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.test.BankManagerConsoleAppTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = auto;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		CBFA09202A5C28CD00901699 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				MACOSX_DEPLOYMENT_TARGET = 13.3;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.test.BankManagerConsoleAppTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = auto;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -292,6 +399,15 @@
 			buildConfigurations = (
 				C7694E7E259C3EC00053667F /* Debug */,
 				C7694E7F259C3EC00053667F /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		CBFA09212A5C28CD00901699 /* Build configuration list for PBXNativeTarget "BankManagerConsoleAppTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				CBFA091F2A5C28CD00901699 /* Debug */,
+				CBFA09202A5C28CD00901699 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
+++ b/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		0A0F9C512A5BF74100AF5569 /* Node.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A0F9C502A5BF74100AF5569 /* Node.swift */; };
+		0A0F9C532A5C106500AF5569 /* CustomerWaitingQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A0F9C522A5C106500AF5569 /* CustomerWaitingQueue.swift */; };
 		C7694E7A259C3EC00053667F /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7694E79259C3EC00053667F /* main.swift */; };
 		C7D65D1B259C8190005510E0 /* BankManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7D65D1A259C8190005510E0 /* BankManager.swift */; };
 		CB4ABCE22A5BF9FD00CC0097 /* LinkedList.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB4ABCE12A5BF9FD00CC0097 /* LinkedList.swift */; };
@@ -27,6 +28,7 @@
 
 /* Begin PBXFileReference section */
 		0A0F9C502A5BF74100AF5569 /* Node.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Node.swift; sourceTree = "<group>"; };
+		0A0F9C522A5C106500AF5569 /* CustomerWaitingQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomerWaitingQueue.swift; sourceTree = "<group>"; };
 		C7694E76259C3EC00053667F /* BankManagerConsoleApp */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = BankManagerConsoleApp; sourceTree = BUILT_PRODUCTS_DIR; };
 		C7694E79259C3EC00053667F /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
 		C7D65D1A259C8190005510E0 /* BankManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = BankManager.swift; path = ../../BankManager.swift; sourceTree = "<group>"; };
@@ -67,6 +69,7 @@
 				C7694E79259C3EC00053667F /* main.swift */,
 				0A0F9C502A5BF74100AF5569 /* Node.swift */,
 				CB4ABCE12A5BF9FD00CC0097 /* LinkedList.swift */,
+				0A0F9C522A5C106500AF5569 /* CustomerWaitingQueue.swift */,
 			);
 			path = BankManagerConsoleApp;
 			sourceTree = "<group>";
@@ -131,6 +134,7 @@
 				0A0F9C512A5BF74100AF5569 /* Node.swift in Sources */,
 				C7694E7A259C3EC00053667F /* main.swift in Sources */,
 				CB4ABCE22A5BF9FD00CC0097 /* LinkedList.swift in Sources */,
+				0A0F9C532A5C106500AF5569 /* CustomerWaitingQueue.swift in Sources */,
 				C7D65D1B259C8190005510E0 /* BankManager.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
+++ b/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0A0F9C512A5BF74100AF5569 /* Node.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A0F9C502A5BF74100AF5569 /* Node.swift */; };
 		C7694E7A259C3EC00053667F /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7694E79259C3EC00053667F /* main.swift */; };
 		C7D65D1B259C8190005510E0 /* BankManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7D65D1A259C8190005510E0 /* BankManager.swift */; };
 /* End PBXBuildFile section */
@@ -24,6 +25,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		0A0F9C502A5BF74100AF5569 /* Node.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Node.swift; sourceTree = "<group>"; };
 		C7694E76259C3EC00053667F /* BankManagerConsoleApp */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = BankManagerConsoleApp; sourceTree = BUILT_PRODUCTS_DIR; };
 		C7694E79259C3EC00053667F /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
 		C7D65D1A259C8190005510E0 /* BankManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = BankManager.swift; path = ../../BankManager.swift; sourceTree = "<group>"; };
@@ -61,6 +63,7 @@
 			children = (
 				C7D65D1A259C8190005510E0 /* BankManager.swift */,
 				C7694E79259C3EC00053667F /* main.swift */,
+				0A0F9C502A5BF74100AF5569 /* Node.swift */,
 			);
 			path = BankManagerConsoleApp;
 			sourceTree = "<group>";
@@ -122,6 +125,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				0A0F9C512A5BF74100AF5569 /* Node.swift in Sources */,
 				C7694E7A259C3EC00053667F /* main.swift in Sources */,
 				C7D65D1B259C8190005510E0 /* BankManager.swift in Sources */,
 			);

--- a/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/xcshareddata/xcschemes/BankManagerConsoleApp.xcscheme
+++ b/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/xcshareddata/xcschemes/BankManagerConsoleApp.xcscheme
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1430"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "C7694E75259C3EC00053667F"
+               BuildableName = "BankManagerConsoleApp"
+               BlueprintName = "BankManagerConsoleApp"
+               ReferencedContainer = "container:BankManagerConsoleApp.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <TestPlans>
+         <TestPlanReference
+            reference = "container:BankManagerConsoleApp.xctestplan"
+            default = "YES">
+         </TestPlanReference>
+      </TestPlans>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES"
+      viewDebuggingEnabled = "No">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "C7694E75259C3EC00053667F"
+            BuildableName = "BankManagerConsoleApp"
+            BlueprintName = "BankManagerConsoleApp"
+            ReferencedContainer = "container:BankManagerConsoleApp.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "C7694E75259C3EC00053667F"
+            BuildableName = "BankManagerConsoleApp"
+            BlueprintName = "BankManagerConsoleApp"
+            ReferencedContainer = "container:BankManagerConsoleApp.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/BankManagerConsoleApp/BankManagerConsoleApp.xctestplan
+++ b/BankManagerConsoleApp/BankManagerConsoleApp.xctestplan
@@ -1,0 +1,29 @@
+{
+  "configurations" : [
+    {
+      "id" : "56238757-FD64-4EF8-A3A7-3FF3D5A9CB2F",
+      "name" : "Test Scheme Action",
+      "options" : {
+
+      }
+    }
+  ],
+  "defaultOptions" : {
+    "targetForVariableExpansion" : {
+      "containerPath" : "container:BankManagerConsoleApp.xcodeproj",
+      "identifier" : "C7694E75259C3EC00053667F",
+      "name" : "BankManagerConsoleApp"
+    }
+  },
+  "testTargets" : [
+    {
+      "parallelizable" : true,
+      "target" : {
+        "containerPath" : "container:BankManagerConsoleApp.xcodeproj",
+        "identifier" : "CBFA091A2A5C28CD00901699",
+        "name" : "BankManagerConsoleAppTests"
+      }
+    }
+  ],
+  "version" : 1
+}

--- a/BankManagerConsoleApp/BankManagerConsoleApp/CustomerWaitingQueue.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/CustomerWaitingQueue.swift
@@ -1,0 +1,30 @@
+//
+//  CustomerWaitingQueue.swift
+//  BankManagerConsoleApp
+//
+//  Created by yyss99, 비모 on 2023/07/10.
+//
+
+struct CustomerWaitingQueue<Element> {
+    private var list: LinkedList<Element> = LinkedList()
+    
+    var peek: Element? {
+        return list.first
+    }
+    
+    var isEmpty: Bool {
+        return list.isEmpty
+    }
+    
+    mutating func enqueue(_ newElemet: Element) {
+        list.append(newElemet)
+    }
+    
+    mutating func dequeue() -> Element? {
+        return list.popFirst()
+    }
+    
+    mutating func clear() {
+        list = LinkedList()
+    }
+}

--- a/BankManagerConsoleApp/BankManagerConsoleApp/CustomerWaitingQueue.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/CustomerWaitingQueue.swift
@@ -16,6 +16,10 @@ struct CustomerWaitingQueue<Element> {
         return list.isEmpty
     }
     
+    var count: Int {
+        return list.count
+    }
+    
     mutating func enqueue(_ newElemet: Element) {
         list.append(newElemet)
     }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/LinkedList.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/LinkedList.swift
@@ -8,6 +8,7 @@
 struct LinkedList<Element> {
     private var head: Node<Element>?
     private var tail: Node<Element>?
+    private(set) var count: Int = 0
     
     var isEmpty: Bool {
         return head == nil
@@ -27,6 +28,7 @@ struct LinkedList<Element> {
         
         tail?.next = newNode
         tail = newNode
+        count += 1
     }
     
     mutating func popFirst() -> Element? {
@@ -35,6 +37,7 @@ struct LinkedList<Element> {
         }
         
         head = head?.next
+        count -= 1
         
         return data
     }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/LinkedList.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/LinkedList.swift
@@ -1,0 +1,41 @@
+//
+//  LinkedList.swift
+//  BankManagerConsoleApp
+//
+//  Created by yyss99, 비모 on 2023/07/10.
+//
+
+struct LinkedList<Element> {
+    private var head: Node<Element>?
+    private var tail: Node<Element>?
+    
+    var isEmpty: Bool {
+        return head == nil
+    }
+    
+    var first: Element? {
+        return head?.data
+    }
+    
+    mutating func append(_ newElement: Element) {
+        let newNode = Node(data: newElement)
+        
+        if isEmpty {
+            head = newNode
+            tail = newNode
+        }
+        
+        tail?.next = newNode
+        tail = newNode
+    }
+    
+    mutating func popFirst() -> Element? {
+        guard let data = head?.data else {
+            return nil
+        }
+        
+        head = head?.next
+        
+        return data
+    }
+}

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Node.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Node.swift
@@ -1,0 +1,16 @@
+//
+//  Node.swift
+//  BankManagerConsoleApp
+//
+//  Created by yyss99, 비모 on 2023/07/10.
+//
+
+final class Node<Element> {
+    var data: Element
+    var next: Node?
+    
+    init(data: Element, next: Node? = nil) {
+        self.data = data
+        self.next = next
+    }
+}

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Node.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Node.swift
@@ -6,7 +6,7 @@
 //
 
 final class Node<Element> {
-    var data: Element
+    private(set) var data: Element
     var next: Node?
     
     init(data: Element, next: Node? = nil) {

--- a/BankManagerConsoleApp/BankManagerConsoleAppTests/CustomerWaitingQueueTests.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleAppTests/CustomerWaitingQueueTests.swift
@@ -1,0 +1,112 @@
+//
+//  CustomerWaitingQueueTests.swift
+//  BankManagerConsoleAppTests
+//
+//  Created by yyss99, 비모 on 2023/07/10.
+//
+
+import XCTest
+@testable import BankManagerConsoleApp
+
+final class CustomerWaitingQueueTests: XCTestCase {
+    var sut: CustomerWaitingQueue<String>!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        sut = CustomerWaitingQueue()
+    }
+
+    override func tearDownWithError() throws {
+        sut = nil
+        try super.tearDownWithError()
+    }
+
+    func test_초기상태에서_isEmpty가_true를_반환한다() {
+        // given
+        
+        // when
+        let result = sut.isEmpty
+        let expectedValue = true
+        
+        // then
+        XCTAssertEqual(result, expectedValue)
+    }
+    
+    func test_enqueue_했을때_isEmpty가_false를_반환한다() {
+        // given
+        sut.enqueue("something")
+        
+        // when
+        let result = sut.isEmpty
+        let expectedValue = false
+        
+        // then
+        XCTAssertEqual(result, expectedValue)
+    }
+
+    func test_enqueue를_3회_하면_count가_3을_반환한다() {
+        // given
+        sut.enqueue("1")
+        sut.enqueue("2")
+        sut.enqueue("3")
+        
+        // when
+        let result = sut.count
+        let expectedValue = 3
+        
+        // then
+        XCTAssertEqual(result, expectedValue)
+    }
+    
+    func test_enqueue_a후_dequeue시_a를_반환한다() {
+        // given
+        sut.enqueue("a")
+        
+        // when
+        let result = sut.dequeue()
+        let expectedValue = "a"
+        
+        // then
+        XCTAssertEqual(result, expectedValue)
+    }
+    
+    func test_enqueue후_clear시_isEmpty가_true를_반환한다() {
+        // given
+        sut.enqueue("1")
+        sut.enqueue("2")
+        sut.enqueue("3")
+        sut.clear()
+        
+        // when
+        let result = sut.isEmpty
+        let expectedValue = true
+        
+        // then
+        XCTAssertEqual(result, expectedValue)
+    }
+    
+    func test_enqueue_a_b_c후_peek이_a를_반환한다() {
+        // given
+        sut.enqueue("a")
+        sut.enqueue("b")
+        sut.enqueue("c")
+        
+        // when
+        let result = sut.peek
+        let expectedValue = "a"
+        
+        // then
+        XCTAssertEqual(result, expectedValue)
+    }
+    
+    func test_초기상태에서_dequeue가_nil을_반환한다() {
+        // given
+        
+        // when
+        let result = sut.dequeue()
+        let expectedValue: String? = nil
+        
+        // then
+        XCTAssertEqual(result, expectedValue)
+    }
+}

--- a/BankManagerConsoleApp/BankManagerConsoleAppTests/CustomerWaitingQueueTests.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleAppTests/CustomerWaitingQueueTests.swift
@@ -46,13 +46,15 @@ final class CustomerWaitingQueueTests: XCTestCase {
 
     func test_enqueue를_3회_하면_count가_3을_반환한다() {
         // given
-        sut.enqueue("1")
-        sut.enqueue("2")
-        sut.enqueue("3")
+        let dummyArray = ["1", "2", "3"]
+        
+        for element in dummyArray {
+            sut.enqueue(element)
+        }
         
         // when
         let result = sut.count
-        let expectedValue = 3
+        let expectedValue = dummyArray.count
         
         // then
         XCTAssertEqual(result, expectedValue)
@@ -87,13 +89,15 @@ final class CustomerWaitingQueueTests: XCTestCase {
     
     func test_enqueue_a_b_c후_peek이_a를_반환한다() {
         // given
-        sut.enqueue("a")
-        sut.enqueue("b")
-        sut.enqueue("c")
+        let dummyArray = ["a", "b", "c"]
+        
+        for element in dummyArray {
+            sut.enqueue(element)
+        }
         
         // when
         let result = sut.peek
-        let expectedValue = "a"
+        let expectedValue = dummyArray.first
         
         // then
         XCTAssertEqual(result, expectedValue)


### PR DESCRIPTION
안녕하세요 Steven! @stevenkim18 
와이 & 비모입니다.
은행창구 매니저 Step1 PR 전송합니다!
2주간  잘 부탁드립니다 😆

---

## 고민했던점

### 1️⃣ Generic Type의 이름

 `T`와 `Element`를 제네릭 타입 선언시 많이 사용한다고 알고 있었습니다. 그 중에서 큐 타입을 구현할때 어떤 것을 써야 할 까 고민이 되어서 둘의 차이점을 찾아 보았습니다.
 `T`는 제네릭 타입을 선언할 때 일반적으로 사용되는 관례적인 이름이고, `Element`는 컬렉션 또는 자료구조에서 개별 요소를 나타내는 데에 사용되는 관례적인 이름이라는 차이점을 알았습니다.
저희는 큐 라는 자료구조를 구현하는 것이기 때문에 `Element`를 사용하기로 결정했습니다.

### 2️⃣ XCode 14.3에서 Unit Test를 하기 위한 방법 변경

저희는 `BankManagerConsoleApp`내에 `Queue`를 구현했습니다. 그리고 `Queue`의 기능을 테스트 하기 위해 `Test navigator`에서 새로운 `Unit Test Target - Unit Testing Bundle`을 추가했습니다. 기존에는 이것만으로 테스트를 진행할 수 있었으나, `XCode 14.3` 부터는 해당 `Scheme`에 대해 `Autocreated`된 `test`를 활용하는 것으로 바뀌었습니다. `Autocreated`된 `Test Plan`은 저희가 추가한 `Unit Testing Bundle`을 자동으로 인식하지 못했기 때문에, 해당 `Test Plan`에 `target`으로 앞서 생성한 `Unit Testing Bundle`을 추가했습니다. 이렇게 target을 추가하는 경우 `xctestplan` 파일이 생성되고, 해당 파일은 `File navigator`에서 확인할 수 있습니다. 이 방법을 통해 이전과 동일하게 테스트하고, 해당 테스트에 대한 `Coverage`까지 확인할 수 있었습니다.