### PR TITLE
은행창구 매니저 [STEP 1] Prism, Danny

### DIFF
--- a/BankManager/Sources/BankManager/BankQueue.swift
+++ b/BankManager/Sources/BankManager/BankQueue.swift
@@ -36,7 +36,7 @@ class BankQueue<T>: Queueable {
     }
     
     func enqueue(element: T) {
-        
+        return list.addLast(element: element)
     }
     
     func dequeue() -> T? {

--- a/BankManager/Sources/BankManager/BankQueue.swift
+++ b/BankManager/Sources/BankManager/BankQueue.swift
@@ -24,7 +24,7 @@ class BankQueue<T>: Queueable {
     }
     
     var count: Int {
-        return 0
+        return list.count
     }
     
     var first: T?

--- a/BankManager/Sources/BankManager/BankQueue.swift
+++ b/BankManager/Sources/BankManager/BankQueue.swift
@@ -36,7 +36,7 @@ final class BankQueue<T>: Queueable {
     }
     
     func enqueue(element: T) {
-        return list.addLast(element: element)
+        list.addLast(element: element)
     }
     
     func dequeue() -> T? {
@@ -44,6 +44,6 @@ final class BankQueue<T>: Queueable {
     }
     
     func clear() {
-        return list.clear()
+        list.clear()
     }
 }

--- a/BankManager/Sources/BankManager/BankQueue.swift
+++ b/BankManager/Sources/BankManager/BankQueue.swift
@@ -27,7 +27,9 @@ class BankQueue<T>: Queueable {
         return list.count
     }
     
-    var first: T?
+    var first: T? {
+        return list.first
+    }
     
     var last: T?
     

--- a/BankManager/Sources/BankManager/BankQueue.swift
+++ b/BankManager/Sources/BankManager/BankQueue.swift
@@ -6,13 +6,13 @@
 //
 
 protocol Queueable {
-    associatedtype T
+    associatedtype Element
     var isEmpty: Bool { get }
     var count: Int { get }
-    var first: T? { get }
-    var last: T? { get }
-    func enqueue(element: T)
-    func dequeue() -> T?
+    var first: Element? { get }
+    var last: Element? { get }
+    func enqueue(element: Element)
+    func dequeue() -> Element?
     func clear()
 }
 

--- a/BankManager/Sources/BankManager/BankQueue.swift
+++ b/BankManager/Sources/BankManager/BankQueue.swift
@@ -16,7 +16,7 @@ protocol Queueable {
     func clear()
 }
 
-class BankQueue<T>: Queueable {
+final class BankQueue<T>: Queueable {
     let list = SinglyLinkedList<T>()
     
     var isEmpty: Bool {

--- a/BankManager/Sources/BankManager/BankQueue.swift
+++ b/BankManager/Sources/BankManager/BankQueue.swift
@@ -44,7 +44,7 @@ class BankQueue<T>: Queueable {
     }
     
     func clear() {
-        
+        return list.clear()
     }
     
 }

--- a/BankManager/Sources/BankManager/BankQueue.swift
+++ b/BankManager/Sources/BankManager/BankQueue.swift
@@ -40,7 +40,7 @@ class BankQueue<T>: Queueable {
     }
     
     func dequeue() -> T? {
-        return nil
+        return list.removeFirst()
     }
     
     func clear() {

--- a/BankManager/Sources/BankManager/BankQueue.swift
+++ b/BankManager/Sources/BankManager/BankQueue.swift
@@ -17,7 +17,7 @@ protocol Queueable {
 }
 
 final class BankQueue<T>: Queueable {
-    let list = SinglyLinkedList<T>()
+    private let list = SinglyLinkedList<T>()
     
     var isEmpty: Bool {
         return list.isEmpty
@@ -46,5 +46,4 @@ final class BankQueue<T>: Queueable {
     func clear() {
         return list.clear()
     }
-    
 }

--- a/BankManager/Sources/BankManager/BankQueue.swift
+++ b/BankManager/Sources/BankManager/BankQueue.swift
@@ -31,7 +31,9 @@ class BankQueue<T>: Queueable {
         return list.first
     }
     
-    var last: T?
+    var last: T? {
+        return list.last
+    }
     
     func enqueue(element: T) {
         

--- a/BankManager/Sources/BankManager/BankQueue.swift
+++ b/BankManager/Sources/BankManager/BankQueue.swift
@@ -1,0 +1,46 @@
+//
+//  BankQueue.swift
+//
+//
+//  Created by Danny, Prism on 3/19/24.
+//
+
+protocol Queueable {
+    associatedtype T
+    var isEmpty: Bool { get }
+    var count: Int { get }
+    var first: T? { get }
+    var last: T? { get }
+    func enqueue(element: T)
+    func dequeue() -> T?
+    func clear()
+}
+
+class BankQueue<T>: Queueable {
+    let list = SinglyLinkedList<T>()
+    
+    var isEmpty: Bool {
+        return true
+    }
+    
+    var count: Int {
+        return 0
+    }
+    
+    var first: T?
+    
+    var last: T?
+    
+    func enqueue(element: T) {
+        
+    }
+    
+    func dequeue() -> T? {
+        return nil
+    }
+    
+    func clear() {
+        
+    }
+    
+}

--- a/BankManager/Sources/BankManager/BankQueue.swift
+++ b/BankManager/Sources/BankManager/BankQueue.swift
@@ -20,7 +20,7 @@ class BankQueue<T>: Queueable {
     let list = SinglyLinkedList<T>()
     
     var isEmpty: Bool {
-        return true
+        return list.isEmpty
     }
     
     var count: Int {

--- a/BankManager/Sources/BankManager/SinglyLinkedList.swift
+++ b/BankManager/Sources/BankManager/SinglyLinkedList.swift
@@ -19,9 +19,9 @@ final class SinglyLinkedList<T> {
         }
     }
     
-    var head: Node? = nil
-    var tail: Node? = nil
-    var count: Int = 0
+    private var head: Node? = nil
+    private var tail: Node? = nil
+    private(set) var count: Int = 0
     
     var isEmpty: Bool {
         return count == 0 ? true : false

--- a/BankManager/Sources/BankManager/SinglyLinkedList.swift
+++ b/BankManager/Sources/BankManager/SinglyLinkedList.swift
@@ -39,14 +39,39 @@ class SinglyLinkedList<T> {
         let newNode = Node(element: element)
         newNode.next = head
         head = newNode
+        
+        if isEmpty {
+            tail = head
+        }
+        
         count += 1
     }
     
     func addLast(element: T) {
         let newNode = Node(element: element)
-        tail?.next = newNode
+        
+        if isEmpty {
+            head = newNode
+        } else {
+            tail?.next = newNode
+        }
+        
         tail = newNode
         count += 1
+    }
+    
+    func removeFirst() -> T? {
+        guard !isEmpty else { return nil }
+        
+        let element = head?.element
+        head = head?.next
+        count -= 1
+        
+        if isEmpty {
+            tail = nil
+        }
+        
+        return element
     }
     
     func clear() {

--- a/BankManager/Sources/BankManager/SinglyLinkedList.swift
+++ b/BankManager/Sources/BankManager/SinglyLinkedList.swift
@@ -5,8 +5,8 @@
 //  Created by Danny, Prism on 3/19/24.
 //
 
-class SinglyLinkedList<T> {
-    class Node {
+final class SinglyLinkedList<T> {
+    final class Node {
         var element: T
         var next: Node? = nil
         

--- a/BankManager/Sources/BankManager/SinglyLinkedList.swift
+++ b/BankManager/Sources/BankManager/SinglyLinkedList.swift
@@ -35,18 +35,6 @@ final class SinglyLinkedList<T> {
         return isEmpty ? nil : tail?.element
     }
     
-    func addFirst(element: T) {
-        let newNode = Node(element: element)
-        newNode.setNext(node: head)
-        head = newNode
-        
-        if isEmpty {
-            tail = head
-        }
-        
-        count += 1
-    }
-    
     func addLast(element: T) {
         let newNode = Node(element: element)
         

--- a/BankManager/Sources/BankManager/SinglyLinkedList.swift
+++ b/BankManager/Sources/BankManager/SinglyLinkedList.swift
@@ -24,7 +24,7 @@ class SinglyLinkedList<T> {
     var count: Int = 0
     
     var isEmpty: Bool {
-        return true
+        return count == 0 ? true : false
     }
     
     var first: T? {

--- a/BankManager/Sources/BankManager/SinglyLinkedList.swift
+++ b/BankManager/Sources/BankManager/SinglyLinkedList.swift
@@ -7,14 +7,14 @@
 
 final class SinglyLinkedList<T> {
     final class Node {
-        var element: T
-        var next: Node? = nil
+        private(set) var element: T
+        private(set) var next: Node? = nil
         
         init(element: T) {
             self.element = element
         }
         
-        func setNext(node: Node) {
+        func setNext(node: Node?) {
             self.next = node
         }
     }
@@ -37,7 +37,7 @@ final class SinglyLinkedList<T> {
     
     func addFirst(element: T) {
         let newNode = Node(element: element)
-        newNode.next = head
+        newNode.setNext(node: head)
         head = newNode
         
         if isEmpty {
@@ -53,7 +53,7 @@ final class SinglyLinkedList<T> {
         if isEmpty {
             head = newNode
         } else {
-            tail?.next = newNode
+            tail?.setNext(node: newNode)
         }
         
         tail = newNode

--- a/BankManager/Sources/BankManager/SinglyLinkedList.swift
+++ b/BankManager/Sources/BankManager/SinglyLinkedList.swift
@@ -32,7 +32,7 @@ class SinglyLinkedList<T> {
     }
     
     var last: T? {
-        return nil
+        return isEmpty ? nil : tail?.element
     }
     
     func addFirst(element: T) {

--- a/BankManager/Sources/BankManager/SinglyLinkedList.swift
+++ b/BankManager/Sources/BankManager/SinglyLinkedList.swift
@@ -28,7 +28,7 @@ class SinglyLinkedList<T> {
     }
     
     var first: T? {
-        return nil
+        return isEmpty ? nil : head?.element
     }
     
     var last: T? {

--- a/BankManager/Sources/BankManager/SinglyLinkedList.swift
+++ b/BankManager/Sources/BankManager/SinglyLinkedList.swift
@@ -5,14 +5,45 @@
 //  Created by Danny, Prism on 3/19/24.
 //
 
-
-class SinglyLinkedList {
-    class Node<T> {
+class SinglyLinkedList<T> {
+    class Node {
         var data: T
-        var next: Node<T>? = nil
+        var next: Node? = nil
         
         init(data: T) {
             self.data = data
         }
+        
+        func setNext(node: Node) {
+            self.next = node
+        }
+    }
+    
+    var head: Node? = nil
+    var tail: Node? = nil
+    var count: Int = 0
+    
+    var isEmpty: Bool {
+        return true
+    }
+    
+    var first: T? {
+        return nil
+    }
+    
+    var last: T? {
+        return nil
+    }
+    
+    func enqueue() {
+        
+    }
+    
+    func dequeue() -> T? {
+        return nil
+    }
+    
+    func clear() {
+        
     }
 }

--- a/BankManager/Sources/BankManager/SinglyLinkedList.swift
+++ b/BankManager/Sources/BankManager/SinglyLinkedList.swift
@@ -75,6 +75,8 @@ class SinglyLinkedList<T> {
     }
     
     func clear() {
-        
+        head = nil
+        tail = nil
+        count = 0
     }
 }

--- a/BankManager/Sources/BankManager/SinglyLinkedList.swift
+++ b/BankManager/Sources/BankManager/SinglyLinkedList.swift
@@ -1,0 +1,18 @@
+//
+//  SinglyLinkedList.swift
+//
+//
+//  Created by Danny, Prism on 3/19/24.
+//
+
+
+class SinglyLinkedList {
+    class Node<T> {
+        var data: T
+        var next: Node<T>? = nil
+        
+        init(data: T) {
+            self.data = data
+        }
+    }
+}

--- a/BankManager/Sources/BankManager/SinglyLinkedList.swift
+++ b/BankManager/Sources/BankManager/SinglyLinkedList.swift
@@ -42,6 +42,13 @@ class SinglyLinkedList<T> {
         count += 1
     }
     
+    func addLast(element: T) {
+        let newNode = Node(element: element)
+        tail?.next = newNode
+        tail = newNode
+        count += 1
+    }
+    
     func clear() {
         
     }

--- a/BankManager/Sources/BankManager/SinglyLinkedList.swift
+++ b/BankManager/Sources/BankManager/SinglyLinkedList.swift
@@ -7,11 +7,11 @@
 
 class SinglyLinkedList<T> {
     class Node {
-        var data: T
+        var element: T
         var next: Node? = nil
         
-        init(data: T) {
-            self.data = data
+        init(element: T) {
+            self.element = element
         }
         
         func setNext(node: Node) {
@@ -35,12 +35,11 @@ class SinglyLinkedList<T> {
         return nil
     }
     
-    func enqueue() {
-        
-    }
-    
-    func dequeue() -> T? {
-        return nil
+    func addFirst(element: T) {
+        let newNode = Node(element: element)
+        newNode.next = head
+        head = newNode
+        count += 1
     }
     
     func clear() {

--- a/BankManager/Tests/BankManagerTests/BankQueueTests.swift
+++ b/BankManager/Tests/BankManagerTests/BankQueueTests.swift
@@ -21,6 +21,25 @@ final class BankQueueTests: XCTestCase {
         sut = nil
     }
     
+    func test_비어있는_큐에_isEmpty() {
+        // When
+        let result = sut.isEmpty
+        
+        // Then
+        XCTAssertTrue(result)
+    }
+    
+    func test_비어있지_않은_큐에_isEmpty() {
+        // Given
+        test_비어있는_큐에_3을_enqueue()
+        
+        // When
+        let result = sut.isEmpty
+        
+        // Then
+        XCTAssertFalse(result)
+    }
+    
     func test_비어있는_큐에_3을_enqueue() {
         // Given
         let expectedLast = 3

--- a/BankManager/Tests/BankManagerTests/BankQueueTests.swift
+++ b/BankManager/Tests/BankManagerTests/BankQueueTests.swift
@@ -1,0 +1,36 @@
+//
+//  BankQueueTests.swift
+//  
+//
+//  Created by Jaehun Lee on 3/19/24.
+//
+
+import XCTest
+@testable import BankManager
+
+final class BankQueueTests: XCTestCase {
+    var sut: BankQueue<Int>!
+    
+    override func setUp() {
+        super.setUp()
+        sut = BankQueue()
+    }
+    
+    override func tearDown() {
+        super.tearDown()
+        sut = nil
+    }
+    
+    func test_비어있는_큐에_3을_enqueue() {
+        // Given
+        let expectedFirst = 3
+        let expectedCount = 1
+        
+        // When
+        sut.enqueue(element: 3)
+        
+        // Then
+        XCTAssertEqual(expectedFirst, sut.first)
+        XCTAssertEqual(expectedCount, sut.count)
+    }
+}

--- a/BankManager/Tests/BankManagerTests/BankQueueTests.swift
+++ b/BankManager/Tests/BankManagerTests/BankQueueTests.swift
@@ -33,4 +33,13 @@ final class BankQueueTests: XCTestCase {
         XCTAssertEqual(expectedFirst, sut.first)
         XCTAssertEqual(expectedCount, sut.count)
     }
+    
+    func test_비어있는_큐에_dequeue() {
+        // When
+        let result = sut.dequeue()
+        
+        // Then
+        XCTAssertNil(result)
+    }
+    
 }

--- a/BankManager/Tests/BankManagerTests/BankQueueTests.swift
+++ b/BankManager/Tests/BankManagerTests/BankQueueTests.swift
@@ -23,14 +23,28 @@ final class BankQueueTests: XCTestCase {
     
     func test_비어있는_큐에_3을_enqueue() {
         // Given
-        let expectedFirst = 3
+        let expectedLast = 3
         let expectedCount = 1
         
         // When
         sut.enqueue(element: 3)
         
         // Then
-        XCTAssertEqual(expectedFirst, sut.first)
+        XCTAssertEqual(expectedLast, sut.last)
+        XCTAssertEqual(expectedCount, sut.count)
+    }
+    
+    func test_비어있지_않은_큐에_5를_enqueue() {
+        // Given
+        test_비어있는_큐에_3을_enqueue()
+        let expectedLast = 5
+        let expectedCount = 2
+        
+        // When
+        sut.enqueue(element: 5)
+        
+        // Then
+        XCTAssertEqual(expectedLast, sut.last)
         XCTAssertEqual(expectedCount, sut.count)
     }
     
@@ -42,4 +56,15 @@ final class BankQueueTests: XCTestCase {
         XCTAssertNil(result)
     }
     
+    func test_비어있지_않은_큐에_dequeue() {
+        // Given
+        test_비어있는_큐에_3을_enqueue()
+        let expectedResult = 3
+        
+        // When
+        let result = sut.dequeue()
+        
+        // Then
+        XCTAssertEqual(expectedResult, result)
+    }
 }

--- a/BankManager/Tests/BankManagerTests/BankQueueTests.swift
+++ b/BankManager/Tests/BankManagerTests/BankQueueTests.swift
@@ -34,6 +34,21 @@ final class BankQueueTests: XCTestCase {
         XCTAssertEqual(expectedCount, sut.count)
     }
     
+    func test_원소의_개수가_1인_큐에서_dequeue_후_4를_enqueue() {
+        // Given
+        test_비어있는_큐에_3을_enqueue()
+        let expectedLast = 4
+        let expectedCount = 1
+        
+        // When
+        let _ = sut.dequeue()
+        sut.enqueue(element: 4)
+        
+        // Then
+        XCTAssertEqual(expectedLast, sut.last)
+        XCTAssertEqual(expectedCount, sut.count)
+    }
+    
     func test_비어있지_않은_큐에_5를_enqueue() {
         // Given
         test_비어있는_큐에_3을_enqueue()

--- a/BankManager/Tests/BankManagerTests/BankQueueTests.swift
+++ b/BankManager/Tests/BankManagerTests/BankQueueTests.swift
@@ -67,4 +67,18 @@ final class BankQueueTests: XCTestCase {
         // Then
         XCTAssertEqual(expectedResult, result)
     }
+    
+    func test_큐에_clear() {
+        // Given
+        test_비어있지_않은_큐에_5를_enqueue()
+        let expectedCount = 0
+        
+        // When
+        sut.clear()
+        
+        // Then
+        XCTAssertNil(sut.first)
+        XCTAssertNil(sut.last)
+        XCTAssertEqual(expectedCount, sut.count)
+    }
 }

--- a/BankManagerUIApp/BankManagerUIApp.xcodeproj/project.pbxproj
+++ b/BankManagerUIApp/BankManagerUIApp.xcodeproj/project.pbxproj
@@ -3,10 +3,11 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 50;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
+		C404EE802BA880F300ACC8E0 /* BankManager in Frameworks */ = {isa = PBXBuildFile; productRef = C404EE7F2BA880F300ACC8E0 /* BankManager */; };
 		C7694E3B259C3E9F0053667F /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7694E3A259C3E9F0053667F /* AppDelegate.swift */; };
 		C7694E3D259C3E9F0053667F /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7694E3C259C3E9F0053667F /* SceneDelegate.swift */; };
 		C7694E3F259C3E9F0053667F /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7694E3E259C3E9F0053667F /* ViewController.swift */; };
@@ -57,6 +58,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				C404EE802BA880F300ACC8E0 /* BankManager in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -85,6 +87,13 @@
 			name = Packages;
 			sourceTree = "<group>";
 		};
+		C404EE7E2BA880F300ACC8E0 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
 		C7694E2E259C3E9F0053667F = {
 			isa = PBXGroup;
 			children = (
@@ -93,6 +102,7 @@
 				C7694E50259C3EA20053667F /* BankManagerUIAppTests */,
 				C7694E5B259C3EA20053667F /* BankManagerUIAppUITests */,
 				C7694E38259C3E9F0053667F /* Products */,
+				C404EE7E2BA880F300ACC8E0 /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -154,6 +164,9 @@
 			dependencies = (
 			);
 			name = BankManagerUIApp;
+			packageProductDependencies = (
+				C404EE7F2BA880F300ACC8E0 /* BankManager */,
+			);
 			productName = BankManagerUIApp;
 			productReference = C7694E37259C3E9F0053667F /* BankManagerUIApp.app */;
 			productType = "com.apple.product-type.application";
@@ -599,6 +612,13 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		C404EE7F2BA880F300ACC8E0 /* BankManager */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = BankManager;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = C7694E2F259C3E9F0053667F /* Project object */;
 }


### PR DESCRIPTION
안녕하세요! @uuu1101 
Prism, Danny 조 입니다. 😁
금주부터 2주간 진행되는 **은행창구 매니저 프로젝트** 잘 부탁드리겠습니다. 🙏
다름이 아니라, [STEP 1]이 완료되어 PR 요청드립니다.

## 🏦 은행창구 매니저 [STEP 1: 큐 타입 구현] 진행사항
- **현재 프로젝트는 크게 3개의 모듈로 이루어져있습니다**
  - 왜 3개의 모듈로 나뉘었을지 고민합시다. (+ 모듈은 무엇일까요?)
➔ 콘솔 앱을 위한 `BankManagerConsoleApp` 모듈과, UI 앱을 위한 `BankManagerUIApp` 모듈, 그리고 두 앱에서 공통으로 사용되는 타입 및 로직들을 모아놓은 `BankManager` 모듈로 나누어져 있습니다. 
공통으로 사용되는 타입 및 로직을 두 앱에서 여러 번 작성할 필요없이 모듈로 묶어 작성하고 각 앱에서 import해서 사용하게 한다면, 타입이나 로직에 변경사항이 생기는 경우 모든 앱을 수정할 필요 없이 모듈만 수정해주면 되기 때문에 비용이 적게 든다는 장점이 있습니다.
  - Console과 UI 앱에서 어떻게 외부 모듈을 가져오고, 사용하는지 확인합시다.
➔ 앱 프로젝트의 Targets General 설정에서 `FrameWorks and Libraries` 에 추가를 해서 외부 모듈을 가져오고 사용합니다.
<img width="901" alt="스크린샷 2024-03-19 오후 5 59 24" src="https://github.com/yagom-academy/ios-bank-manager/assets/154333967/b84b9c2b-630c-4c6f-baf0-0fb7ebe28341">


	   
  - UI 앱에는 오류가 하나 있습니다. Console 앱의 Target 내용과 UI 앱의 Target 내용을 비교 해보면 문제를 해결해 볼 수 있습니다.
➔ UI 앱의 Target 내용의 `FramWorks and Libraries` 에 `BankManager`가 추가 되지 않았기 때문에 오류가 발생한 것을 알 수 있었습니다.
    
- **은행에 도착한 고객이 임시로 대기할 대기열(큐, Queue) 타입을 직접 구현합니다.**
	- Queue 타입 구현을 위한 Linked-list 타입을 직접 구현합니다.
	   ➔ Linked-List를 Singly와 Doubly 두 가지 방식으로 구현할 수 있는데 저희는 두 가지 이유로 SinglyLinkedList를 사용하기로 했습니다.
       - Queue의 경우 한 쪽에서는 데이터가 들어오기만 하고, 반대 쪽에서는 데이터가 나기가만 하기 때문에 SinglyLinkedList만으로도 구현이 가능함
       - SinglyLinkedList의 메모리 사용량이 DoublyLinkedList의 메모리 사용량보다 조금이나마 적음
    - Queue 타입은 다양한 타입의 데이터를 취급할 수 있도록 스위프트의 Generics 기능을 활용합니다.
      - Queue 타입에 Generics를 활용했습니다.
    - Queue 타입이 예상한대로 동작하는지 Unit Test를 통해 동작을 검증합니다.
      - Tests/BankManagerTests/BankQueueTests.swift 파일을 생성하였고, Unit Test 케이스를 생성하여 Queue 타입의 동작을 검증했습니다.
          ![image](https://github.com/yagom-academy/ios-bank-manager/assets/154333967/0771d433-95ab-4fe8-b6ed-a424d1e3e07e)
    - `BankQueue` 타입에 구현한 메서드와 프로퍼티는 다음과 같습니다:
      - `enqueue()`: Queue의 끝에 element를 추가하는 메서드
      - `dequeue()`: Queue의 첫 element를 제거하고 반환하는 메서드
      - `clear()`: Queue를 비우는 메서드
      - `first`: Queue의 첫 번째 element를 반환(queue는 변경하지 않음)하는 연산 프로퍼티
      - `last`: Queue의 마지막 element를 반환(queue는 변경하지 않음)하는 연산 프로퍼티
      - `isEmpty`: Queue가 비어있는지 확인하는 연산 프로퍼티


## 🙏 조언을 얻고 싶었던 점
- `BankManagerUIApp`과 `BankMangerConsoleApp` 프로젝트를 같이 Xcode로 실행하면, **`Missing package product 'BankManager'`** 라는 에러를 볼 수 있었습니다.
`BankManager` 모듈을 사용하는 프로젝트를 xCode를 통해 사용할 시에, 1개의 프로젝트를 제외한 나머지 프로젝트에서는 `BankManager`라는 모듈을 사용하지 못하는 게 정상인지 궁금합니다.
혹시 다른 방법을 통해 이러한 에러를 해결할 수 있는 것인지도 조언을 얻고 싶습니다.

----

은행창구 매니저 프로젝트 [STEP 1] PR 마치도록 하겠습니다. 감사합니다. 😁