### PR TITLE
은행창구 매니저 [STEP 1] hoon, minsup

### DIFF
--- a/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
+++ b/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		1F96FE622A5D410B0020C741 /* QueueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F96FE612A5D410B0020C741 /* QueueTests.swift */; };
+		1F96FE632A5D41770020C741 /* Queue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7862DA7C2A5C1591005A5608 /* Queue.swift */; };
 		1FA1723C2A5C0715006C1894 /* LinkedList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FA1723B2A5C0715006C1894 /* LinkedList.swift */; };
 		1FEBA2F22A5CFE7400963E02 /* NodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FEBA2F12A5CFE7400963E02 /* NodeTests.swift */; };
 		7862DA7B2A5C02D8005A5608 /* Node.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7862DA7A2A5C02D8005A5608 /* Node.swift */; };
@@ -31,6 +33,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		1F96FE612A5D410B0020C741 /* QueueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QueueTests.swift; sourceTree = "<group>"; };
 		1FA1723B2A5C0715006C1894 /* LinkedList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkedList.swift; sourceTree = "<group>"; };
 		1FEBA2EA2A5CFE3B00963E02 /* BankManagerConsoleAppTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = BankManagerConsoleAppTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		1FEBA2F12A5CFE7400963E02 /* NodeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NodeTests.swift; sourceTree = "<group>"; };
@@ -65,6 +68,7 @@
 			children = (
 				7897B9D42A5D1A22008F207D /* LinkedListTests.swift */,
 				1FEBA2F12A5CFE7400963E02 /* NodeTests.swift */,
+				1F96FE612A5D410B0020C741 /* QueueTests.swift */,
 			);
 			path = BankManagerConsoleAppTests;
 			sourceTree = "<group>";
@@ -190,7 +194,9 @@
 			buildActionMask = 2147483647;
 			files = (
 				1FEBA2F22A5CFE7400963E02 /* NodeTests.swift in Sources */,
+				1F96FE632A5D41770020C741 /* Queue.swift in Sources */,
 				7897B9D52A5D1A22008F207D /* LinkedListTests.swift in Sources */,
+				1F96FE622A5D410B0020C741 /* QueueTests.swift in Sources */,
 				7897B9DA2A5D26F5008F207D /* LinkedList.swift in Sources */,
 				7897B9D32A5D0C35008F207D /* Node.swift in Sources */,
 			);

--- a/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
+++ b/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
@@ -13,9 +13,9 @@
 		1FEBA2F22A5CFE7400963E02 /* NodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FEBA2F12A5CFE7400963E02 /* NodeTests.swift */; };
 		7862DA7B2A5C02D8005A5608 /* Node.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7862DA7A2A5C02D8005A5608 /* Node.swift */; };
 		7862DA7D2A5C1591005A5608 /* Queue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7862DA7C2A5C1591005A5608 /* Queue.swift */; };
-		7897B9D32A5D0C35008F207D /* Node.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7862DA7A2A5C02D8005A5608 /* Node.swift */; };
 		7897B9D52A5D1A22008F207D /* LinkedListTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7897B9D42A5D1A22008F207D /* LinkedListTests.swift */; };
 		7897B9DA2A5D26F5008F207D /* LinkedList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FA1723B2A5C0715006C1894 /* LinkedList.swift */; };
+		78CB787E2A5FA218004B1124 /* Node.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7862DA7A2A5C02D8005A5608 /* Node.swift */; };
 		C7694E7A259C3EC00053667F /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7694E79259C3EC00053667F /* main.swift */; };
 		C7D65D1B259C8190005510E0 /* BankManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7D65D1A259C8190005510E0 /* BankManager.swift */; };
 /* End PBXBuildFile section */
@@ -196,9 +196,9 @@
 				1FEBA2F22A5CFE7400963E02 /* NodeTests.swift in Sources */,
 				1F96FE632A5D41770020C741 /* Queue.swift in Sources */,
 				7897B9D52A5D1A22008F207D /* LinkedListTests.swift in Sources */,
+				78CB787E2A5FA218004B1124 /* Node.swift in Sources */,
 				1F96FE622A5D410B0020C741 /* QueueTests.swift in Sources */,
 				7897B9DA2A5D26F5008F207D /* LinkedList.swift in Sources */,
-				7897B9D32A5D0C35008F207D /* Node.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
+++ b/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
@@ -8,6 +8,8 @@
 
 /* Begin PBXBuildFile section */
 		1FA1723C2A5C0715006C1894 /* LinkedList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FA1723B2A5C0715006C1894 /* LinkedList.swift */; };
+		1FEBA2F22A5CFE7400963E02 /* NodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FEBA2F12A5CFE7400963E02 /* NodeTests.swift */; };
+		1FEBA2F32A5CFE7F00963E02 /* Node.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7862DA7A2A5C02D8005A5608 /* Node.swift */; };
 		7862DA7B2A5C02D8005A5608 /* Node.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7862DA7A2A5C02D8005A5608 /* Node.swift */; };
 		7862DA7D2A5C1591005A5608 /* Queue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7862DA7C2A5C1591005A5608 /* Queue.swift */; };
 		C7694E7A259C3EC00053667F /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7694E79259C3EC00053667F /* main.swift */; };
@@ -28,6 +30,8 @@
 
 /* Begin PBXFileReference section */
 		1FA1723B2A5C0715006C1894 /* LinkedList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkedList.swift; sourceTree = "<group>"; };
+		1FEBA2EA2A5CFE3B00963E02 /* BankManagerConsoleAppTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = BankManagerConsoleAppTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		1FEBA2F12A5CFE7400963E02 /* NodeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NodeTests.swift; sourceTree = "<group>"; };
 		7862DA7A2A5C02D8005A5608 /* Node.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Node.swift; sourceTree = "<group>"; };
 		7862DA7C2A5C1591005A5608 /* Queue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Queue.swift; sourceTree = "<group>"; };
 		C7694E76259C3EC00053667F /* BankManagerConsoleApp */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = BankManagerConsoleApp; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -36,6 +40,13 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		1FEBA2E72A5CFE3B00963E02 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		C7694E73259C3EC00053667F /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -46,10 +57,19 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		1FEBA2EB2A5CFE3B00963E02 /* BankManagerConsoleAppTests */ = {
+			isa = PBXGroup;
+			children = (
+				1FEBA2F12A5CFE7400963E02 /* NodeTests.swift */,
+			);
+			path = BankManagerConsoleAppTests;
+			sourceTree = "<group>";
+		};
 		C7694E6D259C3EC00053667F = {
 			isa = PBXGroup;
 			children = (
 				C7694E78259C3EC00053667F /* BankManagerConsoleApp */,
+				1FEBA2EB2A5CFE3B00963E02 /* BankManagerConsoleAppTests */,
 				C7694E77259C3EC00053667F /* Products */,
 			);
 			sourceTree = "<group>";
@@ -58,6 +78,7 @@
 			isa = PBXGroup;
 			children = (
 				C7694E76259C3EC00053667F /* BankManagerConsoleApp */,
+				1FEBA2EA2A5CFE3B00963E02 /* BankManagerConsoleAppTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -77,6 +98,23 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
+		1FEBA2E92A5CFE3B00963E02 /* BankManagerConsoleAppTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 1FEBA2F02A5CFE3B00963E02 /* Build configuration list for PBXNativeTarget "BankManagerConsoleAppTests" */;
+			buildPhases = (
+				1FEBA2E62A5CFE3B00963E02 /* Sources */,
+				1FEBA2E72A5CFE3B00963E02 /* Frameworks */,
+				1FEBA2E82A5CFE3B00963E02 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = BankManagerConsoleAppTests;
+			productName = BankManagerConsoleAppTests;
+			productReference = 1FEBA2EA2A5CFE3B00963E02 /* BankManagerConsoleAppTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 		C7694E75259C3EC00053667F /* BankManagerConsoleApp */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = C7694E7D259C3EC00053667F /* Build configuration list for PBXNativeTarget "BankManagerConsoleApp" */;
@@ -100,9 +138,13 @@
 		C7694E6E259C3EC00053667F /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastSwiftUpdateCheck = 1210;
+				LastSwiftUpdateCheck = 1420;
 				LastUpgradeCheck = 1210;
 				TargetAttributes = {
+					1FEBA2E92A5CFE3B00963E02 = {
+						CreatedOnToolsVersion = 14.2;
+						LastSwiftMigration = 1420;
+					};
 					C7694E75259C3EC00053667F = {
 						CreatedOnToolsVersion = 12.1;
 					};
@@ -122,11 +164,31 @@
 			projectRoot = "";
 			targets = (
 				C7694E75259C3EC00053667F /* BankManagerConsoleApp */,
+				1FEBA2E92A5CFE3B00963E02 /* BankManagerConsoleAppTests */,
 			);
 		};
 /* End PBXProject section */
 
+/* Begin PBXResourcesBuildPhase section */
+		1FEBA2E82A5CFE3B00963E02 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
 /* Begin PBXSourcesBuildPhase section */
+		1FEBA2E62A5CFE3B00963E02 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				1FEBA2F22A5CFE7400963E02 /* NodeTests.swift in Sources */,
+				1FEBA2F32A5CFE7F00963E02 /* Node.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		C7694E72259C3EC00053667F /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -142,6 +204,59 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin XCBuildConfiguration section */
+		1FEBA2EE2A5CFE3B00963E02 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.2;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 12.6;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = minseong.BankManagerConsoleAppTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = auto;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		1FEBA2EF2A5CFE3B00963E02 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.2;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 12.6;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = minseong.BankManagerConsoleAppTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = auto;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
 		C7694E7B259C3EC00053667F /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -278,6 +393,15 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		1FEBA2F02A5CFE3B00963E02 /* Build configuration list for PBXNativeTarget "BankManagerConsoleAppTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				1FEBA2EE2A5CFE3B00963E02 /* Debug */,
+				1FEBA2EF2A5CFE3B00963E02 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		C7694E71259C3EC00053667F /* Build configuration list for PBXProject "BankManagerConsoleApp" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
+++ b/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		1FA1723C2A5C0715006C1894 /* LinkedList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FA1723B2A5C0715006C1894 /* LinkedList.swift */; };
 		7862DA7B2A5C02D8005A5608 /* Node.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7862DA7A2A5C02D8005A5608 /* Node.swift */; };
 		C7694E7A259C3EC00053667F /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7694E79259C3EC00053667F /* main.swift */; };
 		C7D65D1B259C8190005510E0 /* BankManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7D65D1A259C8190005510E0 /* BankManager.swift */; };
@@ -25,6 +26,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		1FA1723B2A5C0715006C1894 /* LinkedList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkedList.swift; sourceTree = "<group>"; };
 		7862DA7A2A5C02D8005A5608 /* Node.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Node.swift; sourceTree = "<group>"; };
 		C7694E76259C3EC00053667F /* BankManagerConsoleApp */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = BankManagerConsoleApp; sourceTree = BUILT_PRODUCTS_DIR; };
 		C7694E79259C3EC00053667F /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
@@ -64,6 +66,7 @@
 				C7D65D1A259C8190005510E0 /* BankManager.swift */,
 				C7694E79259C3EC00053667F /* main.swift */,
 				7862DA7A2A5C02D8005A5608 /* Node.swift */,
+				1FA1723B2A5C0715006C1894 /* LinkedList.swift */,
 			);
 			path = BankManagerConsoleApp;
 			sourceTree = "<group>";
@@ -127,6 +130,7 @@
 			files = (
 				7862DA7B2A5C02D8005A5608 /* Node.swift in Sources */,
 				C7694E7A259C3EC00053667F /* main.swift in Sources */,
+				1FA1723C2A5C0715006C1894 /* LinkedList.swift in Sources */,
 				C7D65D1B259C8190005510E0 /* BankManager.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
+++ b/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		7862DA7B2A5C02D8005A5608 /* Node.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7862DA7A2A5C02D8005A5608 /* Node.swift */; };
 		C7694E7A259C3EC00053667F /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7694E79259C3EC00053667F /* main.swift */; };
 		C7D65D1B259C8190005510E0 /* BankManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7D65D1A259C8190005510E0 /* BankManager.swift */; };
 /* End PBXBuildFile section */
@@ -24,6 +25,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		7862DA7A2A5C02D8005A5608 /* Node.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Node.swift; sourceTree = "<group>"; };
 		C7694E76259C3EC00053667F /* BankManagerConsoleApp */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = BankManagerConsoleApp; sourceTree = BUILT_PRODUCTS_DIR; };
 		C7694E79259C3EC00053667F /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
 		C7D65D1A259C8190005510E0 /* BankManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = BankManager.swift; path = ../../BankManager.swift; sourceTree = "<group>"; };
@@ -61,6 +63,7 @@
 			children = (
 				C7D65D1A259C8190005510E0 /* BankManager.swift */,
 				C7694E79259C3EC00053667F /* main.swift */,
+				7862DA7A2A5C02D8005A5608 /* Node.swift */,
 			);
 			path = BankManagerConsoleApp;
 			sourceTree = "<group>";
@@ -122,6 +125,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				7862DA7B2A5C02D8005A5608 /* Node.swift in Sources */,
 				C7694E7A259C3EC00053667F /* main.swift in Sources */,
 				C7D65D1B259C8190005510E0 /* BankManager.swift in Sources */,
 			);

--- a/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
+++ b/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		1FA1723C2A5C0715006C1894 /* LinkedList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FA1723B2A5C0715006C1894 /* LinkedList.swift */; };
 		7862DA7B2A5C02D8005A5608 /* Node.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7862DA7A2A5C02D8005A5608 /* Node.swift */; };
+		7862DA7D2A5C1591005A5608 /* Queue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7862DA7C2A5C1591005A5608 /* Queue.swift */; };
 		C7694E7A259C3EC00053667F /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7694E79259C3EC00053667F /* main.swift */; };
 		C7D65D1B259C8190005510E0 /* BankManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7D65D1A259C8190005510E0 /* BankManager.swift */; };
 /* End PBXBuildFile section */
@@ -28,6 +29,7 @@
 /* Begin PBXFileReference section */
 		1FA1723B2A5C0715006C1894 /* LinkedList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkedList.swift; sourceTree = "<group>"; };
 		7862DA7A2A5C02D8005A5608 /* Node.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Node.swift; sourceTree = "<group>"; };
+		7862DA7C2A5C1591005A5608 /* Queue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Queue.swift; sourceTree = "<group>"; };
 		C7694E76259C3EC00053667F /* BankManagerConsoleApp */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = BankManagerConsoleApp; sourceTree = BUILT_PRODUCTS_DIR; };
 		C7694E79259C3EC00053667F /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
 		C7D65D1A259C8190005510E0 /* BankManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = BankManager.swift; path = ../../BankManager.swift; sourceTree = "<group>"; };
@@ -67,6 +69,7 @@
 				C7694E79259C3EC00053667F /* main.swift */,
 				7862DA7A2A5C02D8005A5608 /* Node.swift */,
 				1FA1723B2A5C0715006C1894 /* LinkedList.swift */,
+				7862DA7C2A5C1591005A5608 /* Queue.swift */,
 			);
 			path = BankManagerConsoleApp;
 			sourceTree = "<group>";
@@ -128,6 +131,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				7862DA7D2A5C1591005A5608 /* Queue.swift in Sources */,
 				7862DA7B2A5C02D8005A5608 /* Node.swift in Sources */,
 				C7694E7A259C3EC00053667F /* main.swift in Sources */,
 				1FA1723C2A5C0715006C1894 /* LinkedList.swift in Sources */,

--- a/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
+++ b/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
@@ -3,15 +3,17 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 50;
+	objectVersion = 53;
 	objects = {
 
 /* Begin PBXBuildFile section */
 		1FA1723C2A5C0715006C1894 /* LinkedList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FA1723B2A5C0715006C1894 /* LinkedList.swift */; };
 		1FEBA2F22A5CFE7400963E02 /* NodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FEBA2F12A5CFE7400963E02 /* NodeTests.swift */; };
-		1FEBA2F32A5CFE7F00963E02 /* Node.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7862DA7A2A5C02D8005A5608 /* Node.swift */; };
 		7862DA7B2A5C02D8005A5608 /* Node.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7862DA7A2A5C02D8005A5608 /* Node.swift */; };
 		7862DA7D2A5C1591005A5608 /* Queue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7862DA7C2A5C1591005A5608 /* Queue.swift */; };
+		7897B9D32A5D0C35008F207D /* Node.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7862DA7A2A5C02D8005A5608 /* Node.swift */; };
+		7897B9D52A5D1A22008F207D /* LinkedListTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7897B9D42A5D1A22008F207D /* LinkedListTests.swift */; };
+		7897B9DA2A5D26F5008F207D /* LinkedList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FA1723B2A5C0715006C1894 /* LinkedList.swift */; };
 		C7694E7A259C3EC00053667F /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7694E79259C3EC00053667F /* main.swift */; };
 		C7D65D1B259C8190005510E0 /* BankManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7D65D1A259C8190005510E0 /* BankManager.swift */; };
 /* End PBXBuildFile section */
@@ -34,6 +36,7 @@
 		1FEBA2F12A5CFE7400963E02 /* NodeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NodeTests.swift; sourceTree = "<group>"; };
 		7862DA7A2A5C02D8005A5608 /* Node.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Node.swift; sourceTree = "<group>"; };
 		7862DA7C2A5C1591005A5608 /* Queue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Queue.swift; sourceTree = "<group>"; };
+		7897B9D42A5D1A22008F207D /* LinkedListTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkedListTests.swift; sourceTree = "<group>"; };
 		C7694E76259C3EC00053667F /* BankManagerConsoleApp */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = BankManagerConsoleApp; sourceTree = BUILT_PRODUCTS_DIR; };
 		C7694E79259C3EC00053667F /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
 		C7D65D1A259C8190005510E0 /* BankManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = BankManager.swift; path = ../../BankManager.swift; sourceTree = "<group>"; };
@@ -60,6 +63,7 @@
 		1FEBA2EB2A5CFE3B00963E02 /* BankManagerConsoleAppTests */ = {
 			isa = PBXGroup;
 			children = (
+				7897B9D42A5D1A22008F207D /* LinkedListTests.swift */,
 				1FEBA2F12A5CFE7400963E02 /* NodeTests.swift */,
 			);
 			path = BankManagerConsoleAppTests;
@@ -138,8 +142,9 @@
 		C7694E6E259C3EC00053667F /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
+				BuildIndependentTargetsInParallel = YES;
 				LastSwiftUpdateCheck = 1420;
-				LastUpgradeCheck = 1210;
+				LastUpgradeCheck = 1430;
 				TargetAttributes = {
 					1FEBA2E92A5CFE3B00963E02 = {
 						CreatedOnToolsVersion = 14.2;
@@ -185,7 +190,9 @@
 			buildActionMask = 2147483647;
 			files = (
 				1FEBA2F22A5CFE7400963E02 /* NodeTests.swift in Sources */,
-				1FEBA2F32A5CFE7F00963E02 /* Node.swift in Sources */,
+				7897B9D52A5D1A22008F207D /* LinkedListTests.swift in Sources */,
+				7897B9DA2A5D26F5008F207D /* LinkedList.swift in Sources */,
+				7897B9D32A5D0C35008F207D /* Node.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -211,6 +218,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
+				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 16.2;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -238,6 +246,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
+				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 16.2;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -291,6 +300,7 @@
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
+				DEAD_CODE_STRIPPING = YES;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
@@ -352,6 +362,7 @@
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
+				DEAD_CODE_STRIPPING = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
@@ -376,6 +387,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
+				DEAD_CODE_STRIPPING = YES;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 			};
@@ -385,6 +397,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
+				DEAD_CODE_STRIPPING = YES;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 			};

--- a/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/xcshareddata/xcschemes/BankManagerConsoleApp.xcscheme
+++ b/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/xcshareddata/xcschemes/BankManagerConsoleApp.xcscheme
@@ -1,10 +1,26 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1420"
+   LastUpgradeVersion = "1430"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "C7694E75259C3EC00053667F"
+               BuildableName = "BankManagerConsoleApp"
+               BlueprintName = "BankManagerConsoleApp"
+               ReferencedContainer = "container:BankManagerConsoleApp.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
    </BuildAction>
    <TestAction
       buildConfiguration = "Debug"
@@ -13,23 +29,10 @@
       shouldUseLaunchSchemeArgsEnv = "YES">
       <TestPlans>
          <TestPlanReference
-            reference = "container:BankManagerConsoleApp.xcodeproj/QueueTests.xctestplan"
+            reference = "container:BankManagerConsoleApp.xctestplan"
             default = "YES">
          </TestPlanReference>
       </TestPlans>
-      <Testables>
-         <TestableReference
-            skipped = "NO"
-            parallelizable = "YES">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "1FA172402A5C3E7D006C1894"
-               BuildableName = "QueueTests.xctest"
-               BlueprintName = "QueueTests"
-               ReferencedContainer = "container:BankManagerConsoleApp.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-      </Testables>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -40,7 +43,8 @@
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
-      allowLocationSimulation = "YES">
+      allowLocationSimulation = "YES"
+      viewDebuggingEnabled = "No">
       <BuildableProductRunnable
          runnableDebuggingMode = "0">
          <BuildableReference
@@ -58,6 +62,16 @@
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "C7694E75259C3EC00053667F"
+            BuildableName = "BankManagerConsoleApp"
+            BlueprintName = "BankManagerConsoleApp"
+            ReferencedContainer = "container:BankManagerConsoleApp.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/xcshareddata/xcschemes/BankManagerConsoleAppTests.xcscheme
+++ b/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/xcshareddata/xcschemes/BankManagerConsoleAppTests.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1420"
+   LastUpgradeVersion = "1430"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/xcshareddata/xcschemes/BankManagerConsoleAppTests.xcscheme
+++ b/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/xcshareddata/xcschemes/BankManagerConsoleAppTests.xcscheme
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1420"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      codeCoverageEnabled = "YES">
+      <CodeCoverageTargets>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "C7694E75259C3EC00053667F"
+            BuildableName = "BankManagerConsoleApp"
+            BlueprintName = "BankManagerConsoleApp"
+            ReferencedContainer = "container:BankManagerConsoleApp.xcodeproj">
+         </BuildableReference>
+      </CodeCoverageTargets>
+      <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "1FEBA2E92A5CFE3B00963E02"
+               BuildableName = "BankManagerConsoleAppTests.xctest"
+               BlueprintName = "BankManagerConsoleAppTests"
+               ReferencedContainer = "container:BankManagerConsoleApp.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "C7694E75259C3EC00053667F"
+            BuildableName = "BankManagerConsoleApp"
+            BlueprintName = "BankManagerConsoleApp"
+            ReferencedContainer = "container:BankManagerConsoleApp.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "C7694E75259C3EC00053667F"
+            BuildableName = "BankManagerConsoleApp"
+            BlueprintName = "BankManagerConsoleApp"
+            ReferencedContainer = "container:BankManagerConsoleApp.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/xcshareddata/xcschemes/QueueTests.xcscheme
+++ b/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/xcshareddata/xcschemes/QueueTests.xcscheme
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1420"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <TestPlans>
+         <TestPlanReference
+            reference = "container:BankManagerConsoleApp.xcodeproj/QueueTests.xctestplan"
+            default = "YES">
+         </TestPlanReference>
+      </TestPlans>
+      <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "1FA172402A5C3E7D006C1894"
+               BuildableName = "QueueTests.xctest"
+               BlueprintName = "QueueTests"
+               ReferencedContainer = "container:BankManagerConsoleApp.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "C7694E75259C3EC00053667F"
+            BuildableName = "BankManagerConsoleApp"
+            BlueprintName = "BankManagerConsoleApp"
+            ReferencedContainer = "container:BankManagerConsoleApp.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/BankManagerConsoleApp/BankManagerConsoleApp/LinkedList.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/LinkedList.swift
@@ -1,0 +1,24 @@
+//
+//  LinkedList.swift
+//  BankManagerConsoleApp
+//
+//  Created by hoon, minsup on 2023/07/10.
+//
+
+struct LinkedList<Value> {
+    var head: Node<Value>?
+    var tail: Node<Value>?
+    
+    mutating func append(_ value: Value) {
+        let newNode = Node(value)
+        
+        guard head != nil else {
+            head = newNode
+            tail = head
+            return
+        }
+        
+        tail?.next = newNode
+        tail = tail?.next
+    }
+}

--- a/BankManagerConsoleApp/BankManagerConsoleApp/LinkedList.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/LinkedList.swift
@@ -9,7 +9,7 @@ struct LinkedList<Value> {
     private var head: Node<Value>?
     private var tail: Node<Value>?
     
-    var peek: Value? {
+    var first: Value? {
         return head?.value
     }
     

--- a/BankManagerConsoleApp/BankManagerConsoleApp/LinkedList.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/LinkedList.swift
@@ -50,3 +50,43 @@ struct LinkedList<Value> {
         tail = nil
     }
 }
+
+//MARK: - Extension for Unit Test
+#if canImport(XCTest)
+extension LinkedList {
+    var exposedHead: Node<Value>? {
+        return head
+    }
+    
+    var exposedTail: Node<Value>? {
+        return tail
+    }
+    
+    var count: Int {
+        var currentCount = 0
+        var copiedHead = head
+        
+        while copiedHead != nil {
+            currentCount += 1
+            copiedHead = copiedHead?.next
+        }
+        
+        return currentCount
+    }
+    
+    var elements: [Value] {
+        var currentElements = [Value]()
+        var copiedHead = head
+        
+        while copiedHead != nil {
+            if let unwrappedValue = copiedHead?.value {
+                currentElements.append(unwrappedValue)
+            }
+            
+            copiedHead = copiedHead?.next
+        }
+        
+        return currentElements
+    }
+}
+#endif

--- a/BankManagerConsoleApp/BankManagerConsoleApp/LinkedList.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/LinkedList.swift
@@ -6,8 +6,12 @@
 //
 
 struct LinkedList<Value> {
-    var head: Node<Value>?
-    var tail: Node<Value>?
+    private var head: Node<Value>?
+    private var tail: Node<Value>?
+    
+    var peek: Value? {
+        return head?.value
+    }
     
     mutating func append(_ value: Value) {
         let newNode = Node(value)

--- a/BankManagerConsoleApp/BankManagerConsoleApp/LinkedList.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/LinkedList.swift
@@ -36,4 +36,9 @@ struct LinkedList<Value> {
         
         return value
     }
+    
+    mutating func removeAll() {
+        head = nil
+        tail = nil
+    }
 }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/LinkedList.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/LinkedList.swift
@@ -13,6 +13,10 @@ struct LinkedList<Value> {
         return head?.value
     }
     
+    var isEmpty: Bool {
+        return head == nil
+    }
+    
     mutating func append(_ value: Value) {
         let newNode = Node(value)
         

--- a/BankManagerConsoleApp/BankManagerConsoleApp/LinkedList.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/LinkedList.swift
@@ -21,4 +21,19 @@ struct LinkedList<Value> {
         tail?.next = newNode
         tail = tail?.next
     }
+    
+    mutating func removeFirst() -> Value? {
+        guard head != nil else {
+            return nil
+        }
+        
+        let value = head?.value
+        head = head?.next
+        
+        if head == nil {
+            tail = nil
+        }
+        
+        return value
+    }
 }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Node.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Node.swift
@@ -1,0 +1,16 @@
+//
+//  Node.swift
+//  BankManagerConsoleApp
+//
+//  Created by hoon, minsup on 2023/07/10.
+//
+
+final class Node<Value> {
+    let value: Value
+    var next: Node?
+
+    init(value: Value, next: Node? = nil) {
+        self.value = value
+        self.next = next
+    }
+}

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Node.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Node.swift
@@ -9,7 +9,7 @@ final class Node<Value> {
     let value: Value
     var next: Node?
 
-    init(value: Value, next: Node? = nil) {
+    init(_ value: Value, next: Node? = nil) {
         self.value = value
         self.next = next
     }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Queue.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Queue.swift
@@ -1,0 +1,30 @@
+//
+//  Queue.swift
+//  BankManagerConsoleApp
+//
+//  Created by hoon, minsup on 2023/07/10.
+//
+
+struct Queue<Value> {
+    private var elements = LinkedList<Value>()
+    
+    var peek: Value? {
+        return elements.first
+    }
+    
+    var isEmpty: Bool {
+        return elements.isEmpty
+    }
+    
+    mutating func enqueue(_ value: Value) {
+        elements.append(value)
+    }
+    
+    mutating func dequeue() -> Value? {
+        return elements.removeFirst()
+    }
+    
+    mutating func clear() {
+        elements.removeAll()
+    }
+}

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Queue.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Queue.swift
@@ -6,25 +6,38 @@
 //
 
 struct Queue<Value> {
-    private var elements = LinkedList<Value>()
+    private var list = LinkedList<Value>()
     
     var peek: Value? {
-        return elements.first
+        return list.first
     }
     
     var isEmpty: Bool {
-        return elements.isEmpty
+        return list.isEmpty
     }
     
     mutating func enqueue(_ value: Value) {
-        elements.append(value)
+        list.append(value)
     }
     
     mutating func dequeue() -> Value? {
-        return elements.removeFirst()
+        return list.removeFirst()
     }
     
     mutating func clear() {
-        elements.removeAll()
+        list.removeAll()
     }
 }
+
+//MARK: - Extension for Unit Test
+#if canImport(XCTest)
+extension Queue {
+    var exposedList: LinkedList<Value> {
+        return list
+    }
+    
+    var count: Int {
+        return list.count
+    }
+}
+#endif

--- a/BankManagerConsoleApp/BankManagerConsoleAppTests/LinkedListTests.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleAppTests/LinkedListTests.swift
@@ -1,0 +1,169 @@
+//
+//  LinkedListTests.swift
+//  BankManagerConsoleAppTests
+//
+//  Created by hoon, minsup on 2023/07/11.
+//
+
+import XCTest
+@testable import BankManagerConsoleApp
+
+final class LinkedListTests: XCTestCase {
+    var sut: LinkedList<Int>!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        sut = LinkedList()
+    }
+
+    override func tearDownWithError() throws {
+        try super.tearDownWithError()
+        sut = nil
+    }
+
+    func test_링크드리스트를_초기화하면_head와_tail이_nil로_초기화된다() {
+        // then
+        XCTAssertNil(sut.exposedHead)
+        XCTAssertNil(sut.exposedTail)
+    }
+    
+    func test_링크드리스트를_초기화하면_isEmpty가_true를_반환한다() {
+        // then
+        XCTAssertTrue(sut.isEmpty)
+    }
+    
+    func test_요소_1234를_append하면_링크드리스트의_요소가_4개가_된다() {
+        // given
+        sut.append(1)
+        sut.append(2)
+        sut.append(3)
+        sut.append(4)
+        
+        // when
+        let expectation = 4
+        
+        // then
+        XCTAssertEqual(sut.count, expectation)
+    }
+    
+    func test_요소_1234를_추가하면_요소_1234가_저장된다() {
+        // given
+        sut.append(1)
+        sut.append(2)
+        sut.append(3)
+        sut.append(4)
+        
+        // when
+        let expectation = [1, 2, 3, 4]
+        
+        // then
+        XCTAssertEqual(sut.elements, expectation)
+    }
+    
+    func test_빈_링크드리스트에서_removeFirst를_호출하면_nil을_반환한다() {
+        // then
+        XCTAssertNil(sut.removeFirst())
+    }
+    
+    func test_요소_1234가_저장된_링크드리스트에서_removeFirst를_4번_호출하면_1234가_순서대로_반환한다() {
+        // given
+        sut.append(1)
+        sut.append(2)
+        sut.append(3)
+        sut.append(4)
+        
+        let result1 = sut.removeFirst()
+        let result2 = sut.removeFirst()
+        let result3 = sut.removeFirst()
+        let result4 = sut.removeFirst()
+        
+        // when
+        let expectation1 = 1
+        let expectation2 = 2
+        let expectation3 = 3
+        let expectation4 = 4
+        
+        // then
+        XCTAssertEqual(result1, expectation1)
+        XCTAssertEqual(result2, expectation2)
+        XCTAssertEqual(result3, expectation3)
+        XCTAssertEqual(result4, expectation4)
+    }
+    
+    func test_3개의_요소가_들어있는_링크드리스트에서_removeFirst를_3번_호출하면_isEmpty가_true를_반환한다() {
+        // given
+        sut.append(1)
+        sut.append(2)
+        sut.append(3)
+        
+        // when
+        let _ = sut.removeFirst()
+        let _ = sut.removeFirst()
+        let _ = sut.removeFirst()
+        
+        // then
+        XCTAssertTrue(sut.isEmpty)
+    }
+    
+    func test_3개의_요소가_들어있는_링크드리스트에서_removeFirst를_2번_호출하면_isEmpty가_false를_반환한다() {
+        // given
+        sut.append(1)
+        sut.append(2)
+        sut.append(3)
+        
+        // when
+        let _ = sut.removeFirst()
+        let _ = sut.removeFirst()
+        
+        // then
+        XCTAssertFalse(sut.isEmpty)
+    }
+    
+    func test_5개의_요소가_들어있는_링크드리스트에서_removeAll을_호출하면_isEmpty가_true를_반환한다() {
+        // given
+        sut.append(1)
+        sut.append(2)
+        sut.append(3)
+        sut.append(4)
+        sut.append(5)
+        
+        // when
+        sut.removeAll()
+        
+        // then
+        XCTAssertTrue(sut.isEmpty)
+    }
+    
+    func test_3개의_요소가_들어있는_링크드리스트에서_removeAll을_호출하면_head와_tail이_nil로_저장된다() {
+        // given
+        sut.append(1)
+        sut.append(2)
+        sut.append(3)
+        
+        // when
+        sut.removeAll()
+        
+        // then
+        XCTAssertNil(sut.exposedHead)
+        XCTAssertNil(sut.exposedTail)
+    }
+    
+    func test_빈_링크드리스트에서_first를_호출하면_nil을_반환한다() {
+        // then
+        XCTAssertNil(sut.first)
+    }
+    
+    func test_요소_1234가_저장된_링크드리스트에서_first를_호출하면_1을_반환한다() {
+        // given
+        sut.append(1)
+        sut.append(2)
+        sut.append(3)
+        sut.append(4)
+        
+        // when
+        let expectation = 1
+        
+        // then
+        XCTAssertEqual(sut.first, expectation)
+    }
+}

--- a/BankManagerConsoleApp/BankManagerConsoleAppTests/LinkedListTests.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleAppTests/LinkedListTests.swift
@@ -32,7 +32,7 @@ final class LinkedListTests: XCTestCase {
         XCTAssertTrue(sut.isEmpty)
     }
     
-    func test_요소_1234를_append하면_링크드리스트의_요소가_4개가_된다() {
+    func test_요소_n개를_append하면_링크드리스트의_요소가_n개가_된다() {
         // given
         sut.append(1)
         sut.append(2)
@@ -90,36 +90,24 @@ final class LinkedListTests: XCTestCase {
         XCTAssertEqual(result4, expectation4)
     }
     
-    func test_3개의_요소가_들어있는_링크드리스트에서_removeFirst를_3번_호출하면_isEmpty가_true를_반환한다() {
+    func test_removeFirst를_호출하면_첫_번째_요소를_반환하고_count가_1_감소한다() {
         // given
         sut.append(1)
         sut.append(2)
         sut.append(3)
+        sut.append(4)
         
         // when
-        let _ = sut.removeFirst()
-        let _ = sut.removeFirst()
-        let _ = sut.removeFirst()
+        let result = sut.removeFirst()
+        let expectedElement = 1
+        let expectedCount = 3
         
         // then
-        XCTAssertTrue(sut.isEmpty)
+        XCTAssertEqual(result, expectedElement)
+        XCTAssertEqual(sut.count, expectedCount)
     }
-    
-    func test_3개의_요소가_들어있는_링크드리스트에서_removeFirst를_2번_호출하면_isEmpty가_false를_반환한다() {
-        // given
-        sut.append(1)
-        sut.append(2)
-        sut.append(3)
-        
-        // when
-        let _ = sut.removeFirst()
-        let _ = sut.removeFirst()
-        
-        // then
-        XCTAssertFalse(sut.isEmpty)
-    }
-    
-    func test_5개의_요소가_들어있는_링크드리스트에서_removeAll을_호출하면_isEmpty가_true를_반환한다() {
+
+    func test_n개의_요소가_들어있는_링크드리스트에서_removeAll을_호출하면_isEmpty가_true를_반환한다() {
         // given
         sut.append(1)
         sut.append(2)
@@ -134,7 +122,7 @@ final class LinkedListTests: XCTestCase {
         XCTAssertTrue(sut.isEmpty)
     }
     
-    func test_3개의_요소가_들어있는_링크드리스트에서_removeAll을_호출하면_head와_tail이_nil로_저장된다() {
+    func test_n개의_요소가_들어있는_링크드리스트에서_removeAll을_호출하면_head와_tail이_nil로_저장된다() {
         // given
         sut.append(1)
         sut.append(2)

--- a/BankManagerConsoleApp/BankManagerConsoleAppTests/LinkedListTests.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleAppTests/LinkedListTests.swift
@@ -46,7 +46,7 @@ final class LinkedListTests: XCTestCase {
         XCTAssertEqual(sut.count, expectation)
     }
     
-    func test_요소_1234를_추가하면_요소_1234가_저장된다() {
+    func test_요소_1234를_append하면_요소_1234가_저장된다() {
         // given
         sut.append(1)
         sut.append(2)

--- a/BankManagerConsoleApp/BankManagerConsoleAppTests/NodeTests.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleAppTests/NodeTests.swift
@@ -1,0 +1,35 @@
+//
+//  NodeTests.swift
+//  BankManagerConsoleAppTests
+//
+//  Created by hoon, minsup on 2023/07/11.
+//
+
+import XCTest
+@testable import BankManagerConsoleApp
+
+final class NodeTests: XCTestCase {
+    func test_노드를_0으로_초기화하면_value에_0이_저장된다() {
+        // given
+        let input = Node(0)
+        
+        // when
+        let expectation = 0
+        
+        // then
+        XCTAssertEqual(input.value, expectation)
+    }
+    
+    func test_처음_노드에_1로_초기화된_다음_노드를_연결하면_처음_노드에서_다음_노드의_밸류인_1에_접근할_수_있다() {
+        // given
+        let input1 = Node(0)
+        let input2 = Node(1)
+        input1.next = input2
+        
+        // when
+        let expectation = 1
+        
+        // then
+        XCTAssertEqual(input1.next?.value, expectation)
+    }
+}

--- a/BankManagerConsoleApp/BankManagerConsoleAppTests/NodeTests.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleAppTests/NodeTests.swift
@@ -9,25 +9,25 @@ import XCTest
 @testable import BankManagerConsoleApp
 
 final class NodeTests: XCTestCase {
-    func test_노드를_0으로_초기화하면_value에_0이_저장된다() {
+    func test_노드를_1으로_초기화하면_value에_1이_저장된다() {
         // given
-        let input = Node(0)
+        let input = Node(1)
         
         // when
-        let expectation = 0
+        let expectation = 1
         
         // then
         XCTAssertEqual(input.value, expectation)
     }
     
-    func test_처음_노드에_1로_초기화된_다음_노드를_연결하면_처음_노드에서_다음_노드의_밸류인_1에_접근할_수_있다() {
+    func test_처음_노드에_2로_초기화된_다음_노드를_연결하면_처음_노드에서_다음_노드의_value인_1에_접근할_수_있다() {
         // given
-        let input1 = Node(0)
-        let input2 = Node(1)
+        let input1 = Node(1)
+        let input2 = Node(2)
         input1.next = input2
         
         // when
-        let expectation = 1
+        let expectation = 2
         
         // then
         XCTAssertEqual(input1.next?.value, expectation)

--- a/BankManagerConsoleApp/BankManagerConsoleAppTests/QueueTests.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleAppTests/QueueTests.swift
@@ -1,0 +1,157 @@
+//
+//  QueueTests.swift
+//  BankManagerConsoleAppTests
+//
+//  Created by hoon, minsup on 2023/07/11.
+//
+
+import XCTest
+@testable import BankManagerConsoleApp
+
+final class QueueTests: XCTestCase {
+    var sut: Queue<Int>!
+    
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        sut = Queue()
+    }
+
+    override func tearDownWithError() throws {
+        try super.tearDownWithError()
+        sut = nil
+    }
+    
+    func test_큐를_초기화하면_list가_빈_링크드리스트로_초기화된다() {
+        // when
+        let expectation = [Int]()
+        
+        // then
+        XCTAssertEqual(sut.exposedList.elements, expectation)
+    }
+    
+    func test_큐를_초기화하면_isEmpty가_true를_반환한다() {
+        // then
+        XCTAssertTrue(sut.isEmpty)
+    }
+    
+    func test_요소_1234를_enqueue하면_큐의_요소가_4개가_된다() {
+        // given
+        sut.enqueue(1)
+        sut.enqueue(2)
+        sut.enqueue(3)
+        sut.enqueue(4)
+        
+        // when
+        let expectation = 4
+        
+        // then
+        XCTAssertEqual(sut.count, expectation)
+    }
+    
+    func test_요소_1234를_enqueue하면_요소_1234가_저장된다() {
+        // given
+        sut.enqueue(1)
+        sut.enqueue(2)
+        sut.enqueue(3)
+        sut.enqueue(4)
+        
+        // when
+        let expectation = [1, 2, 3, 4]
+        
+        // then
+        XCTAssertEqual(sut.exposedList.elements, expectation)
+    }
+    
+    func test_빈_큐에서_dequeue를_호출하면_nil을_반환한다() {
+        // then
+        XCTAssertNil(sut.dequeue())
+    }
+    
+    func test_요소_1234가_저장된_큐에서_dequeue를_4번_호출하면_1234가_순서대로_반환한다() {
+        // given
+        sut.enqueue(1)
+        sut.enqueue(2)
+        sut.enqueue(3)
+        sut.enqueue(4)
+        
+        let result1 = sut.dequeue()
+        let result2 = sut.dequeue()
+        let result3 = sut.dequeue()
+        let result4 = sut.dequeue()
+        
+        // when
+        let expectation1 = 1
+        let expectation2 = 2
+        let expectation3 = 3
+        let expectation4 = 4
+        
+        // then
+        XCTAssertEqual(result1, expectation1)
+        XCTAssertEqual(result2, expectation2)
+        XCTAssertEqual(result3, expectation3)
+        XCTAssertEqual(result4, expectation4)
+    }
+    
+    func test_3개의_요소가_들어있는_큐에서_dequeue를_3번_호출하면_isEmpty가_true를_반환한다() {
+        // given
+        sut.enqueue(1)
+        sut.enqueue(2)
+        sut.enqueue(3)
+        
+        // when
+        let _ = sut.dequeue()
+        let _ = sut.dequeue()
+        let _ = sut.dequeue()
+        
+        // then
+        XCTAssertTrue(sut.isEmpty)
+    }
+    
+    func test_3개의_요소가_들어있는_큐에서_dequeue를_2번_호출하면_isEmpty가_false를_반환한다() {
+        // given
+        sut.enqueue(1)
+        sut.enqueue(2)
+        sut.enqueue(3)
+        
+        // when
+        let _ = sut.dequeue()
+        let _ = sut.dequeue()
+        
+        // then
+        XCTAssertFalse(sut.isEmpty)
+    }
+    
+    func test_5개의_요소가_들어있는_큐에서_clear을_호출하면_isEmpty가_true를_반환한다() {
+        // given
+        sut.enqueue(1)
+        sut.enqueue(2)
+        sut.enqueue(3)
+        sut.enqueue(4)
+        sut.enqueue(5)
+        
+        // when
+        sut.clear()
+        
+        // then
+        XCTAssertTrue(sut.isEmpty)
+    }
+    
+    func test_빈_큐에서_peek를_호출하면_nil을_반환한다() {
+        // then
+        XCTAssertNil(sut.peek)
+    }
+    
+    func test_요소_1234가_저장된_큐에서_peek를_호출하면_1을_반환한다() {
+        // given
+        sut.enqueue(1)
+        sut.enqueue(2)
+        sut.enqueue(3)
+        sut.enqueue(4)
+        
+        // when
+        let expectation = 1
+        
+        // then
+        XCTAssertEqual(sut.peek, expectation)
+    }
+}


### PR DESCRIPTION
@delmaSong  안녕하세요~~ hoon, minsup 조 입니다.😆
step1 많은 고민을 통해 완성을 했습니다. step1부터 쉽지 않았던 것 같아요.
xcode 버전도 달라 환경 설정에 많은 시간을 투자했습니다🥲
많은 조언 부탁드립니다. 감사합니다!!!

## 고민되었던 점

### `removeAll()` 할 때 `Node deinit` 시점
- `LinkedList`의 `removeAll()` 메소드를 구현하던 중 의문이 들었습니다.
    > * 모든 노드를 순회하며 `nil`을 할당해서 메모리에서 해제시켜야 하는가?
    > * 첫 노드만 `nil`을 할당하면 연결된 모든 노드들이 메모리에서 자동으로 해제되는가?

    질문의 해답을 찾기 위해 직접 실험을 해보았습니다. head에 nil을 할당하면 연쇄적으로 연결된 모든 노드들이 메모리에서 해제되는 것을 확인했습니다.

    ```swift
    mutating func removeAll() {
        head = nil
        tail = nil
    }
    ```

  ![image](https://github.com/yagom-academy/ios-bank-manager/assets/79740398/7ac1ff7d-16f3-44fe-81ed-bc0a3248d0ea)

    `LinkedList`를 사용하여 새로운 `Node`가 추가되면 기존에 있던 `Node`의 `next` 프로퍼티를 통해 다음 `Node`를 참조합니다. 이렇게 각각의 `Node`는 다음에 오는 `Node`를 참조하고 있고 참조하는 `Node`가 없는 경우 `nil`을 가지고 있습니다. 첫 `Node`는 `head`가 참조하고 있습니다. `removeAll()` 메소드를 사용하여 각각 노드를 참조하고 있는 `head`와 `tail`에 `nil`을 할당하면 앞의 `Node`를 참조하고 있던 다음 `Node` 객체의 `reference count`는 0이 되어 메모리에서 해제됩니다. 그러므로 앞에 있던 `Node`부터 순차적으로 `deinit`이 실행됩니다.

### `commandline tool`에서 테스트하는법
- `commandline tool`에서 `Unit Test`를 진행하려고 했을 때 `iOS App` 과는 다른 문제점이 있었습니다. 아래의 설정처럼 `Target to be Tested`를 설정하는 것이 불가능했습니다.
 
    ![image](https://github.com/yagom-academy/ios-bank-manager/assets/79740398/db9407c2-c923-445b-83f3-6fe6b16a4c28)
    
    이를 해결하기 위해 몇 가지 추가적인 설정이 필요했습니다. 테스트하고자 하는 파일의 `Target MemberShip`에 Test 타겟을 설정해야 했습니다.

    - [참고 링크](https://jwonylee.tistory.com/entry/XCode-Swift-Command-Line-Tool-%ED%94%84%EB%A1%9C%EC%A0%9D%ED%8A%B8%EC%97%90%EC%84%9C-%EC%9C%A0%EB%8B%9B-%ED%85%8C%EC%8A%A4%ED%8A%B8-%ED%95%98%EA%B8%B0)

### `xcode` 버전이 달라서 생기는 문제
- 저희는 서로 다른 xcode 버전을 사용 중입니다.(14.3, 14.2)
    버전이 서로 달라 테스트를 할 때 14.3은 `testplan`이 필요했고 14.2는 필요 없었습니다. 이런 문제 때문에 사용하는 환경을 한쪽에 맞춰서 작업을 진행해야 했습니다. 다행히 14.2를 기준으로 만들 `Unit Test scheme`을 14.3 환경에서 사용할 수 있었습니다.

## 조언을 얻고 싶은 부분

### 테스트 함수 이름 짓기
- 테스트 함수의 이름을 지을 때 많은 고민을 했습니다. 통일성, 논리성, 내용을 포함하는지 등등 다양한 상황에 대해 고민했습니다. 

    해당 테스트 코드에 대한 제목을 고민하는 과정에서 여러 후보들이 있었는데 어떤 것이 더 좋을까요? 더 좋은 후보가 있으면 추천해 주시면 감사하겠습니다.

    ```swift
    func test_????() {
        // given
        sut.append(1)
        sut.append(2)
        sut.append(3)
        sut.append(4)

        // when
        let expectation = [1, 2, 3, 4]

        // then
        XCTAssertEqual(sut.elements, expectation)
    }
    ```

    - func test_요소x를_추가하면_요소x가_저장된다()
    - func test_요소1234를_추가하면_요소1234가_저장된다()


### 객체의 `private` 프로퍼티를 테스트 환경에서 어떻게 접근해야 하는지 고민
- 아래와 같은 객체가 있을 때 테스트 코드에서 `head`와 `tail`을 어떻게 사용할지 고민을 했습니다.

    ```swift
    struct LinkedList<Value> {
        private var head: Node<Value>?
        private var tail: Node<Value>?
        ...
    }
    ```

    ![image](https://github.com/yagom-academy/ios-bank-manager/assets/79740398/8762b83a-b671-4427-9575-248f6f20368b)

    저희는 방법을 찾아보다가 전처리문을 사용하여 테스트 코드에서만 적용되는 `extension`을 만들 수 있었습니다.

    ```swift
    //MARK: - Extension for Unit Test
    #if canImport(XCTest)
    extension LinkedList {
        var exposedHead: Node<Value>? {
            return head
        }

        var exposedTail: Node<Value>? {
            return tail
        }
        ...
    }
    #endif
    ```
    
    이 방법은 괜찮은 방법일까요? 더 좋은 방법이 있다면 어떤 것이 있을까요?





