### PR TITLE
은행창구 매니저 [Step1] 토이, 쥬봉이

### DIFF
--- a/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
+++ b/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
@@ -13,6 +13,8 @@
 		3C7538D42B030C9F00D45F35 /* CustomerQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C7538BA2B03080400D45F35 /* CustomerQueue.swift */; };
 		63222B622A691A3500F197ED /* BankManager in Frameworks */ = {isa = PBXBuildFile; productRef = 63222B612A691A3500F197ED /* BankManager */; };
 		BF2304F12B0301260074439A /* Node.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF2304F02B0301260074439A /* Node.swift */; };
+		BF2305002B0310B00074439A /* LinkedList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C7538B82B0302C300D45F35 /* LinkedList.swift */; };
+		BF2305012B0310C30074439A /* Node.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF2304F02B0301260074439A /* Node.swift */; };
 		C7694E7A259C3EC00053667F /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7694E79259C3EC00053667F /* main.swift */; };
 /* End PBXBuildFile section */
 
@@ -196,8 +198,10 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				BF2305002B0310B00074439A /* LinkedList.swift in Sources */,
 				3C7538D02B030C7300D45F35 /* CustomerQueueTests.swift in Sources */,
 				3C7538D42B030C9F00D45F35 /* CustomerQueue.swift in Sources */,
+				BF2305012B0310C30074439A /* Node.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -222,7 +226,7 @@
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = DX425N2A26;
+				DEVELOPMENT_TEAM = "";
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu17;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -244,7 +248,7 @@
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = DX425N2A26;
+				DEVELOPMENT_TEAM = "";
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu17;
 				GENERATE_INFOPLIST_FILE = YES;

--- a/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
+++ b/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
@@ -3,11 +3,12 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 53;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
 		63222B622A691A3500F197ED /* BankManager in Frameworks */ = {isa = PBXBuildFile; productRef = 63222B612A691A3500F197ED /* BankManager */; };
+		BF2304F12B0301260074439A /* Node.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF2304F02B0301260074439A /* Node.swift */; };
 		C7694E7A259C3EC00053667F /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7694E79259C3EC00053667F /* main.swift */; };
 /* End PBXBuildFile section */
 
@@ -25,7 +26,8 @@
 
 /* Begin PBXFileReference section */
 		63222B5F2A6919F700F197ED /* BankManager */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = BankManager; path = ../BankManager; sourceTree = "<group>"; };
-		C7694E76259C3EC00053667F /* BankManagerConsoleApp */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; name = BankManagerConsoleApp; path = "/Users/kjs/Documents/dev/prjs/ios-bank-manager/BankManagerConsoleApp/build/Debug/BankManagerConsoleApp"; sourceTree = "<absolute>"; };
+		BF2304EF2B0300C00074439A /* BankManagerConsoleApp */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = BankManagerConsoleApp; sourceTree = BUILT_PRODUCTS_DIR; };
+		BF2304F02B0301260074439A /* Node.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Node.swift; sourceTree = "<group>"; };
 		C7694E79259C3EC00053667F /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -62,6 +64,7 @@
 				63222B5E2A6919F700F197ED /* Packages */,
 				C7694E78259C3EC00053667F /* BankManagerConsoleApp */,
 				63222B602A691A3500F197ED /* Frameworks */,
+				BF2304EF2B0300C00074439A /* BankManagerConsoleApp */,
 			);
 			sourceTree = "<group>";
 		};
@@ -69,6 +72,7 @@
 			isa = PBXGroup;
 			children = (
 				C7694E79259C3EC00053667F /* main.swift */,
+				BF2304F02B0301260074439A /* Node.swift */,
 			);
 			path = BankManagerConsoleApp;
 			sourceTree = "<group>";
@@ -93,7 +97,7 @@
 				63222B612A691A3500F197ED /* BankManager */,
 			);
 			productName = BankManagerConsoleApp;
-			productReference = C7694E76259C3EC00053667F /* BankManagerConsoleApp */;
+			productReference = BF2304EF2B0300C00074439A /* BankManagerConsoleApp */;
 			productType = "com.apple.product-type.tool";
 		};
 /* End PBXNativeTarget section */
@@ -135,6 +139,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				C7694E7A259C3EC00053667F /* main.swift in Sources */,
+				BF2304F12B0301260074439A /* Node.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
+++ b/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
@@ -9,6 +9,8 @@
 /* Begin PBXBuildFile section */
 		3C7538B92B0302C300D45F35 /* LinkedList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C7538B82B0302C300D45F35 /* LinkedList.swift */; };
 		3C7538BB2B03080400D45F35 /* CustomerQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C7538BA2B03080400D45F35 /* CustomerQueue.swift */; };
+		3C7538D02B030C7300D45F35 /* CustomerQueueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C7538CF2B030C7300D45F35 /* CustomerQueueTests.swift */; };
+		3C7538D42B030C9F00D45F35 /* CustomerQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C7538BA2B03080400D45F35 /* CustomerQueue.swift */; };
 		63222B622A691A3500F197ED /* BankManager in Frameworks */ = {isa = PBXBuildFile; productRef = 63222B612A691A3500F197ED /* BankManager */; };
 		BF2304F12B0301260074439A /* Node.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF2304F02B0301260074439A /* Node.swift */; };
 		C7694E7A259C3EC00053667F /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7694E79259C3EC00053667F /* main.swift */; };
@@ -29,6 +31,8 @@
 /* Begin PBXFileReference section */
 		3C7538B82B0302C300D45F35 /* LinkedList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkedList.swift; sourceTree = "<group>"; };
 		3C7538BA2B03080400D45F35 /* CustomerQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomerQueue.swift; sourceTree = "<group>"; };
+		3C7538CD2B030C7300D45F35 /* CustomerQueueTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CustomerQueueTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		3C7538CF2B030C7300D45F35 /* CustomerQueueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomerQueueTests.swift; sourceTree = "<group>"; };
 		63222B5F2A6919F700F197ED /* BankManager */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = BankManager; path = ../BankManager; sourceTree = "<group>"; };
 		BF2304EF2B0300C00074439A /* BankManagerConsoleApp */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = BankManagerConsoleApp; sourceTree = BUILT_PRODUCTS_DIR; };
 		BF2304F02B0301260074439A /* Node.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Node.swift; sourceTree = "<group>"; };
@@ -36,6 +40,13 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		3C7538CA2B030C7300D45F35 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		C7694E73259C3EC00053667F /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -47,6 +58,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		3C7538CE2B030C7300D45F35 /* CustomerQueueTests */ = {
+			isa = PBXGroup;
+			children = (
+				3C7538CF2B030C7300D45F35 /* CustomerQueueTests.swift */,
+			);
+			path = CustomerQueueTests;
+			sourceTree = "<group>";
+		};
 		63222B5E2A6919F700F197ED /* Packages */ = {
 			isa = PBXGroup;
 			children = (
@@ -67,8 +86,10 @@
 			children = (
 				63222B5E2A6919F700F197ED /* Packages */,
 				C7694E78259C3EC00053667F /* BankManagerConsoleApp */,
+				3C7538CE2B030C7300D45F35 /* CustomerQueueTests */,
 				63222B602A691A3500F197ED /* Frameworks */,
 				BF2304EF2B0300C00074439A /* BankManagerConsoleApp */,
+				3C7538CD2B030C7300D45F35 /* CustomerQueueTests.xctest */,
 			);
 			sourceTree = "<group>";
 		};
@@ -86,6 +107,23 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
+		3C7538CC2B030C7300D45F35 /* CustomerQueueTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 3C7538D32B030C7300D45F35 /* Build configuration list for PBXNativeTarget "CustomerQueueTests" */;
+			buildPhases = (
+				3C7538C92B030C7300D45F35 /* Sources */,
+				3C7538CA2B030C7300D45F35 /* Frameworks */,
+				3C7538CB2B030C7300D45F35 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = CustomerQueueTests;
+			productName = CustomerQueueTests;
+			productReference = 3C7538CD2B030C7300D45F35 /* CustomerQueueTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 		C7694E75259C3EC00053667F /* BankManagerConsoleApp */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = C7694E7D259C3EC00053667F /* Build configuration list for PBXNativeTarget "BankManagerConsoleApp" */;
@@ -113,9 +151,12 @@
 			isa = PBXProject;
 			attributes = {
 				BuildIndependentTargetsInParallel = YES;
-				LastSwiftUpdateCheck = 1210;
+				LastSwiftUpdateCheck = 1500;
 				LastUpgradeCheck = 1430;
 				TargetAttributes = {
+					3C7538CC2B030C7300D45F35 = {
+						CreatedOnToolsVersion = 15.0.1;
+					};
 					C7694E75259C3EC00053667F = {
 						CreatedOnToolsVersion = 12.1;
 					};
@@ -135,11 +176,31 @@
 			projectRoot = "";
 			targets = (
 				C7694E75259C3EC00053667F /* BankManagerConsoleApp */,
+				3C7538CC2B030C7300D45F35 /* CustomerQueueTests */,
 			);
 		};
 /* End PBXProject section */
 
+/* Begin PBXResourcesBuildPhase section */
+		3C7538CB2B030C7300D45F35 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
 /* Begin PBXSourcesBuildPhase section */
+		3C7538C92B030C7300D45F35 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				3C7538D02B030C7300D45F35 /* CustomerQueueTests.swift in Sources */,
+				3C7538D42B030C9F00D45F35 /* CustomerQueue.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		C7694E72259C3EC00053667F /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -154,6 +215,49 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin XCBuildConfiguration section */
+		3C7538D12B030C7300D45F35 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = DX425N2A26;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GENERATE_INFOPLIST_FILE = YES;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.woohyeon.CustomerQueueTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		3C7538D22B030C7300D45F35 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = DX425N2A26;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GENERATE_INFOPLIST_FILE = YES;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.woohyeon.CustomerQueueTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
 		C7694E7B259C3EC00053667F /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -294,6 +398,15 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		3C7538D32B030C7300D45F35 /* Build configuration list for PBXNativeTarget "CustomerQueueTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				3C7538D12B030C7300D45F35 /* Debug */,
+				3C7538D22B030C7300D45F35 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		C7694E71259C3EC00053667F /* Build configuration list for PBXProject "BankManagerConsoleApp" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
+++ b/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		3C7538B92B0302C300D45F35 /* LinkedList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C7538B82B0302C300D45F35 /* LinkedList.swift */; };
 		63222B622A691A3500F197ED /* BankManager in Frameworks */ = {isa = PBXBuildFile; productRef = 63222B612A691A3500F197ED /* BankManager */; };
 		BF2304F12B0301260074439A /* Node.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF2304F02B0301260074439A /* Node.swift */; };
 		C7694E7A259C3EC00053667F /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7694E79259C3EC00053667F /* main.swift */; };
@@ -25,6 +26,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		3C7538B82B0302C300D45F35 /* LinkedList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkedList.swift; sourceTree = "<group>"; };
 		63222B5F2A6919F700F197ED /* BankManager */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = BankManager; path = ../BankManager; sourceTree = "<group>"; };
 		BF2304EF2B0300C00074439A /* BankManagerConsoleApp */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = BankManagerConsoleApp; sourceTree = BUILT_PRODUCTS_DIR; };
 		BF2304F02B0301260074439A /* Node.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Node.swift; sourceTree = "<group>"; };
@@ -73,6 +75,7 @@
 			children = (
 				C7694E79259C3EC00053667F /* main.swift */,
 				BF2304F02B0301260074439A /* Node.swift */,
+				3C7538B82B0302C300D45F35 /* LinkedList.swift */,
 			);
 			path = BankManagerConsoleApp;
 			sourceTree = "<group>";
@@ -138,6 +141,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3C7538B92B0302C300D45F35 /* LinkedList.swift in Sources */,
 				C7694E7A259C3EC00053667F /* main.swift in Sources */,
 				BF2304F12B0301260074439A /* Node.swift in Sources */,
 			);

--- a/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
+++ b/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		3C7538B92B0302C300D45F35 /* LinkedList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C7538B82B0302C300D45F35 /* LinkedList.swift */; };
+		3C7538BB2B03080400D45F35 /* CustomerQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C7538BA2B03080400D45F35 /* CustomerQueue.swift */; };
 		63222B622A691A3500F197ED /* BankManager in Frameworks */ = {isa = PBXBuildFile; productRef = 63222B612A691A3500F197ED /* BankManager */; };
 		BF2304F12B0301260074439A /* Node.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF2304F02B0301260074439A /* Node.swift */; };
 		C7694E7A259C3EC00053667F /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7694E79259C3EC00053667F /* main.swift */; };
@@ -27,6 +28,7 @@
 
 /* Begin PBXFileReference section */
 		3C7538B82B0302C300D45F35 /* LinkedList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkedList.swift; sourceTree = "<group>"; };
+		3C7538BA2B03080400D45F35 /* CustomerQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomerQueue.swift; sourceTree = "<group>"; };
 		63222B5F2A6919F700F197ED /* BankManager */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = BankManager; path = ../BankManager; sourceTree = "<group>"; };
 		BF2304EF2B0300C00074439A /* BankManagerConsoleApp */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = BankManagerConsoleApp; sourceTree = BUILT_PRODUCTS_DIR; };
 		BF2304F02B0301260074439A /* Node.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Node.swift; sourceTree = "<group>"; };
@@ -75,6 +77,7 @@
 			children = (
 				C7694E79259C3EC00053667F /* main.swift */,
 				BF2304F02B0301260074439A /* Node.swift */,
+				3C7538BA2B03080400D45F35 /* CustomerQueue.swift */,
 				3C7538B82B0302C300D45F35 /* LinkedList.swift */,
 			);
 			path = BankManagerConsoleApp;
@@ -142,6 +145,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				3C7538B92B0302C300D45F35 /* LinkedList.swift in Sources */,
+				3C7538BB2B03080400D45F35 /* CustomerQueue.swift in Sources */,
 				C7694E7A259C3EC00053667F /* main.swift in Sources */,
 				BF2304F12B0301260074439A /* Node.swift in Sources */,
 			);

--- a/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/xcshareddata/xcschemes/BankManagerConsoleApp.xcscheme
+++ b/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/xcshareddata/xcschemes/BankManagerConsoleApp.xcscheme
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1500"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "C7694E75259C3EC00053667F"
+               BuildableName = "BankManagerConsoleApp"
+               BlueprintName = "BankManagerConsoleApp"
+               ReferencedContainer = "container:BankManagerConsoleApp.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <TestPlans>
+         <TestPlanReference
+            reference = "container:BankManagerConsoleApp.xctestplan"
+            default = "YES">
+         </TestPlanReference>
+      </TestPlans>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES"
+      viewDebuggingEnabled = "No">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "C7694E75259C3EC00053667F"
+            BuildableName = "BankManagerConsoleApp"
+            BlueprintName = "BankManagerConsoleApp"
+            ReferencedContainer = "container:BankManagerConsoleApp.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "C7694E75259C3EC00053667F"
+            BuildableName = "BankManagerConsoleApp"
+            BlueprintName = "BankManagerConsoleApp"
+            ReferencedContainer = "container:BankManagerConsoleApp.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/BankManagerConsoleApp/BankManagerConsoleApp.xctestplan
+++ b/BankManagerConsoleApp/BankManagerConsoleApp.xctestplan
@@ -9,7 +9,6 @@
     }
   ],
   "defaultOptions" : {
-    "codeCoverage" : false,
     "targetForVariableExpansion" : {
       "containerPath" : "container:BankManagerConsoleApp.xcodeproj",
       "identifier" : "C7694E75259C3EC00053667F",

--- a/BankManagerConsoleApp/BankManagerConsoleApp.xctestplan
+++ b/BankManagerConsoleApp/BankManagerConsoleApp.xctestplan
@@ -1,0 +1,29 @@
+{
+  "configurations" : [
+    {
+      "id" : "DA616278-830C-4AA4-A96C-25AE35E2041A",
+      "name" : "Test Scheme Action",
+      "options" : {
+
+      }
+    }
+  ],
+  "defaultOptions" : {
+    "codeCoverage" : false,
+    "targetForVariableExpansion" : {
+      "containerPath" : "container:BankManagerConsoleApp.xcodeproj",
+      "identifier" : "C7694E75259C3EC00053667F",
+      "name" : "BankManagerConsoleApp"
+    }
+  },
+  "testTargets" : [
+    {
+      "target" : {
+        "containerPath" : "container:BankManagerConsoleApp.xcodeproj",
+        "identifier" : "3C7538CC2B030C7300D45F35",
+        "name" : "CustomerQueueTests"
+      }
+    }
+  ],
+  "version" : 1
+}

--- a/BankManagerConsoleApp/BankManagerConsoleApp/CustomerQueue.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/CustomerQueue.swift
@@ -5,16 +5,26 @@
 //  Created by jyubong, Toy on 11/14/23.
 //
 
-import Foundation
-
-struct CustomerQueue<T> {
-    private var list = LinkedList<T>()
+struct CustomerQueue<Element> {
+    private var list: LinkedList<Element>
     
-    func enqueue(_ element: T) {
+    var peek: Element? { list.first }
+    
+    var isEmpty: Bool { list.isEmpty }
+    
+    init(list: LinkedList<Element>) {
+        self.list = list
+    }
+    
+    func enqueue(_ element: Element) {
         list.append(value: element)
     }
     
-    func dequeue() -> T? {
+    func dequeue() -> Element? {
         return list.removeFirst()
+    }
+    
+    func clear() {
+        list.removeAll()
     }
 }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/CustomerQueue.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/CustomerQueue.swift
@@ -1,0 +1,20 @@
+//
+//  CustomerQueue.swift
+//  BankManagerConsoleApp
+//
+//  Created by jyubong, Toy on 11/14/23.
+//
+
+import Foundation
+
+struct CustomerQueue<T> {
+    private var list = LinkedList<T>()
+    
+    func enqueue(_ element: T) {
+        list.append(value: element)
+    }
+    
+    func dequeue() -> T? {
+        return list.removeFirst()
+    }
+}

--- a/BankManagerConsoleApp/BankManagerConsoleApp/CustomerQueue.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/CustomerQueue.swift
@@ -6,7 +6,7 @@
 //
 
 struct CustomerQueue<Element> {
-    private var list: LinkedList<Element>
+    private let list: LinkedList<Element>
     
     var peek: Element? { list.first }
     

--- a/BankManagerConsoleApp/BankManagerConsoleApp/LinkedList.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/LinkedList.swift
@@ -15,6 +15,11 @@ final class LinkedList<Data> {
     
     var isEmpty: Bool { head == nil }
     
+    init(head: Node<Data>? = nil, tail: Node<Data>? = nil) {
+        self.head = head
+        self.tail = tail
+    }
+    
     func append(value: Data) {
         let newNode: Node = Node(data: value)
         

--- a/BankManagerConsoleApp/BankManagerConsoleApp/LinkedList.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/LinkedList.swift
@@ -1,0 +1,31 @@
+//
+//  LinkedList.swift
+//  BankManagerConsoleApp
+//
+//  Created by jyubong, Toy on 11/14/23.
+//
+
+import Foundation
+
+final class LinkedList<Data> {
+    private var head: Node<Data>?
+    private var tail: Node<Data>?
+    
+    var isEmpty: Bool { head == nil }
+    
+    func append(value: Data) {
+        let newNode: Node = Node(data: value)
+        if isEmpty {
+            head = newNode
+            tail = head
+        } else {
+            tail?.setNext(to: newNode)
+            tail = newNode
+        }
+    }
+    
+    func removeAll() {
+        head = nil
+        tail = nil
+    }
+}

--- a/BankManagerConsoleApp/BankManagerConsoleApp/LinkedList.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/LinkedList.swift
@@ -11,8 +11,6 @@ final class LinkedList<Data> {
     
     var first: Data? { head?.data }
     
-    var last: Data? { tail?.data }
-    
     var isEmpty: Bool { head == nil }
     
     init(head: Node<Data>? = nil, tail: Node<Data>? = nil) {

--- a/BankManagerConsoleApp/BankManagerConsoleApp/LinkedList.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/LinkedList.swift
@@ -5,32 +5,32 @@
 //  Created by jyubong, Toy on 11/14/23.
 //
 
-final class LinkedList<Data> {
-    private var head: Node<Data>?
-    private var tail: Node<Data>?
+final class LinkedList<NodeData> {
+    private var head: Node<NodeData>?
+    private var tail: Node<NodeData>?
     
-    var first: Data? { head?.data }
+    var first: NodeData? { head?.data }
     
     var isEmpty: Bool { head == nil }
     
-    init(head: Node<Data>? = nil, tail: Node<Data>? = nil) {
+    init(head: Node<NodeData>? = nil, tail: Node<NodeData>? = nil) {
         self.head = head
         self.tail = tail
     }
     
-    func append(value: Data) {
+    func append(value: NodeData) {
         let newNode: Node = Node(data: value)
         
         if isEmpty {
             head = newNode
-            tail = head
         } else {
             tail?.setNext(to: newNode)
-            tail = newNode
         }
+        
+        tail = newNode
     }
     
-    func removeFirst() -> Data? {
+    func removeFirst() -> NodeData? {
         guard let headData = head?.data else { return nil }
         
         head = head?.next

--- a/BankManagerConsoleApp/BankManagerConsoleApp/LinkedList.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/LinkedList.swift
@@ -5,16 +5,23 @@
 //  Created by jyubong, Toy on 11/14/23.
 //
 
-import Foundation
-
 final class LinkedList<Data> {
     private var head: Node<Data>?
     private var tail: Node<Data>?
+    
+    var first: Data? {
+        return head?.data
+    }
+    
+    var last: Data? {
+        return tail?.data
+    }
     
     var isEmpty: Bool { head == nil }
     
     func append(value: Data) {
         let newNode: Node = Node(data: value)
+        
         if isEmpty {
             head = newNode
             tail = head
@@ -22,6 +29,14 @@ final class LinkedList<Data> {
             tail?.setNext(to: newNode)
             tail = newNode
         }
+    }
+    
+    func removeFirst() -> Data? {
+        guard let headData = head?.data else { return nil }
+        
+        head = head?.next
+        
+        return headData
     }
     
     func removeAll() {

--- a/BankManagerConsoleApp/BankManagerConsoleApp/LinkedList.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/LinkedList.swift
@@ -9,13 +9,9 @@ final class LinkedList<Data> {
     private var head: Node<Data>?
     private var tail: Node<Data>?
     
-    var first: Data? {
-        return head?.data
-    }
+    var first: Data? { head?.data }
     
-    var last: Data? {
-        return tail?.data
-    }
+    var last: Data? { tail?.data }
     
     var isEmpty: Bool { head == nil }
     

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Node.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Node.swift
@@ -1,0 +1,20 @@
+//
+//  Node.swift
+//  BankManagerConsoleApp
+//
+//  Created by jyubong, Toy
+//
+
+final class Node<DataType> {
+    private(set) var data: DataType
+    private(set) var next: Node?
+    
+    init(data: DataType, next: Node? = nil) {
+        self.data = data
+        self.next = next
+    }
+    
+    func setNext(to node: Node) {
+        self.next = node
+    }
+}

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Node.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Node.swift
@@ -6,7 +6,7 @@
 //
 
 final class Node<DataType> {
-    private(set) var data: DataType
+    let data: DataType
     private(set) var next: Node?
     
     init(data: DataType, next: Node? = nil) {

--- a/BankManagerConsoleApp/CustomerQueueTests/CustomerQueueTests.swift
+++ b/BankManagerConsoleApp/CustomerQueueTests/CustomerQueueTests.swift
@@ -12,7 +12,7 @@ final class CustomerQueueTests: XCTestCase {
     typealias List = LinkedList<Int>
     typealias Queue = CustomerQueue<Int>
     
-    var sut: Queue!
+    private var sut: Queue!
 
     override func setUpWithError() throws {
         try super.setUpWithError()
@@ -72,7 +72,7 @@ final class CustomerQueueTests: XCTestCase {
         XCTAssertFalse(result)
     }
 
-    func test_Queue에1과2를enQueue했을때_1이Queue의첫번째값이고2가Queue의마지막값이다() {
+    func test_Queue에1과2를enQueue했을때_1이Queue의첫번째값이되고2가마지막값이된다() {
         // given
         let firstElement = 1
         let secondElemnet = 2
@@ -82,8 +82,8 @@ final class CustomerQueueTests: XCTestCase {
         sut.enqueue(secondElemnet)
         
         // then
-        XCTAssertEqual(sut.peek, firstElement)
-        XCTAssertNotEqual(sut.peek, secondElemnet)
+        XCTAssertEqual(sut.dequeue(), firstElement)
+        XCTAssertEqual(sut.dequeue(), secondElemnet)
     }
     
     func test_Queue에값이없을때_deQueue했을때_nil을반환된다() {

--- a/BankManagerConsoleApp/CustomerQueueTests/CustomerQueueTests.swift
+++ b/BankManagerConsoleApp/CustomerQueueTests/CustomerQueueTests.swift
@@ -37,7 +37,8 @@ final class CustomerQueueTests: XCTestCase {
     func test_Queue에1을할당할때_peek호출시_1이반환된다() {
         // given
         let element = 1
-        let list = List(head: .init(data: element), tail: .init(data: element))
+        let node = Node(data: element)
+        let list = List(head: node, tail: node)
         sut = Queue(list: list)
         
         // when
@@ -60,7 +61,8 @@ final class CustomerQueueTests: XCTestCase {
     func test_Queue에값이있을때_isEmpty호출시_false가반환된다() {
         // given
         let element = 1
-        let list = List(head: .init(data: element), tail: .init(data: element))
+        let node = Node(data: element)
+        let list = List(head: node, tail: node)
         sut = Queue(list: list)
         
         // when
@@ -82,5 +84,31 @@ final class CustomerQueueTests: XCTestCase {
         // then
         XCTAssertEqual(sut.peek, firstElement)
         XCTAssertNotEqual(sut.peek, secondElemnet)
+    }
+    
+    func test_Queue에값이없을때_deQueue했을때_nil을반환된다() {
+        // given
+        
+        // when
+        let result = sut.dequeue()
+        
+        // then
+        XCTAssertNil(result)
+    }
+    
+    func test_Queue에값이있을때_deQueue했을때_첫번째값이반환된다() {
+        // given
+        let firstElement = 2
+        let secondElement = 1
+        let secondNode = Node(data: secondElement)
+        let firstNode = Node(data: firstElement, next: secondNode)
+        let list = List(head: firstNode, tail: secondNode)
+        sut = Queue(list: list)
+        
+        // when
+        let result = sut.dequeue()
+        
+        // then
+        XCTAssertEqual(result, firstElement)
     }
 }

--- a/BankManagerConsoleApp/CustomerQueueTests/CustomerQueueTests.swift
+++ b/BankManagerConsoleApp/CustomerQueueTests/CustomerQueueTests.swift
@@ -9,28 +9,42 @@ import XCTest
 @testable import BankManagerConsoleApp
 
 final class CustomerQueueTests: XCTestCase {
+    typealias List = LinkedList<Int>
+    typealias Queue = CustomerQueue<Int>
+    
+    var sut: Queue!
 
     override func setUpWithError() throws {
-        // Put setup code here. This method is called before the invocation of each test method in the class.
+        try super.setUpWithError()
+        sut = Queue(list: List())
     }
 
     override func tearDownWithError() throws {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
+        try super.tearDownWithError()
+        sut = nil
+    }
+    
+    func test_Queue에값이없을때_peek호출시_nil이반환된다() {
+        // given
+        
+        // when
+        let result = sut.peek
+        
+        // then
+        XCTAssertNil(result)
     }
 
-    func testExample() throws {
-        // This is an example of a functional test case.
-        // Use XCTAssert and related functions to verify your tests produce the correct results.
-        // Any test you write for XCTest can be annotated as throws and async.
-        // Mark your test throws to produce an unexpected failure when your test encounters an uncaught error.
-        // Mark your test async to allow awaiting for asynchronous code to complete. Check the results with assertions afterwards.
-    }
-
-    func testPerformanceExample() throws {
-        // This is an example of a performance test case.
-        measure {
-            // Put the code you want to measure the time of here.
-        }
+    func test_head에1을할당할때_peek호출시_1이반환된다() {
+        // given
+        let element = 1
+        let list = List(head: .init(data: element), tail: .init(data: element))
+        sut = Queue(list: list)
+        
+        // when
+        let result = sut.peek
+        
+        // then
+        XCTAssertEqual(result, element)
     }
 
 }

--- a/BankManagerConsoleApp/CustomerQueueTests/CustomerQueueTests.swift
+++ b/BankManagerConsoleApp/CustomerQueueTests/CustomerQueueTests.swift
@@ -34,7 +34,7 @@ final class CustomerQueueTests: XCTestCase {
         XCTAssertNil(result)
     }
 
-    func test_head에1을할당할때_peek호출시_1이반환된다() {
+    func test_Queue에1을할당할때_peek호출시_1이반환된다() {
         // given
         let element = 1
         let list = List(head: .init(data: element), tail: .init(data: element))
@@ -46,5 +46,29 @@ final class CustomerQueueTests: XCTestCase {
         // then
         XCTAssertEqual(result, element)
     }
+    
+    func test_Queue에값이없을때_isEmpty호출시_true가반환된다() {
+        // given
+        
+        // when
+        let result = sut.isEmpty
+        
+        // then
+        XCTAssertTrue(result)
+    }
+    
+    func test_Queue에값이있을때_isEmpty호출시_false가반환된다() {
+        // given
+        let element = 1
+        let list = List(head: .init(data: element), tail: .init(data: element))
+        sut = Queue(list: list)
+        
+        // when
+        let result = sut.isEmpty
+        
+        // then
+        XCTAssertFalse(result)
+    }
+
 
 }

--- a/BankManagerConsoleApp/CustomerQueueTests/CustomerQueueTests.swift
+++ b/BankManagerConsoleApp/CustomerQueueTests/CustomerQueueTests.swift
@@ -1,0 +1,36 @@
+//
+//  CustomerQueueTests.swift
+//  CustomerQueueTests
+//
+//  Created by jyubong, Toy on 11/14/23.
+//
+
+import XCTest
+@testable import BankManagerConsoleApp
+
+final class CustomerQueueTests: XCTestCase {
+
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    func testExample() throws {
+        // This is an example of a functional test case.
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+        // Any test you write for XCTest can be annotated as throws and async.
+        // Mark your test throws to produce an unexpected failure when your test encounters an uncaught error.
+        // Mark your test async to allow awaiting for asynchronous code to complete. Check the results with assertions afterwards.
+    }
+
+    func testPerformanceExample() throws {
+        // This is an example of a performance test case.
+        measure {
+            // Put the code you want to measure the time of here.
+        }
+    }
+
+}

--- a/BankManagerConsoleApp/CustomerQueueTests/CustomerQueueTests.swift
+++ b/BankManagerConsoleApp/CustomerQueueTests/CustomerQueueTests.swift
@@ -70,5 +70,17 @@ final class CustomerQueueTests: XCTestCase {
         XCTAssertFalse(result)
     }
 
-
+    func test_Queue에1과2를enQueue했을때_1이Queue의첫번째값이고2가Queue의마지막값이다() {
+        // given
+        let firstElement = 1
+        let secondElemnet = 2
+        
+        // when
+        sut.enqueue(firstElement)
+        sut.enqueue(secondElemnet)
+        
+        // then
+        XCTAssertEqual(sut.peek, firstElement)
+        XCTAssertNotEqual(sut.peek, secondElemnet)
+    }
 }

--- a/BankManagerConsoleApp/CustomerQueueTests/CustomerQueueTests.swift
+++ b/BankManagerConsoleApp/CustomerQueueTests/CustomerQueueTests.swift
@@ -111,4 +111,20 @@ final class CustomerQueueTests: XCTestCase {
         // then
         XCTAssertEqual(result, firstElement)
     }
+    
+    func test_Queue에값이있을때_clear호출시_isEmpty가true가된다() {
+        // given
+        let firstElement = 2
+        let secondElement = 1
+        let secondNode = Node(data: secondElement)
+        let firstNode = Node(data: firstElement, next: secondNode)
+        let list = List(head: firstNode, tail: secondNode)
+        sut = Queue(list: list)
+        
+        // when
+        sut.clear()
+        
+        // then
+        XCTAssertTrue(sut.isEmpty)
+    }
 }


### PR DESCRIPTION
@1Consumption
안녕하세요 올라프☃️ 이번 프로젝트의 리뷰이 토이와 쥬봉이입니다.
2주동안 잘부탁드립니다! step1 PR 보냅니다.

---
### 고민이 되었던 점
**1. 각 모델별 해당 타입 선택 이유**
- `struct CustomerQueue` : [Choosing Between Structures an Classes](https://developer.apple.com/documentation/swift/choosing-between-structures-and-classes)에 따라 상속 등 class를 활용해야할 상황이 없어 `default`인 struct를 사용하였습니다.

- `class LinkedList` : struct는 프로퍼티가 참조타입이면 reference counting이 발생하면서 갯수에 따라 오버헤드가 발생합니다.(한개 정도는 성능에 지장이 없다고 합니다.) 즉, Struct에서 여러개의 레퍼런스를 사용하는 프로퍼티를 사용하게 되면, 클래스보다 성능이 더 안좋아질 수 있습니다. `Linked list의 프로퍼티는 node를 참조하기때문에 struct를 했을 경우 성능이 떨어질 것으로 생각되어 class`로 구현하였습니다. (참고 : [swift struct와 class의 성능 차이](https://corykim0829.github.io/swift/Understanding-Swift-Performance/#))

- `class Node` : linked list는 Noe끼리 주소 포인터를 가리키며 참조함으로써 이어지는 구조입니다. 즉, `Node는 자기 참조형태`이기때문에 class로 구현하였습니다.


**2. 의존성 주입**
 - CustomerQueue에서 `유지보수와 확정성을 높이기 위해서` 의존성 주입을 해주기 위해 내부에서 초기화가 이루어지는 것이 아닌 외부에서 LinkedList객체를 생성하여 내부에 주입할 수 있도록 구현하였습니다.

**3. Unit test**
- Unit test는 FIRST의 Independent/Isolated 원칙에 따라 `각각의 테스트는 서로 독립적이며 서로 의존해서는 안 됩니다.` 그래서 각 test 메서드 별로 CustomerQueue의 메서드를 독립적으로 테스트하고자 하였습니다. 
예를 들어, peek을 테스트하는 메서드에서는 Queue에 값을 할당할때 enQueue를 활용하면 enQueue에 대한 테스트도 이루어지는 것이라고 생각해 사용하지 않고, init을 통해 값을 초기화해주었습니다.
    ```swift
    func test_Queue에1을할당할때_peek호출시_1이반환된다() {
        // given
        let element = 1
        let node = Node(data: element)
        let list = List(head: node, tail: node)
        sut = Queue(list: list)

        // when
        let result = sut.peek

        // then
        XCTAssertEqual(result, element)
    }
    ```

- command line tool test시 target membership을 설정해야 하는 이유
    - 프로세스 내에서 테스트 번들을 로드하는 메커니즘은 프로세스가 GUI 프레임워크(예: Cocoa 또는 Cocoa Touch)를 기반으로 하는 경우에만 작동합니다. command line tool은 일반적으로 GUI 프레임워크를 사용하지 않으므로 테스트 번들을 해당 tool에 로드할 수 없습니다. 따라서, 해결 방법으로 테스트 번들을 코드 파일에 직접 연결하는 것입니다. (참고: [Developer Forums](https://developer.apple.com/forums/thread/52211))

### 조언을 구하고 싶은 부분
1. Node에서 프로퍼티의 값을 불러올 때 `private(set)으로 설정하여 프로퍼티에 직접 접근하는 방법`도 괜찮은 것일까요?
  - `디미터의 법칙`은 자신이 조작하는 객체의 속사정을 몰라야 한다는 것을 의미합니다. 이에 따라 `프로퍼티는 숨기고 함수를 통해 공개`하게 만든 것이 디미터의 법칙입니다.(참고 : [디미터 법칙](https://dkswnkk.tistory.com/687))
  - `private(set)은 setter는 숨기고 getter만 보여주는 접근제어`인데, 이 접근제어자로 프로퍼티에 접근하여 값을 보는 것이 메서드를 만들어 접근하는 것과 비슷한 맥락으로 생각되어 사용하였습니다.
  - 하지만 프로퍼티에 직접 접근한다는 맥락에서 디미터의 법칙에 어긋나는 것인지, 따라서 메서드로 접근하는 것이 좋은지 고민입니다.

2. command line tool test시 target membership을 설정해야하는 이유를 위의 3번에서와 같이 찾아보았고, 참고문서에 따라 아래처럼 이해를 했는데 적절한 방향일까요?
  - UIApp에서는 unit test를 만들때 target to tested를 설정할 수 있지만, command line tool에서는 none으로만 설정이 됩니다. 즉, GUI 프레임워크 환경에서는 생성시 target을 설정할 수 있지만, command line tool에서는 설정할 수 없기때문에 직접 target membership을 설정해주어야합니다.
  - 실험적으로 UIApp에서 test를 만들때 target to tested를 none으로 설정해보았는데, 이때는 command line tool처럼 직접 target membership을 설정해었을 때 작동하였습니다.

3. unit test를 하는데 아직 많이 미숙합니다. 아낌없는 조언 부탁드립니다.