### PR TITLE
은행창구 매니저 [step3] Kiseok

### DIFF
--- a/BankManager/Sources/BankManager/Bank.swift
+++ b/BankManager/Sources/BankManager/Bank.swift
@@ -57,7 +57,10 @@ public struct Bank {
             let taskEnd = CFAbsoluteTimeGetCurrent() - taskStart
             
             close(time: taskEnd)
-            NotificationCenter.default.post(name: Bank.notificationName, object: nil)
+            NotificationCenter.default.post(
+                name: Bank.notificationName,
+                object: nil
+            )
         }
     }
     

--- a/BankManager/Sources/BankManager/Bank.swift
+++ b/BankManager/Sources/BankManager/Bank.swift
@@ -8,6 +8,7 @@ import Foundation
 
 @available(macOS 10.15, *)
 public struct Bank {
+    public static let notificationName = Notification.Name("BankNotification")
     private let bankClerk: BankClerk = .init()
     private let bankManager: BankManager = .init()
     private let customerNumber = Int.random(in: 10...30)
@@ -32,6 +33,7 @@ public struct Bank {
             }
             
             bankClerk.startTask(count: ticketNumber)
+            NotificationCenter.default.post(name: Bank.notificationName, object: nil)
         }
         let taskEnd = CFAbsoluteTimeGetCurrent() - taskStart
         

--- a/BankManager/Sources/BankManager/Bank.swift
+++ b/BankManager/Sources/BankManager/Bank.swift
@@ -11,14 +11,18 @@ public struct Bank {
     private let bankClerk: BankClerk = .init()
     private let bankManager: BankManager = .init()
     private let customerNumber = Int.random(in: 10...30)
-    private let customerLine: CustomerQueue<Customer> = .init()
+    private let firstDepositLine: CustomerQueue<Customer> = .init()
+    private let secondDepositLine: CustomerQueue<Customer> = .init()
+    private let loanLine: CustomerQueue<Customer> = .init()
     
     public init() {}
     
     public func open() {
-        bankManager.giveWaitingTicket(
-            customerNumber: self.customerNumber,
-            customerLine: self.customerLine
+        bankManager.giveWaitingTicketAndLineUp(
+            customerNumber: customerNumber,
+            firstDepositLine: firstDepositLine,
+            secondDepositLine: secondDepositLine,
+            loanLine: loanLine
         )
         
         let taskStart = CFAbsoluteTimeGetCurrent()

--- a/BankManager/Sources/BankManager/Bank.swift
+++ b/BankManager/Sources/BankManager/Bank.swift
@@ -6,6 +6,7 @@
 //
 import Foundation
 
+@available(macOS 10.15, *)
 public struct Bank {
     private let bankClerk: BankClerk = .init()
     private let bankManager: BankManager = .init()

--- a/BankManager/Sources/BankManager/Bank.swift
+++ b/BankManager/Sources/BankManager/Bank.swift
@@ -12,8 +12,7 @@ public struct Bank {
     private let bankClerk: BankClerk = .init()
     private let bankManager: BankManager = .init()
     private let customerNumber = Int.random(in: 10...30)
-    private let firstDepositLine: CustomerQueue<Customer> = .init()
-    private let secondDepositLine: CustomerQueue<Customer> = .init()
+    private let depositLine: CustomerQueue<Customer> = .init()
     private let loanLine: CustomerQueue<Customer> = .init()
     
     public init() {}
@@ -21,8 +20,7 @@ public struct Bank {
     public func open() {
         bankManager.giveWaitingTicketAndLineUp(
             customerNumber: customerNumber,
-            firstDepositLine: firstDepositLine,
-            secondDepositLine: secondDepositLine,
+            depositLine: depositLine,
             loanLine: loanLine
         )
         
@@ -32,7 +30,7 @@ public struct Bank {
         
         Task {
             let taskStart = CFAbsoluteTimeGetCurrent()
-            while firstDepositLine.hasCustomer != 0 || secondDepositLine.hasCustomer != 0 || loanLine.hasCustomer != 0 {
+            while depositLine.hasCustomer != 0 || loanLine.hasCustomer != 0 {
                 await withTaskGroup(of: Void.self) { group in
                     group.addTask {
                         guard let loanCustomer = loanLine.dequeue() else {
@@ -42,14 +40,14 @@ public struct Bank {
                     }
                     
                     group.addTask {
-                        guard let depositCustomer = firstDepositLine.dequeue() else {
+                        guard let depositCustomer = depositLine.dequeue() else {
                             return
                         }
                         await firstBankClerk.startTask(customer: depositCustomer)
                     }
                     
                     group.addTask {
-                        guard let depositCustomer = secondDepositLine.dequeue() else {
+                        guard let depositCustomer = depositLine.dequeue() else {
                             return
                         }
                         await secondBankClerk.startTask(customer: depositCustomer)

--- a/BankManager/Sources/BankManager/Bank.swift
+++ b/BankManager/Sources/BankManager/Bank.swift
@@ -38,21 +38,21 @@ public struct Bank {
                         guard let loanCustomer = loanLine.dequeue() else {
                             return
                         }
-                        await firstBankClerk.startTask(customer: loanCustomer)
+                        await firstBankClerk.startTask(with: loanCustomer)
                     }
                     
                     group.addTask {
                         guard let depositCustomer = depositLine.dequeue() else {
                             return
                         }
-                        await secondBankClerk.startTask(customer: depositCustomer)
+                        await secondBankClerk.startTask(with: depositCustomer)
                     }
                     
                     group.addTask {
                         guard let depositCustomer = depositLine.dequeue() else {
                             return
                         }
-                        await thirdBankClerk.startTask(customer: depositCustomer)
+                        await thirdBankClerk.startTask(with: depositCustomer)
                     }
                 }
             }

--- a/BankManager/Sources/BankManager/BankClerk.swift
+++ b/BankManager/Sources/BankManager/BankClerk.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 
+@available(macOS 10.15, *)
 struct BankClerk {
     
     func startTask(count: Int) {

--- a/BankManager/Sources/BankManager/BankClerk.swift
+++ b/BankManager/Sources/BankManager/BankClerk.swift
@@ -10,10 +10,14 @@ import Foundation
 @available(macOS 10.15, *)
 struct BankClerk {
     
-    func startTask(count: Int) {
-        print("\(count)번 고객 업무 시작")
-        Thread.sleep(forTimeInterval: 0.7)
-        print("\(count)번 고객 업무 완료")
+    func startTask(customer: Customer)  async {
+        print("\(customer.waitingTicket)번 고객 \(customer.bankingCategory.description)업무 시작")
+        do {
+            try await Task.sleep(nanoseconds: customer.bankingCategory.rawValue)
+        } catch {
+            print(error.localizedDescription)
+        }
+        print("\(customer.waitingTicket)번 고객 \(customer.bankingCategory.description)업무 종료")
     }
     
     func endTask(customerNumber: Int, time: CFAbsoluteTime) {

--- a/BankManager/Sources/BankManager/BankClerk.swift
+++ b/BankManager/Sources/BankManager/BankClerk.swift
@@ -10,7 +10,7 @@ import Foundation
 @available(macOS 10.15, *)
 struct BankClerk {
     
-    func startTask(customer: Customer)  async {
+    func startTask(with customer: Customer) async {
         print("\(customer.waitingTicket)번 고객 \(customer.bankingCategory.description)업무 시작")
         do {
             try await Task.sleep(nanoseconds: customer.bankingCategory.rawValue)

--- a/BankManager/Sources/BankManager/BankManager.swift
+++ b/BankManager/Sources/BankManager/BankManager.swift
@@ -1,20 +1,16 @@
 
 struct BankManager {
     
-    func giveWaitingTicketAndLineUp(customerNumber: Int, firstDepositLine: CustomerQueue<Customer>, secondDepositLine: CustomerQueue<Customer>, loanLine: CustomerQueue<Customer>) {
+    func giveWaitingTicketAndLineUp(customerNumber: Int, depositLine: CustomerQueue<Customer>, loanLine: CustomerQueue<Customer>) {
         for i in 1...customerNumber {
             let customer = Customer(waitingTicket: i, bankingCategory: BankingCategory.allCases.randomElement() ?? .deposit)
-            
-            guard customer.bankingCategory == .loan else {
-                if secondDepositLine.hasCustomer < firstDepositLine.hasCustomer {
-                    secondDepositLine.enqueue(customer: customer)
-                } else {
-                    firstDepositLine.enqueue(customer: customer)
-                }
+
+            if customer.bankingCategory == .loan {
+                loanLine.enqueue(customer: customer)
                 continue
             }
             
-            loanLine.enqueue(customer: customer)
+            depositLine.enqueue(customer: customer)
         }
     }
 }

--- a/BankManager/Sources/BankManager/BankManager.swift
+++ b/BankManager/Sources/BankManager/BankManager.swift
@@ -7,10 +7,9 @@ struct BankManager {
 
             if customer.bankingCategory == .loan {
                 loanLine.enqueue(customer: customer)
-                continue
+            } else {
+                depositLine.enqueue(customer: customer)
             }
-            
-            depositLine.enqueue(customer: customer)
         }
     }
 }

--- a/BankManager/Sources/BankManager/BankManager.swift
+++ b/BankManager/Sources/BankManager/BankManager.swift
@@ -1,10 +1,20 @@
 
 struct BankManager {
     
-    func giveWaitingTicket(customerNumber: Int, customerLine: CustomerQueue<Customer>) {
+    func giveWaitingTicketAndLineUp(customerNumber: Int, firstDepositLine: CustomerQueue<Customer>, secondDepositLine: CustomerQueue<Customer>, loanLine: CustomerQueue<Customer>) {
         for i in 1...customerNumber {
-            let customer = Customer(waitingTicket: i)
-            customerLine.enqueue(customer: customer)
+            let customer = Customer(waitingTicket: i, bankingCategory: BankingCategory.allCases.randomElement() ?? .deposit)
+            
+            guard customer.bankingCategory == .loan else {
+                if secondDepositLine.hasCustomer < firstDepositLine.hasCustomer {
+                    secondDepositLine.enqueue(customer: customer)
+                } else {
+                    firstDepositLine.enqueue(customer: customer)
+                }
+                continue
+            }
+            
+            loanLine.enqueue(customer: customer)
         }
     }
 }

--- a/BankManager/Sources/BankManager/BankManager.swift
+++ b/BankManager/Sources/BankManager/BankManager.swift
@@ -3,12 +3,22 @@ struct BankManager {
     
     func giveWaitingTicketAndLineUp(customerNumber: Int, depositLine: CustomerQueue<Customer>, loanLine: CustomerQueue<Customer>) {
         for i in 1...customerNumber {
-            let customer = Customer(waitingTicket: i, bankingCategory: BankingCategory.allCases.randomElement() ?? .deposit)
+            let customer = Customer(
+                waitingTicket: i,
+                bankingCategory: BankingCategory.allCases.randomElement() ?? .deposit
+            )
 
             if customer.bankingCategory == .loan {
-                loanLine.enqueue(customer: customer)
+                loanLine.enqueue(customer)
             } else {
-                depositLine.enqueue(customer: customer)
+                depositLine.enqueue(customer)
+            }
+            
+            switch customer.bankingCategory {
+            case .deposit:
+                depositLine.enqueue(customer)
+            case .loan:
+                loanLine.enqueue(customer)
             }
         }
     }

--- a/BankManager/Sources/BankManager/BankingCategory.swift
+++ b/BankManager/Sources/BankManager/BankingCategory.swift
@@ -1,0 +1,20 @@
+//
+//  BankingCategory.swift
+//
+//
+//  Created by Kiseok on 11/22/23.
+//
+
+enum BankingCategory: UInt64, CaseIterable {
+    case deposit = 700_000_000
+    case loan = 1_100_000_000
+    
+    var description: String {
+        switch self {
+        case .deposit:
+            return "예금"
+        case .loan:
+            return "대출"
+        }
+    }
+}

--- a/BankManager/Sources/BankManager/Customer.swift
+++ b/BankManager/Sources/BankManager/Customer.swift
@@ -7,4 +7,5 @@
 
 public struct Customer: CustomerProtocol {
     let waitingTicket: Int
+    let bankingCategory: BankingCategory
 }

--- a/BankManager/Sources/BankManager/Model/CustomerQueue.swift
+++ b/BankManager/Sources/BankManager/Model/CustomerQueue.swift
@@ -22,7 +22,7 @@ public struct CustomerQueue<T: CustomerProtocol> {
     
     public init() {}
     
-    public func enqueue(customer: T) {
+    public func enqueue(_ customer: T) {
         queue.append(data: customer)
     }
     

--- a/BankManagerConsoleApp/BankManagerConsoleApp/main.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/main.swift
@@ -36,4 +36,4 @@ func start() {
 }
 
 start()
-
+RunLoop.current.run()

--- a/BankManagerConsoleApp/BankManagerConsoleApp/main.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/main.swift
@@ -21,7 +21,12 @@ func start() {
     switch userInput {
     case "1":
         bank.open()
-        start()
+        NotificationCenter.default.addObserver(
+            forName: Bank.notificationName,
+            object: nil,
+            queue: nil) { _ in
+                start()
+            }
     case "2":
         exit(0)
     default:


### PR DESCRIPTION
@havilog 
안녕하세요 하비!
Step3 PR 보냅니다!
정말 길고도 험한 Concurrency였습니다,,,,,,

## 고민했던 점
### 1. 은행원 3명이 동시에 업무 & 각각의 은행 업무가 모두 끝나야 close호출
task group을 이용하여 하나의 Task 생성 후 while문 안에 각각의 child task를 생성 후 bankClerk들이 업무를 하도록 구현했습니다. while문 바깥에 close메서드를 호출하여 while문이 끝나야 실행되도록 구현했습니다.
### 2. 은행업무 종료 후 다시 메뉴 출력
concurrency의 기능으로는 비동기 함수와 동기 함수를 serial하게 실행할 방법을 찾지 못해 close메서드 호출 직후에 notificationCenter를 이용하여 Bank의 open메서드가 모두 끝났을 때 post하여 메뉴 출력을 다시 하도록 구현했습니다.
### 3. 은행개점 메뉴 선택 시 프로그램이 바로 종료되는 문제
bank.open메서드가 모두 실행된 후 메뉴 출력을 다시 하도록 구현했을 때 open메서드가 끝나기도 전에 프로그램이 종료되어버리는 문제가 발생했습니다.
[Swift 지연 실행 테스트](https://songios.tistory.com/30)
해당 블로그 글을 참고하여 RunLoop.current.run()메서드를 활용하여 정상 작동하도록 구현했습니다.

## 조언을 구하고 싶은 점
### runLoop 관련

은행개점 메뉴 선택 시 프로그램이 바로 종료되는 부분의 이유를 생각해 봤을 때 아마 저 함수를 실행하는 스레드의 runloop를 직접 생성해 준 후 실행되도록 만들어 주지 않았기 때문이라고 생각했는데 맞을까요?
[Swift 공식문서 RunLoop](https://developer.apple.com/documentation/foundation/runloop)
>Your application neither creates nor explicitly manages RunLoop objects. The system creates a RunLoop object as needed for each Thread object, including the application’s main thread. If you need to access the current thread’s run loop, use the class method current.

아래 Documentation Archive의 내용을 저는 "Main Thread는 애플리케이션의 프레임워크가 자동으로 Run Loop를 생성하고 실행시키지만 다른 스레드들은 개발자가 명시적으로 실행시켜줘야한다" 라고 이해했는데 맞을까요?
[Apple Documentation Archive: Run Loops](https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/Multithreading/RunLoopManagement/RunLoopManagement.html)
>Run loop management is not entirely automatic. You must still design your thread’s code to start the run loop at appropriate times and respond to incoming events. Both Cocoa and Core Foundation provide run loop objects to help you configure and manage your thread’s run loop. Your application does not need to create these objects explicitly; each thread, including the application’s main thread, has an associated run loop object. Only secondary threads need to run their run loop explicitly, however. The app frameworks automatically set up and run the run loop on the main thread as part of the application startup process

### Task 관련

아래 내용처럼 suspend된 task가 이전에 실행되었던 thread로 다시 돌아온다고 가정하고 코드를 작성하게 되었을 때 어떠한 문제점들이 발생할 수 있는지 궁금합니다.
[PointFree Concurrency 내용 중](https://www.pointfree.co/collections/concurrency/threads-queues-and-tasks/ep192-concurrency-s-future-tasks-and-cooperation#t118)
>The thread changes quite a bit, and so we do see it’s possible for suspended tasks to be resumed on a different thread. This means we should not make any assumptions about adjacent lines of code executing on the same thread. This seems quite strange, but also these tools are specifically designed to largely keep us from thinking about asynchrony and concurrency in terms of threads.

---
5일 간 concurrency만 열심히 파봤지만 아직은 많이 부족합니다,,,
제가 작성한 코드 중에서 다른 방식으로도 해볼 수 있다거나
조금 더 깊게 찾아봤으면 좋겠다싶은 키워드들을 말씀해 주신다면 정말 좋을 것 같습니다.
잘 부탁드립니다!

